### PR TITLE
Feature: Important items to be added

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -97,8 +97,7 @@ const katex = require("rehype-katex");
         },
 
         prism: {
-          theme: darkCodeTheme,
-          darkTheme: darkCodeTheme,
+          theme: require("prism-react-renderer/themes/oceanicNext"),
         },
 
         colorMode: {

--- a/src/components/features/HomepageFeatures.module.scss
+++ b/src/components/features/HomepageFeatures.module.scss
@@ -54,13 +54,8 @@
   justify-content: space-between;
 
   & > img {
-    width: 18rem;
-    height: 15rem;
-
-    @media screen and (min-width: variables.$screen-lg) {
-      width: 28rem;
-      height: 20rem;
-    }
+    width: 28rem;
+    height: 20rem;
   }
 
   @media screen and (min-width: variables.$screen-lg) {

--- a/src/scss/base/_reset_docusaurus.scss
+++ b/src/scss/base/_reset_docusaurus.scss
@@ -42,6 +42,10 @@ We must use `!important` at times to override some default styles.
   background: url("@site/static/svg/common/chevron_up.svg");
 }
 
+.menu__link--active {
+  background-color: inherit !important;
+}
+
 .menu {
   padding-left: var(--ifm-menu-link-padding-horizontal);
   @media screen and (min-width: variables.$screen-md) {
@@ -93,6 +97,13 @@ We must use `!important` at times to override some default styles.
   &:hover,
   & > a {
     transition: none !important;
+    background-color: variables.$mina-gray-light;
+  }
+}
+
+.menu__list-item-collapsible {
+  &:hover {
+    background-color: variables.$mina-gray-light;
   }
 }
 

--- a/src/scss/base/_reset_docusaurus.scss
+++ b/src/scss/base/_reset_docusaurus.scss
@@ -88,7 +88,7 @@ We must use `!important` at times to override some default styles.
 }
 
 .menu__link {
-  line-height: 2rem;
+  line-height: 1.5rem;
 
   &:hover,
   & > a {

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -30,6 +30,8 @@
 
   --ifm-navbar-padding-vertical: 1rem;
   --ifm-navbar-padding-horizontal: 1.5rem;
+  --ifm-menu-link-padding-vertical: 0.6rem;
+
   --ifm-navbar-height: 6rem;
 
   @media screen and (min-width: variables.$screen-md) {

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -13,7 +13,7 @@
   --ifm-color-primary-lightest: #ffac99;
   --ifm-code-font-size: 95%;
 
-  --ifm-menu-color-background-active: none;
+  --ifm-hover-overlay: #f8f8f8;
 
   --ifm-menu-color: variables.$mina-black;
   --ifm-breadcrumb-item-background-active: none;

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -13,7 +13,7 @@
   --ifm-color-primary-lightest: #ffac99;
   --ifm-code-font-size: 95%;
 
-  --ifm-hover-overlay: #f8f8f8;
+  --ifm-hover-overlay: #d9d9d9;
 
   --ifm-menu-color: variables.$mina-black;
   --ifm-breadcrumb-item-background-active: none;

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -25,6 +25,8 @@
 
   --ifm-toc-link-color: variables.$mina-black;
 
+  --ifm-transition-fast: 0.01s;
+
   --docsearch-primary-color: none !important;
   --docusaurus-announcement-bar-height: 40px;
 

--- a/src/scss/utilities/_variables.scss
+++ b/src/scss/utilities/_variables.scss
@@ -7,6 +7,7 @@ $screen-xl2: 1920px;
 $mina-orange: #ff603b;
 $mina-teal: #9fe4c9;
 $mina-gray: #d9d9d9;
+$mina-gray-light: #f8f8f8;
 $mina-gray-dark: #9b9b9b;
 $mina-black: #2d2d2d;
 $mina-white: #ffffff;


### PR DESCRIPTION
# Important 
- On mobile, make the background for “On this page” dropdown the default, grayish color again. The default some kind of light gray with rounded corners. Problem is that it’s not very usable without a background and this seems to have inherited something unintended.

- Update syntax highlighting colors, to be more similar to previously used, to fit better with brand colors.

- On small desktop and mobile, the homepage hero image is squished (stretched vertically for some reason)

- Let’s tweak sidebar’s line-height for situations when an items has text on two lines )e.g. zkApps for Ethereum Developers”, so that the line height is smaller. I.e. the old docs is easier to distinguish what is a multi-line item vs another single line item within the sidebar. Try `line-height:1.5rem`, that is what the old docs seems to have. Then `padding: 0.6rem 0;` is used to separate different rows of items.

- On mobile, make the background for “On this page” dropdown the default, grayish color again. The default some kind of light gray with rounded corners. Problem is that it’s not very usable without a background and this seems to have inherited something unintended.

# Nice To Have
- In sidebar, change the dropdown arrow’s rotation animation to be a little faster (so it feels more similar to our now, quicker dropdown speed which is great)
