### PR TITLE
fix image in zkapps page

### DIFF
--- a/docs/zkapps/how-zkapps-work.mdx
+++ b/docs/zkapps/how-zkapps-work.mdx
@@ -24,7 +24,7 @@ zkApps are written in TypeScript using the Mina zkApp CLI. In the upcoming secti
 A “zkApp” consists of two parts: 1) a smart contract and 2) an UI (user interface) for users to interact with it.
 
 <figure>
-  <img src="/img/3_zkapps_Structure.jpg" width="100%" />
+  <img src="/img/3_zkApps_Structure.jpg" width="100%" />
   <figcaption>zkApps consists of two parts: 1) a smart contract and 2) an UI (user interface) for users to interact with it.</figcaption>
 </figure>
 
@@ -161,7 +161,7 @@ For larger data, you may want to consider storing the root of a [Merkle tree](ht
 
 When the zkApp runs in a user’s web browser, it may insert state to an external storage, such as IPFS. When the transaction is sent to the Mina network, if it accepts this zkApp transaction (i.e. this proof & state were valid so the updates are allowed), then the zkApp transaction would update the root of the Merkle tree that is stored on chain.
 
-<img src="/img/9_zkapps_Off-Chain_State.jpg" width="95%" />
+<img src="/img/9_zkApps_Off-Chain_State.jpg" width="95%" />
 
 ### Keep going
 


### PR DESCRIPTION
There was a typo in the image name (need to capitalize A) which is why the image didn't show up