### PR TITLE
Add vercel server redirects

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "redirects": [
+    { "source": "/en", "destination": "/" },
+    { "source": "/en/:path", "destination": "/:path" }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "redirects": [
     { "source": "/en", "destination": "/" },
-    { "source": "/en/:path", "destination": "/:path" }
+    { "source": "/en/:path(.*)", "destination": "/:path(.*)" }
   ]
 }


### PR DESCRIPTION
# Description
Using `vercel` configuration instead of the [Docusaurus plugin-client-redirects](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-client-redirects) plugin as the docs for the plugin suggest to prefer using a hosting provider feature instead. The plugin seems to do a client redirect instead of server-side so that is why we prefer to use a `vercel` config.