### PR TITLE
Fixtutoriallink

### DIFF
--- a/docs/using-mina/how-to-stake-delegate.mdx
+++ b/docs/using-mina/how-to-stake-delegate.mdx
@@ -12,5 +12,4 @@ Currently, hundreds of block producers are accepting delegations on Mina. You ca
 Will the wallet you use affect how well you stake?
 No.
 
-Link us to “how staking works in Mina” (in About Mina)  
-
+Link us to “how staking works in Mina” (in About Mina)

--- a/docs/zkapps/index.mdx
+++ b/docs/zkapps/index.mdx
@@ -99,7 +99,7 @@ Play around with a few example zkApps to see what’s possible:
 
 To learn more, read about [how zkApps work](/zkapps/how-zkapps-work), [how to write a zkApp](/zkapps/how-to-write-a-zkapp), and [zkApps for Ethereum Developers](/zkapps/zkapps-for-ethereum-developers).
 
-Try the [zkApps tutorials](/zkapps/tutorials) to learn by doing!
+Try the [zkApps tutorials](/zkapps/tutorials/hello-world) to learn by doing!
 
 ### Get help
 


### PR DESCRIPTION
I recommend that until we figure out why this redirect isn't working here, lets just directly link to the hello world tutorial. 