### PR TITLE
add tip saying use copy button for code snippets

### DIFF
--- a/docs/zkapps/tutorials/01-hello-world.mdx
+++ b/docs/zkapps/tutorials/01-hello-world.mdx
@@ -132,6 +132,12 @@ This will run `main` if the build is successful.
 
 Now, the fun part! Let's write our smart contract: `src/Square.ts`. Line numbers are provided for convenience. A final version of what we're writing can be found [here](https://github.com/es92/zkApp-examples/blob/main/01-hello-world/src/Square.ts).
 
+ :::tip
+
+ To avoid inserting the line numbers into your smart contract, copy these code snippets using the button provided. It will appear at the top right of the snippet box when you mouseover it. 
+
+ :::
+
 ### Imports
 
 First, open `src/Square.ts` in your editor, then add the following at the top of the file:


### PR DESCRIPTION
We use hardcoded line numbers to keep track of where different snippets should be in their source files. The line numbers copy as well if you select the text with your mouse. Copying using the button avoids this issue.