### PR TITLE
Init() and other 0.7.0 updates

### DIFF
--- a/docs/zkapps/advanced-snarkyjs/actions-and-reducer.mdx
+++ b/docs/zkapps/advanced-snarkyjs/actions-and-reducer.mdx
@@ -11,12 +11,6 @@ Please note that zkApp programmability is not yet available on Mina Mainnet, but
 
 # Actions & Reducer
 
-:::info
-
-Experimental. This API may change.
-
-:::
-
 Like events, **actions** are arbitrary information passed along with a zkApp transaction. However, actions give you an additional power: you can process previous actions in a smart contract! Under the hood, this is possible because we store a commitment to the history of dispatched actions on every account -- the **actionsHash**. It allows us to prove that the actions you process are, in fact, the actions that were dispatched to the same smart contract.
 
 Using actions and a "lagging state" pattern, you can write zkApps that can _process concurrent state updates by multiple users_ -- see the next section. Besides that, we imagine all kinds of use cases where actions act as a built-in, "append-only" off-chain storage layer.
@@ -24,10 +18,10 @@ Using actions and a "lagging state" pattern, you can write zkApps that can _proc
 To use actions, we first have to declare their type on the smart contract. The object we declare is called a **reducer** -- because it can take a list of actions and reduce them:
 
 ```ts
-import { SmartContract, Experimental, Field } from "snarkyjs";
+import { SmartContract, Reducer, Field } from 'snarkyjs';
 
 class MyContract extends SmartContract {
-  reducer = Experimental.Reducer({ actionType: Field });
+  reducer = Reducer({ actionType: Field });
 }
 ```
 
@@ -63,7 +57,7 @@ let actions = [[Field(1000)], [Field(2)], [Field(100)]];
 // state and actionsHash before applying actions
 let initial = {
   state: Bool(false),
-  actionsHash: Experimental.Reducer.initialActionsHash,
+  actionsHash: Reducer.initialActionsHash,
 };
 
 let { state, actionsHash } = this.reducer.reduce(
@@ -83,7 +77,7 @@ There is one interesting nuance here when compared to traditional Elm Architectu
 ### Reducer - API reference
 
 ```ts
-reducer = Experimental.Reducer({ actionType: AsFieldElements<A> });
+reducer = Reducer({ actionType: AsFieldElements<A> });
 
 this.reducer.dispatch(action: A): void;
 
@@ -94,10 +88,10 @@ this.reducer.reduce<S>(
   initial: { state: S, actionsHash: Field }
 ): { state: S, actionsHash: Field };
 
-Experimental.Reducer.initialActionsHash: Field;
+Reducer.initialActionsHash: Field;
 ```
 
-The above API is available now, but still marked as "Experimental". In the near future, we want to add a function to retrieve actions from an archive node:
+In the near future, we want to add a function to retrieve actions from an archive node:
 
 ```ts
 this.reducer.getActions({ fromActionsHash?: Field, endActionsHash?: Field }): A[][];

--- a/docs/zkapps/advanced-snarkyjs/merkle-tree.mdx
+++ b/docs/zkapps/advanced-snarkyjs/merkle-tree.mdx
@@ -11,12 +11,6 @@ Please note that zkApp programmability is not yet available on Mina Mainnet, but
 
 # Merkle Tree
 
-:::info
-
-Experimental. This API may change.
-
-:::
-
 #### Referencing off-chain data
 
 We already learned that zkApps can only store a small amount of data on-chain, the reason for that is we want Mina to stay succinct and not become bloated.
@@ -103,7 +97,7 @@ class Leaderboard extends SmartContract {
     // this is our hash we want to guess! its the hash of the preimage "22", but keep it a secret!
     this.z.set(
       Field(
-        "17057234437185175411792943285768571642343179330449434169483610110583519635705"
+        '17057234437185175411792943285768571642343179330449434169483610110583519635705'
       )
     );
   }
@@ -171,10 +165,10 @@ Where and how to store the data off-chain storage is left up to the developer. W
 const treeHeight = 8;
 
 // creates a tree of height 8
-const Tree = new Experimental.MerkleTree(treeHeight);
+const Tree = new MerkleTree(treeHeight);
 
 // creates the corresponding MerkleWitness class that is circuit-compatible
-class MerkleWitness extends Experimental.MerkleWitness(treeHeight) {}
+class MyMerkleWitness extends MerkleWitness(treeHeight) {}
 
 // sets a value at position 0n
 Tree.setLeaf(0n, Field(123));
@@ -186,12 +180,10 @@ const root = Tree.getRoot();
 const witness = Tree.getWitness(0n);
 
 // creates a circuit-compatible witness
-const circuitWitness = new MerkleWitness(witness);
+const circuitWitness = new MyMerkleWitness(witness);
 
 // calculates the root of the witness
 const calculatedRoot = circuitWitness.calculateRoot(Field(123));
 
 calculatedRoot.assertEquals(root);
 ```
-
-The above API is available now, but still marked as "Experimental".

--- a/docs/zkapps/advanced-snarkyjs/merkle-tree.mdx
+++ b/docs/zkapps/advanced-snarkyjs/merkle-tree.mdx
@@ -91,8 +91,8 @@ class Leaderboard extends SmartContract {
   // z is the hashed number we want to guess!
   @state(Field) z = State<Field>();
 
-  deploy(args: DeployArgs) {
-    super.deploy(args);
+  init() {
+    super.init();
 
     // this is our hash we want to guess! its the hash of the preimage "22", but keep it a secret!
     this.z.set(

--- a/docs/zkapps/how-to-test-a-zkapp.mdx
+++ b/docs/zkapps/how-to-test-a-zkapp.mdx
@@ -25,8 +25,8 @@ To generate a test coverage report for your project, run `npm run coverage`. Cov
 Creating tests for your smart contract is easy using the Mina zkApp CLI. To scaffold a TypeScript file with a corresponding test file, simply run the command `zk file foo`. This will generate two files, named `foo.ts` and `foo.test.ts`. `foo.test.ts` is a great place to start writing all your smart contract test code. To write good unit tests, it's vital that you concretely understand the functionality your smart contract provides. An example is shown below of a basic test written in Jest:
 
 ```ts
-describe("foo.test.ts", () => {
-  describe("test()", () => {
+describe('foo.test.ts', () => {
+  describe('test()', () => {
     // your test here
   });
 });
@@ -80,7 +80,7 @@ Then, use the test account and zkApp keys to construct a transaction to pay acco
 ```ts
 let txn = await Mina.transaction(feePayer, () => {
   Party.fundNewAccount(feePayer);
-  zkAppInstance.deploy({ zkappKey: zkAppPrivateKey});
+  zkAppInstance.deploy({ zkappKey: zkAppPrivateKey });
 });
 txn.send();
 ```
@@ -90,7 +90,7 @@ txn.send();
 Jest can be used to write both unit and integration tests. A well written integration test tests the flow of your smart contracts expected behavior, and verifies correctness of state updates. After you test the expected behavior, it's benifical to verify the preconditions of your methods and test edge cases of your smart contract. Below is an example of a basic integration test script.
 
 ```ts
-  describe('Add smart contract integration test', () => {
+describe('Add smart contract integration test', () => {
   let feePayer: PrivateKey,
     zkAppAddress: PublicKey,
     zkAppPrivateKey: PrivateKey,
@@ -116,7 +116,6 @@ Jest can be used to write both unit and integration tests. A well written integr
     txn = await Mina.transaction(feePayer, () => {
       Party.fundNewAccount(feePayer);
       zkAppInstance.deploy({ zkappKey: zkAppPrivateKey });
-      zkAppInstance.init();
     });
     await txn.send();
   });
@@ -144,7 +143,6 @@ Jest can be used to write both unit and integration tests. A well written integr
 ```
 
 ## Learn more
-
 
 Please see the <a href="https://jestjs.io/docs/getting-started">Jest docs</a> for further information on how to use Jest.
 

--- a/docs/zkapps/how-to-write-a-zkapp.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp.mdx
@@ -473,31 +473,27 @@ However, the secret itself remains private, because it can't be deduced from it'
 
 ##### Initializing state
 
-We didn't cover how to initialize on-chain state yet. This can be done in the `deploy()` method.
+We didn't cover how to initialize on-chain state yet. This can be done in the `init()` method.
 
-Like the constructor, `deploy()` is predefined on the base `SmartContract` class.
-It will be called when you deploy your zkApp with the zkApp CLI.
+Like the constructor, `init()` is predefined on the base `SmartContract` class.
+It will be called when you deploy your zkApp with the zkApp CLI, for the first time. It won't be called if you upgrade your contract and deploy a second time.
 You can override this method to add initialization of your on-chain state:
 
 ```ts
 class HelloWorld extends SmartContract {
   @state(Field) x = State<Field>();
 
-  deploy(args: DeployArgs) {
-    super.deploy(args);
+  init() {
+    super.init();
     this.x.set(Field(10)); // initial state
   }
 }
 ```
 
-Note that we have to pass the arguments on to `super.deploy()`, which runs the default deploy logic. So, this line is required:
+Note that we have to call `super.init()`, which sets your entire state to 0.
 
-```ts
-super.deploy(args);
-```
-
-If you don't need to add anything else to `deploy`, there's no need to override it, just leave it out.
-In the example above however, we are setting our state `x` to `Field(10)`. Uninitialized values will be zero.
+If you don't have any state to initialize to values other than 0, then there's no need to override `init()`, you can just leave it out.
+In the example above however, we are setting our state `x` to `Field(10)`.
 
 ##### Custom data types
 
@@ -505,8 +501,8 @@ As mentioned previously, smart contract method arguments can be any of the built
 
 However, what if you want to define your own data type?
 
-You can create a custom data type for your smart contract using the `Struct` class that SnarkyJS exposes. To do this, create a class that extends `Struct`.
-Then, inside the class, define the fields that you want to use in your custom data type.
+You can create a custom data type for your smart contract using the `Struct` function that SnarkyJS exposes. To do this, create a class that extends `Struct({ })`.
+Then, inside the object `{ }`, define the fields that you want to use in your custom data type.
 
 For example, let us say you want to create a custom data type called `Point` representing a 2D point on a grid. The `Point` struct has no instance methods and is only used to hold information about the `x` and `y` points.
 You can create a such a Point class by creating a new class that extends the `Struct` class:
@@ -518,7 +514,7 @@ class Point extends Struct({
 }) {}
 ```
 
-Now that you have defined your circuit Struct, you can use it in your smart contract for any SnarkyJS built-in types.
+Now that you have defined your Struct, you can use it in your smart contract for any SnarkyJS built-in types.
 
 For example, the following smart contract uses the `Point` Struct defined above as state and as a method argument:
 

--- a/docs/zkapps/how-to-write-a-zkapp.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp.mdx
@@ -283,7 +283,7 @@ Under the hood, every `@method` defines a zk-SNARK circuit. From the cryptograph
 
 :::tip
 
-You will find that inside a `@nethod`, things sometimes behave a little differently. For example, the following code can't be used in a method where `x: Field` is an input parameter:
+You will find that inside a `@method`, things sometimes behave a little differently. For example, the following code can't be used in a method where `x: Field` is an input parameter:
 
 ```ts
 console.log(x.toString()); // don't do this inside a `@method`! 😬

--- a/docs/zkapps/how-to-write-a-zkapp.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp.mdx
@@ -126,9 +126,12 @@ new Bool(x);   // accepts true or false
 new Field(x);  // accepts an integer, or a numeric string if you want to represent a number greater than JavaScript can represent but within the max value that a field can store.
 new UInt64(x); // accepts a Field - useful for constraining numbers to 64 bits
 new UInt32(x); // accepts a Field - useful for constraining numbers to 32 bits
+
 PrivateKey, PublicKey, Signature; // useful for accounts and signing
 new Group(x, y); // a point on our elliptic curve, accepts two Fields/numbers/strings
 Scalar; // the corresponding scalar field (different than Field)
+
+CircuitString.from('some string'); // string of max length 128
 ```
 
 In the case of `Field` and `Bool`, you can also call the constructor without `new`:
@@ -137,12 +140,6 @@ In the case of `Field` and `Bool`, you can also call the constructor without `ne
 let x = Field(10);
 let b = Bool(true);
 ```
-
-:::info
-
-Support for strings within SnarkyJS will be available soon.
-
-:::
 
 ##### Conditionals
 
@@ -198,7 +195,7 @@ let sig = Signature.create(privKey, msg); // sign a message
 sig.verify(pubKey, msg); // Bool(true)
 ```
 
-For a full list, see the [snarkyJS reference](snarkyjs-reference).
+For a full list, see the [SnarkyJS reference](snarkyjs-reference).
 
 ##### Smart Contract
 
@@ -280,6 +277,28 @@ One more note about private inputs: The method above has one input parameter, `x
 
 Under the hood, every `@method` defines a zk-SNARK circuit. From the cryptography standpoint, a smart contract is a collection of circuits, all of which are compiled into a single prover & verification key. The proof says something to the effect of "I ran one of these methods, with some private input, and it produced this particular set of account updates". In ZKP terms, the account updates are the _public input_. The proof will only be accepted on the network if it verifies against the verification key stored in the account. This ensures that indeed, the same code that the zkApp developer wrote also ran on the user's device -- thus, the account updates conform to the smart contract's rules.
 
+:::
+
+<!-- TODO: create at least a basic section about zk circuits below this subsection which contains (among other things) a more thourough explanation of what this tip hints at -->
+
+:::tip
+
+You will find that inside a `@nethod`, things sometimes behave a little differently. For example, the following code can't be used in a method where `x: Field` is an input parameter:
+
+```ts
+console.log(x.toString()); // don't do this inside a `@method`! 😬
+```
+
+This doesn't work because, when we compile the SmartContract into prover and verification keys, we will run your method in an environment where the method inputs don't have any concrete values attached to them. They are like mathematical variables `x`, `y`, `z` which are used to build up abstract computations like `x^2 + y^2`, just by running your method code.
+
+Therefore, when executing your code and trying to read the value of `x` to turn it into a string via `x.toString()`, it will blow up because such a value can't be found. On the other hand, during proof generation all the variables _have_ actual values attached to them (cryptographers call them "witnesses"); and it makes perfect sense to want to log these values for debugging.
+This is why we have a special function for logging stuff from inside your method:
+
+```ts
+Circuit.log(x);
+```
+
+The API is like that of `console.log`, but it will automatically handle printing SnarkyJS data types in a nice format. During SmartContract compilation, it will simply do nothing.
 :::
 
 ##### On-chain state

--- a/docs/zkapps/tutorials/01-hello-world.mdx
+++ b/docs/zkapps/tutorials/01-hello-world.mdx
@@ -19,7 +19,7 @@ In this tutorial, we will code a zkApp step by step, from start to finish.
 
 We will write a basic smart contract that stores a number as on-chain state and contains logic to only allow this number to be replaced by its square (e.g. 2 -> 4 -> 16...). We will create this project using the [Mina zkApp CLI](https://www.npmjs.com/package/zkapp-cli), write our smart contract code, and then use a local Mina blockchain to interact with it.
 
-Future tutorials will introduce further concepts and patterns. But we hope this helps you get started with SnarkyJS, zkApps, and programming with zero knowledge proofs. Then you can go further by reading the [zkApps docs](/zkapps) and additional tutorials.
+Later tutorials will introduce further concepts and patterns. But we hope this helps you get started with SnarkyJS, zkApps, and programming with zero knowledge proofs. Then you can go further by reading the [zkApps docs](/zkapps) and additional tutorials.
 
 You can find the full source code for this example [here](https://github.com/es92/zkApp-examples/tree/main/01-hello-world).
 
@@ -99,7 +99,7 @@ zk file src/Square
 touch src/main.ts
 ```
 
-The `zk file <name>` command created both `src/Square.ts` and `src/Square.test.ts` for us, but we won't worry about writing tests in this tutorial. We'll use `main.ts` as a script to interact with the smart contract and observe how it works. In future tutorials, we will see how to interact with a smart contract from the browser, like a typical end user, but for now we'll just use our `main.ts` script to do this.
+The `zk file <name>` command created both `src/Square.ts` and `src/Square.test.ts` for us, but we won't worry about writing tests in this tutorial. We'll use `main.ts` as a script to interact with the smart contract and observe how it works. In later tutorials, we will see how to interact with a smart contract from the browser, like a typical end user, but for now we'll just use our `main.ts` script to do this.
 
 Now, let's open `src/index.ts` in a text editor and change it to look like below. This file contains all exports we want to make available for consumption from outside our smart contract project, such as from a UI.
 
@@ -247,7 +247,7 @@ Notice that we have `get()` and `set()` methods for retrieving and setting on-ch
 
 Our logic also uses the `.mul()` method for multiplication of our values stored in fields. You can view all available methods in the [SnarkyJS reference](/zkapps/snarkyjs-reference). Keep in mind that _all functions used inside your smart contract must operate on SnarkyJS compatible data types (e.g. Fields and other types built on top of Fields)_. This is to say, functions from random NPM packages won't work inside our smart contract, because it's really a zero-knowledge circuit, unless the functions it provides operate on SnarkyJS-compatible data types.
 
-**Importantly, data passed as an input to smart contract method in SnarkyJS is private and never seen by the network.** But you can also store data publicly on-chain when needed, such as we do with our `num` in this example. A future tutorial will cover an example leveraging privacy.
+**Importantly, data passed as an input to smart contract method in SnarkyJS is private and never seen by the network.** But you can also store data publicly on-chain when needed, such as we do with our `num` in this example. A later tutorial will cover an example leveraging privacy.
 
 This completes the smart contract!
 

--- a/docs/zkapps/tutorials/01-hello-world.mdx
+++ b/docs/zkapps/tutorials/01-hello-world.mdx
@@ -335,11 +335,10 @@ Now, let's initalize our smart contract. Comments are provided to break down eac
  28   const contract = new Square(zkAppAddress);
  29   const deployTxn = await Mina.transaction(deployerAccount, () => {
  30     AccountUpdate.fundNewAccount(deployerAccount);
- 31     contract.deploy({ zkappKey: zkAppPrivateKey });
- 32     contract.init();
+ 31     contract.deploy({ zkappKey: zkAppPrivateKey }); // this calls init()
  33     contract.sign(zkAppPrivateKey);
  34   });
- 35   await deployTxn.send().wait();
+ 35   await deployTxn.send();
  36
  37   // Get the initial state of our zkApp account after deployment
  38   const num0 = contract.num.get();
@@ -377,7 +376,7 @@ Now let's try updating our local zkApp account with a transaction! Add the follo
  44     contract.update(Field(9));
  45     contract.sign(zkAppPrivateKey);
  46   });
- 47   await txn1.send().wait();
+ 47   await txn1.send();
  48
  49   const num1 = contract.num.get();
  50   console.log('state after txn1:', num1.toString());
@@ -413,7 +412,7 @@ Now let's try adding a transaction that should fail - updating the state to `75`
  56       contract.update(Field(75));
  57       contract.sign(zkAppPrivateKey);
  58     });
- 59     await txn2.send().wait();
+ 59     await txn2.send();
  60   } catch (err: any) {
  61     console.log(err.message);
  62   }
@@ -450,7 +449,7 @@ And lastly, to show the correct update:
  69     contract.update(Field(81));
  70     contract.sign(zkAppPrivateKey);
  71   });
- 72   await txn3.send().wait();
+ 72   await txn3.send();
  73
  74   const num3 = contract.num.get();
  75   console.log('state after txn3:', num3.toString());

--- a/docs/zkapps/tutorials/01-hello-world.mdx
+++ b/docs/zkapps/tutorials/01-hello-world.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Tutorial 1: Hello World"
+title: 'Tutorial 1: Hello World'
 hide_title: true
-sidebar_label: "Tutorial 1: Hello World"
+sidebar_label: 'Tutorial 1: Hello World'
 ---
 
 :::info
@@ -140,7 +140,7 @@ Now, the fun part! Let's write our smart contract: `src/Square.ts`. Line numbers
 
 :::tip
 
-To avoid inserting the line numbers into your smart contract, copy these code snippets using the button provided. It will appear at the top right of the snippet box when you mouseover it. 
+To avoid inserting the line numbers into your smart contract, copy these code snippets using the button provided. It will appear at the top right of the snippet box when you mouseover it.
 
 :::
 

--- a/docs/zkapps/tutorials/05-common-types-and-functions.mdx
+++ b/docs/zkapps/tutorials/05-common-types-and-functions.mdx
@@ -268,14 +268,14 @@ Besides the `a.assertEquals(b)` we've often used, there is also `.assertTrue()` 
 
 ## Merkle Trees
 
-Lastly, let's go over an example using [merkle trees](../snarkyjs-reference/modules/Experimental#merkletree). Merkle trees are very powerful, since they let us manage large amounts of data within a circuit. In the [project corresponding to this tutorial](https://github.com/es92/zkApp-examples/tree/main/05-common-types-and-functions/src), you can find a full reference for the example here. The contract can be found in [BasicMerkleTreeContract.ts](https://github.com/es92/zkApp-examples/blob/main/05-common-types-and-functions/src/BasicMerkleTreeContract.ts), and the example can be found in a section of [main.ts](https://github.com/es92/zkApp-examples/blob/main/05-common-types-and-functions/src/main.ts).
+Lastly, let's go over an example using [merkle trees](../snarkyjs-reference/classes/MerkleTree). Merkle trees are very powerful, since they let us manage large amounts of data within a circuit. In the [project corresponding to this tutorial](https://github.com/es92/zkApp-examples/tree/main/05-common-types-and-functions/src), you can find a full reference for the example here. The contract can be found in [BasicMerkleTreeContract.ts](https://github.com/es92/zkApp-examples/blob/main/05-common-types-and-functions/src/BasicMerkleTreeContract.ts), and the example can be found in a section of [main.ts](https://github.com/es92/zkApp-examples/blob/main/05-common-types-and-functions/src/main.ts).
 
-Merkle trees are currently in the `Experimental` module of SnarkyJS. So start off by importing `Experimental`:
+Start off by importing `MerkleTree`:
 
 ```ts
 import {
   ...
-  Experimental,
+  MerkleTree,
   ...
 } from 'snarkyjs'
 ```
@@ -284,7 +284,7 @@ Merkle Trees can be created in your application as so:
 
 ```ts
 const height = 20;
-const tree = new Experimental.MerkleTree(height);
+const tree = new MerkleTree(height);
 ```
 
 The height variable determines how many leaves are available to your application. A height of 20 for example will lead to a tree with `2^(20-1)`, or 524,288 leaves.
@@ -331,8 +331,8 @@ const zkapp = new BasicMerkleTreeContract(basicTreeZkAppAddress);
 
 // create a new tree
 const height = 20;
-const tree = new Experimental.MerkleTree(height);
-class MerkleWitness extends Experimental.MerkleWitness(height) {}
+const tree = new MerkleTree(height);
+class MerkleWitness20 extends MerkleWitness(height) {}
 
 // deploy the smart contract
 const deployTxn = await Mina.transaction(deployerAccount, () => {
@@ -344,14 +344,14 @@ const deployTxn = await Mina.transaction(deployerAccount, () => {
 });
 await deployTxn.send().wait();
 
-const incrementIndex = 522;
+const incrementIndex = 522n;
 const incrementAmount = Field(9);
 
 // get the witness for the current tree
-const witness = new MerkleWitness(tree.getWitness(BigInt(incrementIndex)));
+const witness = new MerkleWitness20(tree.getWitness(incrementIndex));
 
 // update the leaf locally
-tree.setLeaf(BigInt(incrementIndex), incrementAmount);
+tree.setLeaf(incrementIndex, incrementAmount);
 
 // update the smart contract
 const txn1 = await Mina.transaction(deployerAccount, () => {

--- a/docs/zkapps/zkapps-for-ethereum-developers.mdx
+++ b/docs/zkapps/zkapps-for-ethereum-developers.mdx
@@ -87,9 +87,9 @@ export class Add extends SmartContract {
   for practical purposes, but loops back to 1 after overflowing) */
   @state(Field) num = State<Field>();
 
-  // Deploy the contract (similar to a constructor in Solidity)
-  deploy(args: unknown) {
-    super.deploy(args);
+  // Initialize the contract (similar to a constructor in Solidity)
+  init() {
+    super.init();
     // Set num equal to a Field element of value 1 on contract deployment
     this.num.set(Field(1));
   }


### PR DESCRIPTION
Document `init()` and `Circuit.log()`, remove `Experimental` in some places, fix some code that was broken by API changes