### PR TITLE
Add a CI job to auto build SnarkyJS API docs

### DIFF
--- a/.github/workflows/snarkyjs-api-reference.yml
+++ b/.github/workflows/snarkyjs-api-reference.yml
@@ -1,0 +1,33 @@
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+          - info
+          - warning
+          - debug
+      tags:
+        description: 'Test scenario tags'
+        required: false
+        type: boolean
+      environment:
+        description: 'Environment to run tests against'
+        type: environment
+        required: true
+
+jobs:
+  log-the-inputs:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Log level: $LEVEL"
+          echo "Tags: $TAGS"
+          echo "Environment: $ENVIRONMENT"
+        env:
+          LEVEL: ${{ inputs.logLevel }}
+          TAGS: ${{ inputs.tags }}
+          ENVIRONMENT: ${{ inputs.environment }}

--- a/.github/workflows/snarkyjs-api-reference.yml
+++ b/.github/workflows/snarkyjs-api-reference.yml
@@ -1,12 +1,6 @@
 name: SnarkyJS-API-Reference
-on:
-  workflow_dispatch:
-    snarkyjs_branch:
-      type: choice
-      description: SnarkyJS branch to build from
-      options:
-        - main
-        - releases
+on: workflow_dispatch
+
 jobs:
   update-snarkyjs-api-reference:
     runs-on: ubuntu-latest
@@ -26,7 +20,7 @@ jobs:
         with:
           repository: o1-labs/snarkyjs
           path: snarkyjs
-          ref: ${{ github.event.inputs.${{ github.event.inputs.message }} }}
+          ref: releases
 
       - name: Build API reference docs
         run: |

--- a/.github/workflows/snarkyjs-api-reference.yml
+++ b/.github/workflows/snarkyjs-api-reference.yml
@@ -42,9 +42,11 @@ jobs:
           node update-sidebars-snarkyjs-api.js && npx prettier --config .prettierrc --write docusaurus.config.js
 
           # Configure git and push
+          BRANCH_NAME=docs/snarkyjs-api-reference-$(git --git-dir ../snarkyjs/.git rev-parse --short HEAD)
           git config user.name github-actions
           git config user.email github-actions@github.com
+          git switch -c $BRANCH_NAME
           git add docs/zkapps/snarkyjs-reference
           git add docusaurus.config.js
           git commit -m "Build and publish new SnarkyJS API reference docs"
-          git push
+          git push --set-upstream origin $BRANCH_NAME

--- a/.github/workflows/snarkyjs-api-reference.yml
+++ b/.github/workflows/snarkyjs-api-reference.yml
@@ -23,6 +23,8 @@ jobs:
           ref: releases
 
       - name: Build API reference docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Install dependencies and build SnarkyJS
           cd snarkyjs && npm ci && npm run build
@@ -49,4 +51,7 @@ jobs:
           git add docs/zkapps/snarkyjs-reference
           git add sidebars.js
           git commit -m "Build and publish new SnarkyJS API reference docs"
+
+          # Use Github CLI to create a PR
           git push --set-upstream origin $BRANCH_NAME
+          gh pr create -B main -H $BRANCH_NAME --title "Build and publish new SnarkyJS API reference docs" --body ""

--- a/.github/workflows/snarkyjs-api-reference.yml
+++ b/.github/workflows/snarkyjs-api-reference.yml
@@ -1,33 +1,42 @@
-on:
-  workflow_dispatch:
-    inputs:
-      logLevel:
-        description: 'Log level'
-        required: true
-        default: 'warning'
-        type: choice
-        options:
-          - info
-          - warning
-          - debug
-      tags:
-        description: 'Test scenario tags'
-        required: false
-        type: boolean
-      environment:
-        description: 'Environment to run tests against'
-        type: environment
-        required: true
+name: SnarkyJS-API-Reference
+on: workflow_dispatch
 
 jobs:
-  log-the-inputs:
+  update-snarkyjs-api-reference:
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "Log level: $LEVEL"
-          echo "Tags: $TAGS"
-          echo "Environment: $ENVIRONMENT"
-        env:
-          LEVEL: ${{ inputs.logLevel }}
-          TAGS: ${{ inputs.tags }}
-          ENVIRONMENT: ${{ inputs.environment }}
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Checkout Docs repo
+        uses: actions/checkout@v3
+        with:
+          path: docs
+      - name: Checkout SnarkyJS repo
+        uses: actions/checkout@v3
+        with:
+          repository: o1-labs/snarkyjs
+          path: snarkyjs
+      - name: Build API reference docs
+        run: |
+          cd snarkyjs
+          npm ci
+          npm run build
+
+          npm install typedoc-plugin-markdown
+          npx typedoc --readme none --name SnarkyJS --plugin typedoc-plugin-markdown --out snarkyjs-reference src/index.ts --hideBreadcrumbs true
+
+          cd ../docs/
+          rm -rf docs/zkapps/snarkyjs-reference
+          cp -rv ../snarkyjs/snarkyjs-reference docs/zkapps/snarkyjs-reference
+
+          node update-sidebars-snarkyjs-api.js
+          npx prettier --write ./docusaurus.config.js
+
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add docs/zkapps/snarkyjs-reference
+          git add docusaurus.config.js
+          git commit -m "Build and publish new SnarkyJS API reference docs"
+          git push

--- a/.github/workflows/snarkyjs-api-reference.yml
+++ b/.github/workflows/snarkyjs-api-reference.yml
@@ -1,6 +1,12 @@
 name: SnarkyJS-API-Reference
-on: workflow_dispatch
-
+on:
+  workflow_dispatch:
+    snarkyjs_branch:
+      type: choice
+      description: SnarkyJS branch to build from
+      options:
+        - main
+        - releases
 jobs:
   update-snarkyjs-api-reference:
     runs-on: ubuntu-latest
@@ -9,15 +15,19 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+
       - name: Checkout Docs repo
         uses: actions/checkout@v3
         with:
           path: docs
+
       - name: Checkout SnarkyJS repo
         uses: actions/checkout@v3
         with:
           repository: o1-labs/snarkyjs
           path: snarkyjs
+          ref: ${{ github.event.inputs.${{ github.event.inputs.message }} }}
+
       - name: Build API reference docs
         run: |
           # Install dependencies and build SnarkyJS

--- a/.github/workflows/snarkyjs-api-reference.yml
+++ b/.github/workflows/snarkyjs-api-reference.yml
@@ -39,7 +39,7 @@ jobs:
           rm -rf docs/zkapps/snarkyjs-reference && cp -rv ../snarkyjs/snarkyjs-reference docs/zkapps/snarkyjs-reference
 
           # Update with new enteries and format sidebars.js
-          node update-sidebars-snarkyjs-api.js && npx prettier --config .prettierrc --write docusaurus.config.js
+          node update-sidebars-snarkyjs-api.js && npx prettier --config .prettierrc --write sidebars.js
 
           # Configure git and push
           BRANCH_NAME=docs/snarkyjs-api-reference-$(git --git-dir ../snarkyjs/.git rev-parse --short HEAD)
@@ -47,6 +47,6 @@ jobs:
           git config user.email github-actions@github.com
           git switch -c $BRANCH_NAME
           git add docs/zkapps/snarkyjs-reference
-          git add docusaurus.config.js
+          git add sidebars.js
           git commit -m "Build and publish new SnarkyJS API reference docs"
           git push --set-upstream origin $BRANCH_NAME

--- a/.github/workflows/snarkyjs-api-reference.yml
+++ b/.github/workflows/snarkyjs-api-reference.yml
@@ -20,20 +20,23 @@ jobs:
           path: snarkyjs
       - name: Build API reference docs
         run: |
-          cd snarkyjs
-          npm ci
-          npm run build
+          # Install dependencies and build SnarkyJS
+          cd snarkyjs && npm ci && npm run build
 
+          # Install markdown-plugin for typedoc and build the SnarkyJS API reference
           npm install typedoc-plugin-markdown
           npx typedoc --readme none --name SnarkyJS --plugin typedoc-plugin-markdown --out snarkyjs-reference src/index.ts --hideBreadcrumbs true
 
-          cd ../docs/
-          rm -rf docs/zkapps/snarkyjs-reference
-          cp -rv ../snarkyjs/snarkyjs-reference docs/zkapps/snarkyjs-reference
+          # Install dependencies for Docs repo
+          cd ../docs/ && npm ci
 
-          node update-sidebars-snarkyjs-api.js
-          npx prettier --write ./docusaurus.config.js
+          # Remove the old API reference and copy the newly generated reference
+          rm -rf docs/zkapps/snarkyjs-reference && cp -rv ../snarkyjs/snarkyjs-reference docs/zkapps/snarkyjs-reference
 
+          # Update with new enteries and format sidebars.js
+          node update-sidebars-snarkyjs-api.js && npx prettier --config .prettierrc --write docusaurus.config.js
+
+          # Configure git and push
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add docs/zkapps/snarkyjs-reference

--- a/.github/workflows/snarkyjs-api-reference.yml
+++ b/.github/workflows/snarkyjs-api-reference.yml
@@ -26,6 +26,7 @@ jobs:
           # Install markdown-plugin for typedoc and build the SnarkyJS API reference
           npm install typedoc-plugin-markdown
           npx typedoc --readme none --name SnarkyJS --plugin typedoc-plugin-markdown --out snarkyjs-reference src/index.ts --hideBreadcrumbs true
+          rm snarkyjs-reference/.nojekyll
 
           # Install dependencies for Docs repo
           cd ../docs/ && npm ci


### PR DESCRIPTION
## Description
This PR adds a Github Actions job that builds new SnarkyJS API reference docs and copies them over to the docs repo to be pushed and updated. This can be triggered manually with `workflow_dispatch`.

It starts by checking out both the SnarkyJS repo and the docs repo, installing dependencies, running `typedoc-plugin-markdown`, copying over the generated reference docs into the docs repo, updating and formatting `sidebars.js`, and finally configuring git and pushing to the docs repo.

## Tested
This was tested manually on my system by cloning both SnarkyJS and docs2 and running through the commands manually up to the point of pushing on git.