### PR TITLE
Tutorial 6: Fix typo and update function name reference

### DIFF
--- a/docs/zkapps/tutorials/06-offchain-storage.mdx
+++ b/docs/zkapps/tutorials/06-offchain-storage.mdx
@@ -210,7 +210,7 @@ Continuing, let's setup our smart contract:
 
 Here we add 3 pieces of state to our contract: the public key of the storage server, the "storageNumber"—which is used to ensure the storage server is actively storing states, and the root of the merkle tree.
 
-We also initialize our zkApp's initState function for these three values, by setting them to the public key of our storage server, setting storage number to 0, and storing the root of an empty tree.
+We also initialize our zkApp's state for these three values, by setting them to the public key of our storage server, setting storage number to 0, and storing the root of an empty tree.
 
 Continuing, here is our update function:
 

--- a/docs/zkapps/tutorials/06-offchain-storage.mdx
+++ b/docs/zkapps/tutorials/06-offchain-storage.mdx
@@ -210,7 +210,7 @@ Continuing, let's setup our smart contract:
 
 Here we add 3 pieces of state to our contract: the public key of the storage server, the "storageNumber"—which is used to ensure the storage server is actively storing states, and the root of the merkle tree.
 
-We also initialize our zkApp's initialize for these three values, by setting them to the public key of our storage server, setting storage number to 0, and storing the root of an empty tree.
+We also initialize our zkApp's initState function for these three values, by setting them to the public key of our storage server, setting storage number to 0, and storing the root of an empty tree.
 
 Continuing, here is our update function:
 
@@ -302,7 +302,7 @@ Our goal in this function is to:
 
 1. Get the currently stored tree from the storage server
 2. Select a random leaf
-3. Change the value at that leaf to a bigger nubmer
+3. Change the value at that leaf to a bigger number
 4. Create a transaction that performs this update.
 
 To start, let's get the existing tree:


### PR DESCRIPTION
- fixed typo for "nubmer" to "number" 
- updated "initiState" function reference in explanation