### PR TITLE
Fix import for "CreditScoreOracle.test.ts"

### DIFF
--- a/docs/zkapps/tutorials/07-oracle.mdx
+++ b/docs/zkapps/tutorials/07-oracle.mdx
@@ -297,7 +297,7 @@ this.emitEvent('verified', id);
 The zkApp CLI automatically generated a file called `CreditScoreOracle.test.ts` for us when we ran `zk file CreditScoreOracle`. Let’s add some tests. Open it and paste in the following:
 
 ```ts
-import { OracleExample } from './OracleExample';
+import { OracleExample } from './CreditScoreOracle';
 import {
   isReady,
   shutdown,


### PR DESCRIPTION
import function `OracleExample` for the test file "CreditScoreOracle.test.ts" should be from `./CreditScoreOracle` and not `./OracleExample` as per beginning of the guide. 
With this change, it passes the `npm run test` command