### PR TITLE
[updated]Broken Link

### DIFF
--- a/docs/about-mina/index.mdx
+++ b/docs/about-mina/index.mdx
@@ -22,7 +22,7 @@ Learn more about [Mina’s unique protocol architecture](about-mina/protocol-arc
 
 Mina’s unique characteristics are made possible using  zero-knowledge proofs.
 
-Watch this [video to learn about zero-knowledge proofs](./what-are-zero-knowledge-proofs />.
+Watch this [video to learn about zero-knowledge proofs](./what-are-zero-knowledge-proofs).
 
 ### What are zkApps?
 


### PR DESCRIPTION
The link in the `What are zero-knowledge proofs?` was broken due to incorrect syntax just changed that to correct syntax.

Link to the page where link was broken [https://docs.minaprotocol.com/about-mina](https://docs.minaprotocol.com/about-mina)

Incorrect syntax:
![image](https://user-images.githubusercontent.com/29760727/207925859-cf34d190-b3e4-4174-80a4-d65c90eb6f98.png)
