### PR TITLE
Add empty environment variables for algolia

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -309,8 +309,8 @@ module.exports = {
         respectPrefersColorScheme: false,
       },
       algolia: {
-        appId: process.env.ALGOLIA_APP_ID,
-        apiKey: process.env.ALGOLIA_SEARCH_API_KEY,
+        appId: process.env.ALGOLIA_APP_ID ?? 'mina-appId',
+        apiKey: process.env.ALGOLIA_SEARCH_API_KEY ?? 'mina-apiKey',
         indexName: 'mina',
         contextualSearch: false,
       },


### PR DESCRIPTION
This adds empty environment variables to our site config related to algolia if none are present. When we deploy to dev/preview environments on Vercel, the algolia environment variables will not be defined, and this causes build errors. Here, we specify empty environment variables if they are not defined to get around the build issues.