### PR TITLE
Update JS copy code snippet to handle $ in multi and single line commands

### DIFF
--- a/src/theme/CodeBlock/CopyButton/index.js
+++ b/src/theme/CodeBlock/CopyButton/index.js
@@ -15,9 +15,17 @@ export default function CopyButton({ code, className }) {
     let copiedCode = code.replace(removeLineNumbers, '');
     copiedCode = copiedCode.replace(removeEllipses, '');
 
+    /**
+     This removes all lines from the code snippet that 
+     do not start with $ (i.e. the output of a terminal command),
+     and removes the $ from the remaining lines. 
+    **/
     if (copiedCode.startsWith('$')) {
-      const codeArr = copiedCode.split('\n');
-      copiedCode = codeArr.filter((line) => line[0] === '$').join('\n');
+      const copiedCodeArr = copiedCode.split('\n');
+      copiedCode = copiedCodeArr
+        .filter((line) => line[0] === '$')
+        .join('\n')
+        .replace(removeDollarSymbol, '');
     }
 
     copy(copiedCode);

--- a/src/theme/CodeBlock/CopyButton/index.js
+++ b/src/theme/CodeBlock/CopyButton/index.js
@@ -7,6 +7,7 @@ import styles from './styles.module.css';
 export default function CopyButton({ code, className }) {
   const [isCopied, setIsCopied] = useState(false);
   const copyTimeout = useRef(undefined);
+
   const handleCopyCode = useCallback(() => {
     const removeLineNumbers = /^\s*\d+\s/gm;
     const removeEllipses = /(^\s*\.{3})(?![^a-z])|(^\.{3})/gm;
@@ -16,10 +17,10 @@ export default function CopyButton({ code, className }) {
     copiedCode = copiedCode.replace(removeEllipses, '');
 
     /**
-     This removes all lines from the code snippet that 
-     do not start with $ (i.e. the output of a terminal command),
-     and removes the $ from the remaining lines. 
-    **/
+     * This removes all lines from the code snippet after the lines
+     * that start with $ (i.e. the output of a terminal command),
+     * and removes the $ from the remaining lines.
+     **/
     if (copiedCode.startsWith('$')) {
       const copiedCodeArr = copiedCode.split('\n');
       copiedCode = copiedCodeArr

--- a/src/theme/CodeBlock/CopyButton/index.js
+++ b/src/theme/CodeBlock/CopyButton/index.js
@@ -10,9 +10,11 @@ export default function CopyButton({ code, className }) {
   const handleCopyCode = useCallback(() => {
     const removeLineNumbers = /^\s*\d+\s/gm;
     const removeEllipses = /(^\s*\.{3})(?![^a-z])|(^\.{3})/gm;
+    const removeDollarSymbol = /^\$\s/gm;
 
     let copiedCode = code.replace(removeLineNumbers, '');
     copiedCode = copiedCode.replace(removeEllipses, '');
+    copiedCode = copiedCode.replace(removeDollarSymbol, '');
 
     copy(copiedCode);
     setIsCopied(true);

--- a/src/theme/CodeBlock/CopyButton/index.js
+++ b/src/theme/CodeBlock/CopyButton/index.js
@@ -14,7 +14,10 @@ export default function CopyButton({ code, className }) {
 
     let copiedCode = code.replace(removeLineNumbers, '');
     copiedCode = copiedCode.replace(removeEllipses, '');
-    copiedCode = copiedCode.replace(removeDollarSymbol, '');
+
+    if (copiedCode.startsWith('$')) {
+      const codeArr = copiedCode.split('\n');
+    }
 
     copy(copiedCode);
     setIsCopied(true);

--- a/src/theme/CodeBlock/CopyButton/index.js
+++ b/src/theme/CodeBlock/CopyButton/index.js
@@ -17,6 +17,7 @@ export default function CopyButton({ code, className }) {
 
     if (copiedCode.startsWith('$')) {
       const codeArr = copiedCode.split('\n');
+      copiedCode = codeArr.filter((line) => line[0] === '$').join('\n');
     }
 
     copy(copiedCode);


### PR DESCRIPTION
Closes 239 & 243 

This PR updates the JS copy code snippet to remove all lines from the snippet after the lines that start with a `$`  (i.e. the output of a terminal command), and strips the `$` from the start of the remaining lines. 