### PR TITLE
Add note at top of each tutorial to show which version of SnarkyJS it was tested with

### DIFF
--- a/docs/zkapps/tutorials/01-hello-world.mdx
+++ b/docs/zkapps/tutorials/01-hello-world.mdx
@@ -11,6 +11,12 @@ zkApps can now be deployed to Berkeley Testnet.
 
 :::
 
+:::note
+
+This tutorial was last tested with [SnarkyJS](https://www.npmjs.com/package/snarkyjs) 0.8.0.
+
+:::
+
 # Tutorial 1: Hello World
 
 ## Overview

--- a/docs/zkapps/tutorials/02-private-inputs-hash-functions.mdx
+++ b/docs/zkapps/tutorials/02-private-inputs-hash-functions.mdx
@@ -11,6 +11,12 @@ zkApps can now be deployed to Berkeley Testnet.
 
 :::
 
+:::note
+
+This tutorial was last tested with [SnarkyJS](https://www.npmjs.com/package/snarkyjs) 0.8.0.
+
+:::
+
 # Tutorial 2: Private Inputs and Hash Functions
 
 ## Overview

--- a/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
+++ b/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
@@ -11,6 +11,12 @@ zkApps can now be deployed to Berkeley Testnet.
 
 :::
 
+:::note
+
+This tutorial was last tested with [SnarkyJS](https://www.npmjs.com/package/snarkyjs) 0.8.0.
+
+:::
+
 # Tutorial 3: Deploying to a Live Network
 
 ## Overview

--- a/docs/zkapps/tutorials/04-zkapp-ui-with-react.mdx
+++ b/docs/zkapps/tutorials/04-zkapp-ui-with-react.mdx
@@ -13,12 +13,6 @@ zkApps can now be deployed to Berkeley Testnet.
 
 :::
 
-:::note
-
-This tutorial was last tested with [SnarkyJS](https://www.npmjs.com/package/snarkyjs) 0.8.0.
-
-:::
-
 ## Overview
 
 In previous tutorials, we've seen how to [write zkApps](hello-world) and [deploy them to a network](deploying-to-a-network).
@@ -237,7 +231,7 @@ Continuing, we load our zkApp in the web worker. We load the contract, compile i
  61         await zkappWorkerClient.compileContract();
  62         console.log('zkApp compiled');
  63
- 64         const zkappPublicKey = PublicKey.fromBase58('B62qrBBEARoG78KLD1bmYZeEirUfpNXoMPYQboTwqmGLtfqAGLXdWpU');
+ 64         const zkappPublicKey = PublicKey.fromBase58('B62qiqD8k9fAq94ejkvzaGEV44P1uij6vd6etGLxcR4dA8ZRZsxkwvR');
  65
  66         await zkappWorkerClient.initZkappInstance(zkappPublicKey);
  67

--- a/docs/zkapps/tutorials/04-zkapp-ui-with-react.mdx
+++ b/docs/zkapps/tutorials/04-zkapp-ui-with-react.mdx
@@ -13,6 +13,12 @@ zkApps can now be deployed to Berkeley Testnet.
 
 :::
 
+:::note
+
+This tutorial was last tested with [SnarkyJS](https://www.npmjs.com/package/snarkyjs) 0.8.0.
+
+:::
+
 ## Overview
 
 In previous tutorials, we've seen how to [write zkApps](hello-world) and [deploy them to a network](deploying-to-a-network).

--- a/docs/zkapps/tutorials/05-common-types-and-functions.mdx
+++ b/docs/zkapps/tutorials/05-common-types-and-functions.mdx
@@ -11,6 +11,12 @@ zkApps can now be deployed to Berkeley Testnet.
 
 :::
 
+:::note
+
+This tutorial was last tested with [SnarkyJS](https://www.npmjs.com/package/snarkyjs) 0.8.0.
+
+:::
+
 # Tutorial 5: Common Types and Functions
 
 In previous tutorials, we've seen how to deploy smart contracts to the network, and we've interacted with them from both a React UI and NodeJS.

--- a/docs/zkapps/tutorials/06-offchain-storage.mdx
+++ b/docs/zkapps/tutorials/06-offchain-storage.mdx
@@ -11,6 +11,12 @@ zkApps can now be deployed to Berkeley Testnet.
 
 :::
 
+:::note
+
+This tutorial was last tested with [SnarkyJS](https://www.npmjs.com/package/snarkyjs) 0.8.0.
+
+:::
+
 # Tutorial 6: Off-Chain Storage
 
 ## Overview

--- a/docs/zkapps/tutorials/08-custom-tokens.mdx
+++ b/docs/zkapps/tutorials/08-custom-tokens.mdx
@@ -11,6 +11,12 @@ zkApps can now be deployed to Berkeley Testnet.
 
 :::
 
+:::note
+
+This tutorial was last tested with [SnarkyJS](https://www.npmjs.com/package/snarkyjs) 0.8.0.
+
+:::
+
 # Tutorial 8: Custom Tokens
 
 ## Overview
@@ -21,7 +27,7 @@ Mina comes with native support for custom tokens. Each account on Mina can also 
 
 To create a new token, one creates a smart contract, which becomes the manager for the token, and uses that contract to set the rules around how the token can be mint, burned, and sent.
 
-The manager account may also set a token symbol for its token, such as in this example, `MYTKN`. Uniqueness is not enforced for token names. Instead the public key of the manager account is used to identify tokens. 
+The manager account may also set a token symbol for its token, such as in this example, `MYTKN`. Uniqueness is not enforced for token names. Instead the public key of the manager account is used to identify tokens.
 
 In this tutorial, we will review smart contract code that creates and manages new tokens. You can find the full code of what we'll be building in this tutorial [here](https://github.com/o1-labs/docs2/tree/main/examples/zkapps/08-custom-tokens/src).
 

--- a/docs/zkapps/tutorials/interacting-with-zkapps-server-side.mdx
+++ b/docs/zkapps/tutorials/interacting-with-zkapps-server-side.mdx
@@ -11,6 +11,12 @@ zkApps can now be deployed to Berkeley Testnet.
 
 :::
 
+:::note
+
+This tutorial was last tested with [SnarkyJS](https://www.npmjs.com/package/snarkyjs) 0.8.0.
+
+:::
+
 # Interacting with zkApps server-side
 
 ## Overview

--- a/examples/zkapps/04-zkapp-browser-ui/ui/pages/_app.page.tsx
+++ b/examples/zkapps/04-zkapp-browser-ui/ui/pages/_app.page.tsx
@@ -59,7 +59,7 @@ export default function App() {
         console.log('zkApp compiled');
 
         const zkappPublicKey = PublicKey.fromBase58(
-          'B62qph2VodgSo5NKn9gZta5BHNxppgZMDUihf1g7mXreL4uPJFXDGDA'
+          'B62qiqD8k9fAq94ejkvzaGEV44P1uij6vd6etGLxcR4dA8ZRZsxkwvR'
         );
 
         await zkappWorkerClient.initZkappInstance(zkappPublicKey);


### PR DESCRIPTION
Closes #205 

A note was added at the top of each tutorial stating which SnarkyJS version it was tested with.

<img width="1685" alt="Screen Shot 2023-02-01 at 2 38 35 AM" src="https://user-images.githubusercontent.com/2808242/215865145-2d716bdc-3c7e-4626-b298-51d4d0b26ea3.png">
