### PR TITLE
Document how to capture assertion exceptions and show in a zkApp UI

### DIFF
--- a/docs/zkapps/how-to-write-a-zkapp-ui.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp-ui.mdx
@@ -231,6 +231,7 @@ href="https://docs.aurowallet.com/general/reference/api-reference/mina-provider-
 If an assertion error occurs while a user is interacting with your zkApp, you may want capture the assertion error and display a helpful message for the user in your UI.
 
 1. Capture errors that occur when a user interacts with a method on your smart contract in a try catch statement.
+2. Filter by the error message that was created.
 
 ```ts
 try {

--- a/docs/zkapps/how-to-write-a-zkapp-ui.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp-ui.mdx
@@ -227,3 +227,5 @@ href="https://docs.aurowallet.com/general/reference/api-reference/mina-provider-
 :::
 
 ## Displaying assertion exceptions in your UI
+
+If an assertion error occurs while a user is interacting with your zkApp, you may want capture the assertion error and display a helpful message for the user in your UI.

--- a/docs/zkapps/how-to-write-a-zkapp-ui.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp-ui.mdx
@@ -240,7 +240,8 @@ try {
 } catch (err) {
   let uiErrorMessage;
   switch (err.message) {
-    case 'Overflow': // The assertion error message thrown by invoking YourSmartContract.yourMethod when there is an insufficent balance.
+    // The assertion error message thrown by invoking YourSmartContract.yourMethod when there is an insufficent balance. In this case, a custom error message.
+    case 'INSUFFICIENT_BALANCE':
       // Create a helpful message to display to your user in the UI. This message can be shown in a modal or displayed somewhere in your UI.
       uiErrorMessage =
         'Your account has an insufficent balance for this transaction';

--- a/docs/zkapps/how-to-write-a-zkapp-ui.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp-ui.mdx
@@ -232,6 +232,7 @@ If an assertion error occurs while a user is interacting with your zkApp, you ma
 
 1. Capture errors that occur when a user interacts with a method on your smart contract in a try catch statement.
 2. Filter by the error message that was created.
+3. Display a helpful error message for the user in your UI based on what assertion exception was captured. This could be a modal or a message in your UI.
 
 ```ts
 try {
@@ -239,7 +240,7 @@ try {
 } catch (err) {
   switch (err.message) {
     case INSUFFICIENT_BALANCE:
-      // show a modal telling the user they have insufficient balance for this
+      // show a modal or a message telling the user they have insufficient balance for this
       break;
     // etc
   }

--- a/docs/zkapps/how-to-write-a-zkapp-ui.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp-ui.mdx
@@ -106,7 +106,6 @@ onMounted(async () => {
 To load SnarkyJS code in your UI, you must set the [COOP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy)
 and [COEP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy) headers as described below. These enable SnarkyJS' use of [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer), which SnarkyJS relies on to enable important WebAssembly features.
 
-
 - `Cross-Origin-Opener-Policy` must be set to `same-origin`.
 - `Cross-Origin-Embedder-Policy` must be set to `require-corp`.
 
@@ -226,3 +225,5 @@ href="https://docs.aurowallet.com/general/reference/api-reference/mina-provider-
 ">reference docs</a>.
 
 :::
+
+## Displaying assertion exceptions in your UI

--- a/docs/zkapps/how-to-write-a-zkapp-ui.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp-ui.mdx
@@ -240,7 +240,7 @@ try {
 } catch (err) {
   let uiErrorMessage;
   switch (err.message) {
-    case 'Overflow': // The assertion error message thrown by invoking YourSmartContract.yourMethod
+    case 'Overflow': // The assertion error message thrown by invoking YourSmartContract.yourMethod when there is an insufficent balance.
       // Create a helpful message to display to your user in the UI. This message can be shown in a modal or displayed somewhere in your UI.
       uiErrorMessage =
         'Your account has an insufficent balance for this transaction';

--- a/docs/zkapps/how-to-write-a-zkapp-ui.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp-ui.mdx
@@ -226,9 +226,11 @@ href="https://docs.aurowallet.com/general/reference/api-reference/mina-provider-
 
 :::
 
-## Displaying assertion exceptions in your UI
+### Displaying assertion exceptions in your UI
 
 If an assertion error occurs while a user is interacting with your zkApp, you may want capture the assertion error and display a helpful message for the user in your UI.
+
+1. Capture errors that occur when a user interacts with a method on your smart contract in a try catch statement.
 
 ```ts
 try {

--- a/docs/zkapps/how-to-write-a-zkapp-ui.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp-ui.mdx
@@ -236,7 +236,7 @@ If an assertion error occurs while a user is interacting with your zkApp, you ma
 
 ```ts
 try {
-  methodOnYourSmartContract(arg);
+  YourSmartContract.yourMethod();
 } catch (err) {
   switch (err.message) {
     case INSUFFICIENT_BALANCE:

--- a/docs/zkapps/how-to-write-a-zkapp-ui.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp-ui.mdx
@@ -232,9 +232,9 @@ If an assertion error occurs while a user is interacting with your zkApp, you ma
 
 ```ts
 try {
-  callMyMethod(arg);
-} catch (e) {
-  switch (e.message) {
+  methodOnYourSmartContract(arg);
+} catch (err) {
+  switch (err.message) {
     case INSUFFICIENT_BALANCE:
       // show a modal telling the user they have insufficient balance for this
       break;

--- a/docs/zkapps/how-to-write-a-zkapp-ui.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp-ui.mdx
@@ -238,9 +238,12 @@ If an assertion error occurs while a user is interacting with your zkApp, you ma
 try {
   YourSmartContract.yourMethod();
 } catch (err) {
+  let uiErrorMessage;
   switch (err.message) {
-    case INSUFFICIENT_BALANCE:
-      // show a modal or a message telling the user they have insufficient balance for this
+    case 'Overflow': // The assertion error message thrown by invoking YourSmartContract.yourMethod
+      // Create a helpful message to display to your user in the UI. This message can be shown in a modal or displayed somewhere in your UI.
+      uiErrorMessage =
+        'Your account has an insufficent balance for this transaction';
       break;
     // etc
   }

--- a/docs/zkapps/how-to-write-a-zkapp-ui.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp-ui.mdx
@@ -229,3 +229,16 @@ href="https://docs.aurowallet.com/general/reference/api-reference/mina-provider-
 ## Displaying assertion exceptions in your UI
 
 If an assertion error occurs while a user is interacting with your zkApp, you may want capture the assertion error and display a helpful message for the user in your UI.
+
+```ts
+try {
+  callMyMethod(arg);
+} catch (e) {
+  switch (e.message) {
+    case INSUFFICIENT_BALANCE:
+      // show a modal telling the user they have insufficient balance for this
+      break;
+    // etc
+  }
+}
+```


### PR DESCRIPTION
Closes #232 

This PR adds a section at the end of the section [How to Write a zkApp UI](https://docs.minaprotocol.com/zkapps/how-to-write-a-zkapp-ui) on how to capture assertion errors and display helpful messages in the UI.

We can link to [this](https://github.com/o1-labs/docs2/issues/263) page documenting all the assertion exceptions and ways to mitigate them when it is created. 