### PR TITLE
zkApps roadmap (v0)

### DIFF
--- a/docs/zkapps/roadmap.mdx
+++ b/docs/zkapps/roadmap.mdx
@@ -1,0 +1,96 @@
+---
+title: Roadmap
+hide_title: true
+---
+
+import Subhead from '@site/src/components/common/Subhead';
+
+:::info
+
+Please note that zkApp programmability is not yet available on Mina Mainnet, but
+zkApps can now be deployed to Berkeley Testnet.
+
+:::
+
+# zkApps Roadmap
+
+<Subhead>High-level overview of features available now, next, or later</Subhead>
+
+## Now
+
+### Mina zkApp CLI
+
+- [Scaffold projects & files](/zkapps/how-to-write-a-zkapp#option-b-start-your-own-project)
+- [Example projects](/zkapps/how-to-write-a-zkapp#option-a-start-with-an-example-recommended)
+- [Deployment](/zkapps/how-to-deploy-a-zkapp)
+- Create a project with an accompanying UI — SvelteKit, NextJS, or NuxtJS
+
+:::note
+
+Install via `npm install -g zkapp-cli`. Use `zk --help` to see all commands.
+
+:::
+
+### SnarkyJS
+
+- [Built-in data types](/zkapps/how-to-write-a-zkapp#built-in-data-types) — Field, Bool, UInt32, UInt64, PublicKey, PrivateKey, Signature, Group, Scalar, & CircuitString
+- [Custom data types](/zkapps/how-to-write-a-zkapp#custom-data-types) — a.k.a. Struct
+- [Composability](/zkapps/how-to-write-a-zkapp#composing-zkapps)
+- [Recursion](/zkapps/advanced-snarkyjs/recursion) — a.k.a. ZkProgram
+- [Events](/zkapps/advanced-snarkyjs/events) — writing events to the archive node
+- [Encryption & decryption](/zkapps/snarkyjs-reference/modules/Encryption) — using Mina’s curves
+- [Actions & reducer](/zkapps/advanced-snarkyjs/actions-and-reducer)
+- [Merkle tree](/zkapps/advanced-snarkyjs/merkle-tree)
+- [Custom tokens](/zkapps/advanced-snarkyjs/custom-tokens)
+- [Using on-chain values](/zkapps/advanced-snarkyjs/on-chain-values) — a.k.a. protocol & account preconditions
+- [Local blockchain](/zkapps/snarkyjs-reference/modules/Mina#localblockchain)
+- [And more...](/zkapps/snarkyjs-reference)
+
+### Data Availability
+
+- [On-chain state](/zkapps/how-to-write-a-zkapp#on-chain-state) — 8 x 32 bytes of arbitrary data per zkApp account
+- [Off-chain storage](/zkapps/tutorials/offchain-storage) — for Merkle tree data; see Tutorial 6
+
+### Other
+
+- [Oracles](/zkapps/tutorials/oracle)
+
+## Next
+
+### SnarkyJS
+
+- [Events](https://github.com/o1-labs/snarkyjs/issues/606) — reading events from the archive node; awaiting Archive Node API; ETA Q1 2023
+- [Actions](https://github.com/o1-labs/snarkyjs/issues/688) — reading events from the archive node; awaiting Archive Node API; ETA Q1 2023
+- [Reduce memory requirements during file import](https://github.com/o1-labs/snarkyjs/issues/609) — ETA H1 2023
+- Remove need for a dev to use a service worker for their UI — ETA H1 2023
+- [Reduce KB file size, for aspects needed for UIs](https://github.com/o1-labs/snarkyjs/issues/610) — ETA H1 2023
+- Improve error messages — ETA H1 2023
+
+### Data Availability
+
+- Off-chain storage for Merkle tree data with better guarantees — WIP; two teams awarded grants by Mina Foundation
+
+### Other
+
+- Archive Node API — Phase I; link to RFC on Github coming; ETA Q1 2023
+
+## Later
+
+### Mina zkApp CLI
+
+- [3rd-party fee payer for deployment txs](https://github.com/o1-labs/zkapp-cli/issues/129)
+
+### SnarkyJS
+
+- [Dynamic array access](https://github.com/o1-labs/snarkyjs/issues/90) — awaiting support in proof system for extended lookup tables
+- [Dynamic-length strings](https://github.com/o1-labs/snarkyjs/issues/730) — awaiting dynamic array access
+- [JSON parsing](https://github.com/o1-labs/snarkyjs/issues/91) — awaiting dynamic-length strings
+- [secp256k1](https://github.com/o1-labs/snarkyjs/issues/61) — awaiting support in Kimchi
+- [keccak256](https://github.com/o1-labs/snarkyjs/issues/62) — awaiting support in Kimchi
+- [ECDSA](https://github.com/o1-labs/snarkyjs/issues/732) — awaiting support in Kimchi
+- [sha256](https://github.com/o1-labs/snarkyjs/issues/731) — awaiting support in Kimchi
+
+### Other
+
+- Archive Node API — Phase II; for serverless hosts!
+- zkOracles — with robust privacy guarantees

--- a/docs/zkapps/roadmap.mdx
+++ b/docs/zkapps/roadmap.mdx
@@ -1,6 +1,7 @@
 ---
-title: Roadmap
+title: zkApps Roadmap
 hide_title: true
+sidebar_label: Roadmap
 ---
 
 import Subhead from '@site/src/components/common/Subhead';

--- a/docs/zkapps/roadmap.mdx
+++ b/docs/zkapps/roadmap.mdx
@@ -28,7 +28,7 @@ zkApps can now be deployed to Berkeley Testnet.
 
 :::note
 
-Install via `npm install -g zkapp-cli`. Use `zk --help` to see all commands.
+To view all commands offered by the zkApp CLI, install it via `npm install -g zkapp-cli` and then run `zk --help`.
 
 :::
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -66,9 +66,6 @@ module.exports = {
             'zkapps/tutorials/interacting-with-zkapps-server-side',
           ],
         },
-        'zkapps/roadmap',
-        'zkapps/zkapps-for-ethereum-developers',
-        'zkapps/faq',
         {
           type: 'category',
           label: 'SnarkyJS Reference',
@@ -278,6 +275,9 @@ module.exports = {
             },
           ],
         },
+        'zkapps/roadmap',
+        'zkapps/faq',
+        'zkapps/zkapps-for-ethereum-developers',
       ],
     },
     {

--- a/sidebars.js
+++ b/sidebars.js
@@ -66,6 +66,7 @@ module.exports = {
             'zkapps/tutorials/interacting-with-zkapps-server-side',
           ],
         },
+        'zkapps/roadmap',
         'zkapps/zkapps-for-ethereum-developers',
         'zkapps/faq',
         {


### PR DESCRIPTION
Why? Goal is a quick and rough roadmap, so that it exists for zkIgnite and devs can have a high-level overview of what features exist now/next/later.