### PR TITLE
fix broken link in Repository Structure doc

### DIFF
--- a/docs/node-developers/codebase-overview.mdx
+++ b/docs/node-developers/codebase-overview.mdx
@@ -19,7 +19,7 @@ Assuming basic familiarity with OCaml, here's some more info on how it is used i
 
 ## Code Structure
 
-See the [Repository Structure page](/node-developers/directory-structure).
+See the [Repository Structure page](/node-developers/repository-structure).
 
 ## Compilation
 


### PR DESCRIPTION
here's your preview of the [Repository Structure](https://docs2-git-fork-duncand0nuts-patch-22-minadocs.vercel.app/node-developers/repository-structure) doc