### PR TITLE
docs: use evergreen invite link to Discord server [zkApp Developers section]

### DIFF
--- a/docs/zkapps/index.mdx
+++ b/docs/zkapps/index.mdx
@@ -97,10 +97,10 @@ Play around with a few example zkApps to see what’s possible:
 
 ### Learn more
 
-To learn more, read about [how zkApps work](/zkapps/how-zkapps-work), [how to write a zkApp](/zkapps/how-to-write-a-zkapp), and [zkApps for Ethereum Developers](/zkapps/zkapps-for-ethereum-developers).
+To learn more about developing zkApps, read [how zkApps work](/zkapps/how-zkapps-work), [how to write a zkApp](/zkapps/how-to-write-a-zkapp), and [zkApps for Ethereum Developers](/zkapps/zkapps-for-ethereum-developers).
 
 Try the [zkApps tutorials](/zkapps/tutorials/hello-world) to learn by doing!
 
 ### Get help
 
-Join the [#zkapps-developers](https://discord.gg/R25r5Zha) channel on Discord and come to our weekly [zkApps Developers Office Hours](/participate/office-hours) to ask questions.
+Join the [#zkapps-developers](https://discord.com/channels/484437221055922177/915745847692636181) channel on Mina Protocol Discord. Participate and ask questions in [zkApps Developers Office Hours](/participate/office-hours).

--- a/docs/zkapps/tutorials/anonymous-message-board.mdx
+++ b/docs/zkapps/tutorials/anonymous-message-board.mdx
@@ -339,7 +339,13 @@ What would you like to say? (should only work if you are one of the Bobs): Hello
 
 Hopefully you enjoyed this tutorial, and it gave you a sense of what's possible with SnarkyJS. The messaging protocol we built is quite simple but also very powerful. This basic pattern could be used to create a whistleblower system, an anonymous NFT project, or even anonymous DAO voting. SnarkyJS makes it easy for developers to build things that don’t intuitively seem possible, and this is really the point.
 
-Zero-knowledge proofs open the door to an entirely different way of thinking about the internet, and we are so excited to see what people like you will build. Make sure to join the [#zkapps-developers](https://discord.com/channels/484437221055922177/915745847692636181) channel on [our Discord](https://bit.ly/MinaDiscord), and apply for the [zkApp Builders Program](https://share.hsforms.com/1KUeCPxJzQC6PIZ-LLdZe1g4xuul) if you are interested in building something more complex with the guidance of our team at O(1) Labs. More tutorials are on the way ([suggest ideas](https://docs.google.com/forms/d/e/1FAIpQLSctM8rq5B7teYhGl8hi2mk8NoSs6YiCDqjOnUfzpAAymU6Uug/viewform?usp=sf_link)), but these are some logical next steps if you are interested in extending this project.
+Zero-knowledge proofs open the door to an entirely different way of thinking about the internet, and we are so excited to see what people like you will build. 
+
+- Make sure to join the [#zkapps-developers](https://discord.com/channels/484437221055922177/915745847692636181) channel on Mina Protocol Discord.  
+- If you are interested in building something more complex with the guidance of our team at O(1) Labs, you can watch for future zkApp Builders Programs. 
+- To suggest tutorials, submit your ideas in the [SnarkyJS/zkApp Tutorial Request Form](https://docs.google.com/forms/d/e/1FAIpQLSctM8rq5B7teYhGl8hi2mk8NoSs6YiCDqjOnUfzpAAymU6Uug/viewform?usp=sf_link). 
+
+Here are the logical next steps to extend this project.
 
 1. Allow users to pass signers into the `publishMessage()` method directly so that many different organizations can use a single contract. (Hint: You’ll have to store a commitment to the signers on-chain.)
 2. Allow users to pass an arbitrarily large number of signers into the `publishMessage()` method.

--- a/docs/zkapps/zkapps-for-ethereum-developers.mdx
+++ b/docs/zkapps/zkapps-for-ethereum-developers.mdx
@@ -117,15 +117,12 @@ export class Add extends SmartContract {
 Mina proofs are small and easy to verify; this means that any Turing complete
 blockchain (like Ethereum) can validate the entire Mina state in a single
 transaction using a bridge contract. These are a bit different from existing
-bridging solutions because they don’t require any additional security
+bridging solutions because they don't require additional security
 assumptions. Think of them as full Mina nodes that are implemented in smart
 contracts on other chains. They validate the Mina state in exactly the same way
 a Mina block producer would and expose Mina directly to any other contract.
-Today the Nil Foundation is working on
- [the first of these](https://verify.mina.nil.foundation/walkthrough/index.html)
- for Ethereum and other EVM compatible networks.
+The Nil Foundation is working on the [first of these bridges](https://verify.mina.nil.foundation/walkthrough/index.html) for Ethereum and other EVM-compatible networks.
 
 ### Have another question?
 
-Feel free to reach out in the #zkapps-developers channel in [our Discord](https://bit.ly/MinaDiscord). We would
-  love to help answer any questions!
+Reach out in the [#zkapps-developers](https://discord.com/channels/484437221055922177/915745847692636181) channel on Mina Protocol Discord. It's better when we learn together. 


### PR DESCRIPTION
For issue #294

To retain channel-specific links, I've changed the "invite to channel" links to a consistent channel link. 

I've used the following syntax for channel-specific links:

> [#ledger-hardware](https://discord.com/channels/484437221055922177/733755408161833040) channel on Mina Protocol Discord
`[#ledger-hardware](https://discord.com/channels/484437221055922177/733755408161833040) channel on Mina Protocol Discord`

> [#zkapps-developers](https://discord.com/channels/484437221055922177/915745847692636181) channel on Mina Protocol Discord
`[#zkapps-developers](https://discord.com/channels/484437221055922177/915745847692636181) channel on Mina Protocol Discord`

If you are wondering how to get the channel link in Discord, right-click a channel and select **Copy Link**.

**Key points** 
- omit the article "the" before 
- omit "server" after
- change personal invite links to channel links 
- spell out full server name `[Mina Protocol Discord]`
- replace all Discord invite links with evergreen URL `(https://discord.gg/minaprotocol)`