### PR TITLE
docs: ecosystem partner mentions, move company name outside of the link text

### DIFF
--- a/docs/mina-faq.mdx
+++ b/docs/mina-faq.mdx
@@ -44,6 +44,8 @@ triage the issue and fix it in a future sprint -- thanks for your help!
 
 #### How can I report other issues / get in touch with the development team?
 
+It's better when we learn together. 
+
 - The Mina community's live discussion channel is the
   [Discord server](https://bit.ly/MinaDiscord)
 - You can also create Github issues: https://github.com/minaprotocol/mina/issues

--- a/docs/node-operators/bp-sidecar.mdx
+++ b/docs/node-operators/bp-sidecar.mdx
@@ -22,13 +22,13 @@ The current sidecar tracking system is being phased out to be replaced by the SN
 - [Instructions for the sidecar tracking system](./bp-sidecar)
 - [Instructions for the SNARK-work-based uptime system](./uptime-tracking-system)
 
-Please follow the latest updates and post questions in the [#delegation-program channel](https://discord.gg/ywDzwmGABT) on Discord.
+Please follow the latest updates and post questions in the [#delegation-program channel](https://discord.com/channels/484437221055922177/808895957978447882) on Mina Protocol Discord.
 
 :::
 
 <br></br>
 
-In order to maintain eligibility for various grants and the Foundation Delegation Program, you must run a sidecar with your daemon to report node uptime.
+In order to maintain eligibility for various grants and the Mina Foundation Delegation Program, you must run a sidecar with your daemon to report node uptime.
 
 If you are required to keep your node online for a grant or specific program, you must run a small sidecar program that will report your daemon's uptime. This tutorial will walk you through the process of installing, configuring and running the sidecar program.
 
@@ -160,5 +160,7 @@ It likely means you're shipping off data to the ingest pipeline without any bloc
 - [Mina Docs: Foundation Delegation Program](foundation-delegation-program)
 - [Mina Docs: SNARK-based Uptime System](./uptime-tracking-system)
 
-#### Need any help? Post your questions in the [#Delegation-Program](https://discord.gg/ywDzwmGABT) channel on Discord.
+#### Need any help? 
+
+Post your questions in the [#Delegation-Program](https://discord.com/channels/484437221055922177/808895957978447882) channel on Mina Protocol Discord.
 

--- a/docs/node-operators/connecting-to-the-network.mdx
+++ b/docs/node-operators/connecting-to-the-network.mdx
@@ -158,7 +158,7 @@ minaprotocol/mina-daemon:1.3.1.2-25388a0-bullseye-mainnet \
 daemon
 ```
 
-Run `docker logs -f mina` to follow the logs, and if it crashes save the log output to a file with `docker logs mina > mina-log.txt` and post the output to the #mentor-nodes channel or attach the full ~/.mina-config/mina.log to a github issue and link the issue in discord.
+Run `docker logs -f mina` to follow the logs, and if it crashes save the log output to a file with `docker logs mina > mina-log.txt` and post the output to the [#mentor-nodes](https://discord.com/channels/484437221055922177/746316198806814760) channel on Mina Protocol Discord or attach the `full ~/.mina-config/mina.log` to a GitHub issue and link the issue in discord.
 
 Run `docker exec -it mina mina client status` to monitor connectivity to the network, you should quickly find at least 10 peers and watch the block height / max observed block height climb.
 

--- a/docs/node-operators/delegation-tiebreak.mdx
+++ b/docs/node-operators/delegation-tiebreak.mdx
@@ -99,6 +99,6 @@ e.&nbsp; In “Part 4: Go!” press the “Randomize” button
     />
 </figure>
 
-Through this process you will be able to confirm the random tiebreak result. If you need any help, please post your question in the [#Delegation-Program](https://discord.gg/ywDzwmGABT) channel on Discord.
+Through this process you will be able to confirm the random tiebreak result. If you need any help, please post your question in the [#delegation-program](https://discord.com/channels/484437221055922177/808895957978447882) channel on Mina Protocol Discord.
 
 

--- a/docs/node-operators/faq.mdx
+++ b/docs/node-operators/faq.mdx
@@ -40,13 +40,13 @@ Head over to the [Docker](connecting-to-the-network#docker) [Devnet page](connec
 
 #### My daemon crashed -- where should I share the error log?
 
-First, check out [Github issues](https://github.com/minaprotocol/mina/issues) to see if this is a known issue. If the error you experienced is a new issue, file a Github issue with the appropriate tags (daemon, bug). Mina developers will triage the issue and fix it in a future sprint -- thanks for your help!
+First, check out existing [GitHub issues](https://github.com/minaprotocol/mina/issues) to see if this is a known issue. If the error you experienced is a new issue, file a GitHub issue with the appropriate tags (daemon, bug). Mina developers will triage the issue and fix it in a future sprint -- thanks for your help!
 
 #### How can I report other issues / get in touch with the development team?
 
-- The Mina community's live discussion takes place is the [Mina Protocol Discord](https://discord.gg/minaprotocol)
-- You can also create Github issues: https://github.com/minaprotocol/mina/issues
-- If you need to get in touch, you can submit a ticket via the [Mina Support chat](https://support.minaprotocol.com/).
+- The Mina community's live discussion takes place in the [Mina Protocol Discord](https://discord.gg/minaprotocol)
+- You can also create GitHub issues: https://github.com/minaprotocol/mina/issues
+- If you need to get in touch, you can submit a ticket by using the [Mina Support chat](https://support.minaprotocol.com/).
 
 #### Is there a block explorer?
 

--- a/docs/node-operators/faq.mdx
+++ b/docs/node-operators/faq.mdx
@@ -44,7 +44,7 @@ First, check out [Github issues](https://github.com/minaprotocol/mina/issues) to
 
 #### How can I report other issues / get in touch with the development team?
 
-- The Mina community's live discussion channel is the [Discord server](https://bit.ly/MinaDiscord)
+- The Mina community's live discussion takes place is the [Mina Protocol Discord](https://discord.gg/minaprotocol)
 - You can also create Github issues: https://github.com/minaprotocol/mina/issues
 - If you need to get in touch, you can submit a ticket via the [Mina Support chat](https://support.minaprotocol.com/).
 

--- a/docs/node-operators/foundation-delegation-program.mdx
+++ b/docs/node-operators/foundation-delegation-program.mdx
@@ -28,7 +28,7 @@ The current sidecar tracking system is being phased out to be replaced by the SN
 - [Instructions for the sidecar tracking system](/node-operators/bp-sidecar)
 - [Instructions for the SNARK-work-based uptime system](/node-operators/uptime-tracking-system)
 
-Please follow the latest updates and post questions in the [#delegation-program channel](https://discord.gg/ywDzwmGABT) on Discord.
+Please follow the latest updates and post questions in the [the [#delegation-program](https://discord.com/channels/484437221055922177/808895957978447882) channel on Mina Protocol Discord.
 
 :::
 
@@ -234,4 +234,6 @@ If the Foundation share is 2 million MINA and the total stake is 3 million MINA,
 - [Delegation Program Tiebreak System](/node-operators/delegation-tiebreak)
 - [Mina Docs: SNARK-based Uptime System](/node-operators/uptime-system)
 
-#### Need any help? Post your questions in the [#Delegation-Program](https://discord.gg/ywDzwmGABT) channel on Discord.
+#### Need any help? 
+
+Post your questions in the the [#delegation-program](https://discord.com/channels/484437221055922177/808895957978447882) channel on Mina Protocol Discord.

--- a/docs/node-operators/troubleshooting.mdx
+++ b/docs/node-operators/troubleshooting.mdx
@@ -108,7 +108,7 @@ Yes. Set the `MINA_PRIVKEY_PASS` environment variable to be your password.
 
 ### I am trying to install on Ubuntu 20.04 / Debian 10 and get dependency errors?
 
-See this [guide on our Discord](https://discordapp.com/channels/484437221055922177/583400552487059546/822269019687354418) to manually resolve the required dependencies. Alternatively, use a supported OS (Ubuntu 18.04/Debian 9) or use Docker.
+See this [guide for ubuntu 20.04](https://discordapp.com/channels/484437221055922177/583400552487059546/822269019687354418) on Mina Protocol Discord to manually resolve the required dependencies. Alternatively, use a supported OS (Ubuntu 18.04/Debian 9) or use Docker.
 
 ## Syncing a node
 

--- a/docs/node-operators/uptime-tracking-system.mdx
+++ b/docs/node-operators/uptime-tracking-system.mdx
@@ -29,7 +29,7 @@ The current sidecar tracking system is being phased out to be replaced by the SN
 - [Instructions for the sidecar tracking system](/node-operators/bp-sidecar)
 - [Instructions for the SNARK-work-based uptime system](/node-operators/uptime-system)
 
-Please follow the latest updates and post questions in the [#delegation-program channel](https://discord.gg/ywDzwmGABT) on Discord.
+Please follow the latest updates and post questions in the [#delegation-program](https://discord.com/channels/484437221055922177/808895957978447882) channel on Mina Protocol Discord.
 
 :::
 

--- a/docs/participate/careers.mdx
+++ b/docs/participate/careers.mdx
@@ -4,11 +4,16 @@ title: Careers
 
 # Careers
 
-If you’re looking for another way to get involved with Mina, consider exploring the following career opportunities at Mina Foundation and Mina ecosystem partners.
+If you're looking for another way to get involved with Mina, consider exploring the following career opportunities at Mina Foundation and Mina ecosystem partners.
 
 
 ### Mina Foundation
-[Mina Foundation’s Careers Page](https://mina-foundation.breezy.hr/)
+[Mina Foundation Careers Page](https://mina-foundation.breezy.hr/)
 
 ### Mina Ecosystem Partners
-[O(1) Labs’ Careers Page](https://boards.greenhouse.io/o1labs)
+
+- O(1) Labs [Careers](https://boards.greenhouse.io/o1labs) - Incubators of the Mina Protocol
+- =nil; Foundation [Careers](https://nil.foundation/careers/) - Creators of the zkBridge bridge from Mina to Ethereum
+- Viable Systems [Careers](https://www.viablesystems.io/rust-jobs) - Tools to help improve the performance of the Mina nodes and overall network
+
+Are you a Mina ecosystem partner? Select __EDIT THIS PAGE__ at the top of this page to submit a pull request to add your company blog. Thank you for helping grow the Mina ecosystem.

--- a/docs/participate/online-communities.mdx
+++ b/docs/participate/online-communities.mdx
@@ -45,6 +45,6 @@ The Mina community and its members are the core of Mina's global, decentralized 
 
 - O(1) Labs [Blog](https://blog.o1labs.org/) - Incubators of the Mina Protocol 
 - =nil; Foundation [Blog](https://blog.nil.foundation/tag/mina/) - Creators of the zkBridge bridge from Mina to Ethereum
-- Viable Systems [OpenMina Blog](https://medium.com/openmina) and [CEO Juraj Selep Blog](https://medium.com/@jurajselep) - Tools to help improve the performance of the Mina nodes and overall network
+- Viable Systems [OpenMina Blog](https://medium.com/openmina) - Tools to help improve the performance of the Mina nodes and overall network
 
 Are you a Mina ecosystem partner? Select __EDIT THIS PAGE__ at the top of this page to submit a pull request to add your company blog. Thank you for helping grow the Mina ecosystem.

--- a/docs/participate/online-communities.mdx
+++ b/docs/participate/online-communities.mdx
@@ -43,8 +43,8 @@ The Mina community and its members are the core of Mina's global, decentralized 
 
 ## Ecosystem Partners
 
-- [O(1) Labs Blog](https://blog.o1labs.org/) - Incubators of the Mina Protocol 
-- [=nil; Foundation Blog](https://blog.nil.foundation/tag/mina/) - Creators of the zkBridge bridge from Mina to Ethereum
-- [Viable Systems' OpenMina Blog](https://medium.com/openmina) - Tools to help improve the performance of the Mina nodes and overall network
+- O(1) Labs [Blog](https://blog.o1labs.org/) - Incubators of the Mina Protocol 
+- =nil; Foundation [Blog](https://blog.nil.foundation/tag/mina/) - Creators of the zkBridge bridge from Mina to Ethereum
+- Viable Systems [OpenMina Blog](https://medium.com/openmina) - Tools to help improve the performance of the Mina nodes and overall network
 
-Are you a Mina ecosystem partner? Select **EDIT THIS PAGE** at the top of this page to submit a pull request to add your company blog. Thank you for helping grow the Mina ecosystem.
+Are you a Mina ecosystem partner? Select __EDIT THIS PAGE__ at the top of this page to submit a pull request to add your company blog. Thank you for helping grow the Mina ecosystem.

--- a/docs/participate/online-communities.mdx
+++ b/docs/participate/online-communities.mdx
@@ -41,7 +41,7 @@ The [Mina Community Blog](https://minafoundation.notion.site/minafoundation/Mina
 
 The Mina community and its members are the core of Mina's global, decentralized network. You can be an active contributor to collective brilliance. For inspiration and steps on how to contribute to the experimental community blog, see [Open Call for Mina Community Creators](https://minaprotocol.com/blog/mina-community-blog).
 
-## Ecosystem Partners
+## Mina Ecosystem Partners
 
 - O(1) Labs [Blog](https://blog.o1labs.org/) - Incubators of the Mina Protocol 
 - =nil; Foundation [Blog](https://blog.nil.foundation/tag/mina/) - Creators of the zkBridge bridge from Mina to Ethereum

--- a/docs/participate/online-communities.mdx
+++ b/docs/participate/online-communities.mdx
@@ -45,6 +45,6 @@ The Mina community and its members are the core of Mina's global, decentralized 
 
 - O(1) Labs [Blog](https://blog.o1labs.org/) - Incubators of the Mina Protocol 
 - =nil; Foundation [Blog](https://blog.nil.foundation/tag/mina/) - Creators of the zkBridge bridge from Mina to Ethereum
-- Viable Systems [OpenMina Blog](https://medium.com/openmina) - Tools to help improve the performance of the Mina nodes and overall network
+- Viable Systems [OpenMina Blog](https://medium.com/openmina) and [CEO Juraj Selep Blog](https://medium.com/@jurajselep) - Tools to help improve the performance of the Mina nodes and overall network
 
 Are you a Mina ecosystem partner? Select __EDIT THIS PAGE__ at the top of this page to submit a pull request to add your company blog. Thank you for helping grow the Mina ecosystem.

--- a/docs/using-mina/ledger-hardware-wallet.mdx
+++ b/docs/using-mina/ledger-hardware-wallet.mdx
@@ -65,4 +65,4 @@ Congrats! Now that you have installed Mina’s Ledger app, you can start using y
 - [Aurowallet.com](https://www.aurowallet.com/)
 - [Clor.io](https://clor.io/)
 
-If you need help or have any questions about Ledger, join the **#ledger-hardware** channel on [Mina Protocol Discord](https://discord.gg/minaprotocol).
+If you need help or have questions about Ledger, join the [#ledger-hardware](https://discord.com/channels/484437221055922177/733755408161833040) channel on Mina Protocol Discord.


### PR DESCRIPTION
This PR does a few things:
- fixes all of the Discord channel links that I missed earlier (oof) 
- standardizes the way we mention Mina Ecosystem Partners
- moves the company name outside of the descriptive link text (avoid the possessive of a company name to retain strong branding)
- tests using double underscores to bold text:

`Are you a Mina ecosystem partner? Select __EDIT THIS PAGE__ at the top of this page`

The double asterisk Markdown syntax or the double underscore syntax for bold doesn't seem to work for all capital text, happens infrequently, but it's not bolding here (not a big issue, imo) 
<img width="804" alt="image" src="https://user-images.githubusercontent.com/10067215/227524275-91ace0c8-55f3-4975-9c73-56bae895684a.png">
