### PR TITLE
Added descriptive links [Welcome & MINA sections]

### DIFF
--- a/docs/about-mina/consensus.mdx
+++ b/docs/about-mina/consensus.mdx
@@ -6,7 +6,7 @@ title: Consensus
 
 Mina Protocol uses a proof-of-stake consensus mechanism called **Ouroboros Samasika**. 
 
-Consensus is the process by which the network determines which information will be retained in the blockchain. You can read about the difference between proof of stake (PoS) vs proof of work (PoW) consensus mechanisms in this blog post <a href="https://minaprotocol.com/blog/proof-of-work-vs-proof-of-stake">here</a>.
+Consensus is the process by which the network determines which information will be retained in the blockchain. You can read about the difference between <a href="https://minaprotocol.com/blog/proof-of-work-vs-proof-of-stake"> proof of stake (PoS) vs proof of work (PoW)</a> consensus mechanisms.
 
 Learn more about how Ouroboros Samasika works in this video, below:
 
@@ -19,4 +19,4 @@ Based on Cardano’s PoS Ouroboros, Ouroboros Samisika is a secure PoS protocol 
 - **No staking minimum** — You can produce blocks and receive block rewards based on your % of the MINA staked on the network. Any user with any amount of MINA can receive these rewards.
 - **No slashing** — the protocol does not need explicit slashing, since the protocol already enforces the required level of correctness.
 
-You can also learn how Ouroboros Samasika upholds Mina’s goals of decentralization <a href="https://minaprotocol.com/blog/how-ouroboros-samasika-upholds-minas-goals-of-decentralization">here</a>.
+Learn about <a href="https://minaprotocol.com/blog/how-ouroboros-samasika-upholds-minas-goals-of-decentralization"> how Ouroboros Samasika upholds Mina’s goals of decentralization</a>.

--- a/docs/using-mina/how-to-delegate.mdx
+++ b/docs/using-mina/how-to-delegate.mdx
@@ -59,7 +59,7 @@ Here’s how to delegate MINA within common wallets:
 </center>
 <br></br>
 
-- [**Ledger Hardware Wallet**](https://www.ledger.com/mina-wallet) - Follow the instructions on creating a Ledger Mina account via Auro Wallet [here](https://support.ledger.com/hc/en-us/articles/5458493215901-Creating-a-Ledger-MINA-account-via-Auro-Wallet?docs=true), then see the instructions for staking MINA on Auro wallet above.
+- [**Ledger Hardware Wallet**](https://www.ledger.com/mina-wallet) - Follow the [instructions on creating a Ledger Mina account via Auro Wallet](https://support.ledger.com/hc/en-us/articles/5458493215901-Creating-a-Ledger-MINA-account-via-Auro-Wallet?docs=true), then see the instructions for staking MINA on Auro wallet above.
 
 :::note
 

--- a/docs/using-mina/how-to-send-and-receive.mdx
+++ b/docs/using-mina/how-to-send-and-receive.mdx
@@ -24,7 +24,7 @@ Here’s how to find your address within common wallets:
 - [**Auro**](https://www.aurowallet.com) - Open the wallet, tap “*Receive*”, and tap “*Copy*” to share your address or QR code representing this address.
 - [**Clorio Wallet**](https://clor.io) - Open the wallet and tap <img src="/img/Copy_icon.png" alt="Copy icon on Clor.io" width="3%"/> at the top to copy your address.
 - [**Staking Power**](https://www.staking-power.com) - Open the wallet, tap “Receive”, and tap <img src="/img/Copy_icon_2.png" alt="Copy icon on Staking Power" width="3%"/> or “*Share*” to copy your address or QR code representing this address.
-- [**Ledger Hardware Wallet**](https://www.ledger.com/mina-wallet) - Follow the instructions on creating a Ledger Mina account via Auro Wallet [here](https://support.ledger.com/hc/en-us/articles/5458493215901-Creating-a-Ledger-MINA-account-via-Auro-Wallet?docs=true), then see the instructions for receiving MINA on Auro wallet above.
+- [**Ledger Hardware Wallet**](https://www.ledger.com/mina-wallet) - Follow the [instructions on creating a Ledger Mina account via Auro Wallet](https://support.ledger.com/hc/en-us/articles/5458493215901-Creating-a-Ledger-MINA-account-via-Auro-Wallet?docs=true), then see the instructions for receiving MINA on Auro wallet above.
 
 <br></br>
 <center>
@@ -50,7 +50,7 @@ When sending MINA, always double check that you have the correct Mina address fo
 - [**Auro**](https://www.aurowallet.com) - Open the wallet, tap “*Send*”, enter in the address, amount, and fee, and tap “*Next*” then “*Confirm*”.
 - [**Clorio Wallet**](https://clor.io) - Open the wallet, tap “*Send TX*”, and enter in the address, memo, amount, and fee, tap “*Preview*”, and enter in the nonce then tap “*Confirm*”.
 - [**Staking Power**](https://www.staking-power.com) - Open wallet, tap “*Send*”, enter in the address and memo (optional), tap “*Continue*”, enter in the amount, tap “*Continue*”, and “*Confirm*”.
-- [**Ledger Hardware Wallet**](https://www.ledger.com/mina-wallet) - Follow the instructions on creating a Ledger Mina account via Auro Wallet [here](https://support.ledger.com/hc/en-us/articles/5458493215901-Creating-a-Ledger-MINA-account-via-Auro-Wallet?docs=true), then see the instructions for sending MINA on Auro wallet above.
+- [**Ledger Hardware Wallet**](https://www.ledger.com/mina-wallet) - Follow the [instructions on creating a Ledger Mina account via Auro Wallet](https://support.ledger.com/hc/en-us/articles/5458493215901-Creating-a-Ledger-MINA-account-via-Auro-Wallet?docs=true), then see the instructions for sending MINA on Auro wallet above.
 
 <br></br>
 <center>

--- a/docs/using-mina/install-a-wallet.mdx
+++ b/docs/using-mina/install-a-wallet.mdx
@@ -15,7 +15,7 @@ for Chrome supports interactions with zkApps.
 - [Auro Wallet (Chrome, Firefox, iOS, & Android)](https://www.aurowallet.com)
 - [Clorio Wallet (Windows, MacOS, Linux, & online)](https://clor.io)
 - [Staking Power (iOS & Android)](https://www.staking-power.com)
-- [Ledger Hardware Wallet](https://www.ledger.com/mina-wallet) (see instructions [here](../using-mina/ledger-hardware-wallet))
+- [Ledger Hardware Wallet](https://www.ledger.com/mina-wallet) (see [instructions](../using-mina/ledger-hardware-wallet))
 
 :::note
 

--- a/src/components/features/HomepageFeatures.tsx
+++ b/src/components/features/HomepageFeatures.tsx
@@ -96,7 +96,7 @@ const FeatureList: FeatureItem[] = [
   {
     title: "Participate",
     image: "/svg/homepage/participate.svg",
-    buttonText: "Learn More",
+    buttonText: "Online Communities",
     buttonLink: "/participate/online-communities",
     description: (
       <>


### PR DESCRIPTION
Contributes to o1-labs/docs2#292

Changed non-descriptive links (eg. `click here`) in the Welcome and Mina sections to be more descriptive. Updated the following sections:
- Welcome page
- Consensus page under About Mina
- Install a wallet page under Using Mina
- How to Send & Receive page under Using Mina
- How to Delegate page under Using Mina