### PR TITLE
docs: add clarity to core library references in Node Developers > Codebase Overview

### DIFF
--- a/docs/node-developers/codebase-overview.mdx
+++ b/docs/node-developers/codebase-overview.mdx
@@ -31,7 +31,7 @@ For the linking step, `dune` uses `ldd` under the hood. You can also use things 
 
 ## Open-source Library Documentation
 
-There are multiple libraries for OCaml. One challenge with learning OCaml is locating and reading documentation for the various libraries. In particular, the `Core` library has the following structure:
+There are multiple libraries for OCaml. One challenge with learning OCaml is locating and reading documentation for the various libraries. For example, the Jane Street `Core` library has the following structure:
 
 ```
               Base
@@ -41,11 +41,11 @@ There are multiple libraries for OCaml. One challenge with learning OCaml is loc
     Unix  <-  Core  ->       Async
 ```
 
-In general, the source code of an installed library is not available so to find the documentation.
+In general, the source code of an installed library is not available, so follow these tips to find the documentation.
 
-To review the docs for Core, a popular alternative to the OCaml standard library, go to the [standard library overlay](https://github.com/janestreet/core) codebase on GitHub and then locate the correct documentation. If you don't see the module you're looking for, go to `Core_kernel`. If that fails, then look for `Base`. To use the find capability in GitHub, expand the sections.
+To review the docs for Core, a standard library overlay. Core is a popular alternative to the OCaml standard library. First, go to the [Core](https://github.com/janestreet/core) codebase on GitHub and then locate the correct documentation. If you don't see the module you're looking for, go to next to `Core_kernel`. If that fails, then look for `Base`. To use the find capability in GitHub, expand the sections.
 
-The [Core library documentation](https://v2.ocaml.org/manual/core.html) is published in HTML. However, you can use the Merlin editor service that provides modern IDE features for OCaml. Merlin provides type hints and code navigation, like Go To Definition. Note that Merlin works only if your code compiles. 
+Most documentation is published in HTML. However, you can use the an IDE to find and review code and documentation, like the Merlin editor service that provides modern IDE features for OCaml. Merlin provides type hints and code navigation, like Go To Definition. Note that Merlin works only if your code compiles. 
 
 OPAM, the source-based package manager for OCaml, usually ships documentation with libraries that you can access using Merlin.
 

--- a/docs/node-developers/codebase-overview.mdx
+++ b/docs/node-developers/codebase-overview.mdx
@@ -29,9 +29,9 @@ Interface files in OCaml with the `.mli` extension contain type signatures and s
 
 For the linking step, `dune` uses `ldd` under the hood. You can also use things like `-O3` for optimization. For debugging, you can use `gdb`.
 
-## Documentation
+## Open-source Library Documentation
 
-One challenge with learning OCaml is locating and reading documentation for libraries. In particular, the `Core` library has the following structure:
+There are multiple libraries for OCaml. One challenge with learning OCaml is locating and reading documentation for the various libraries. In particular, the `Core` library has the following structure:
 
 ```
               Base
@@ -41,7 +41,9 @@ One challenge with learning OCaml is locating and reading documentation for libr
     Unix  <-  Core  ->       Async
 ```
 
-There are multiple sources for OCaml Core library documentation. In general, the source code of an installed library is not available so to find the  documentation, first go to the codebase on GitHub and then locate the correct documentation. If you don't see the module you're looking for, go to `Core_kernel`. If that fails, then look for `Base`. To use the find capability in GitHub, expand the sections.
+In general, the source code of an installed library is not available so to find the documentation.
+
+To review the docs for Core, a popular alternative to the OCaml standard library, go to the [standard library overlay](https://github.com/janestreet/core) codebase on GitHub and then locate the correct documentation. If you don't see the module you're looking for, go to `Core_kernel`. If that fails, then look for `Base`. To use the find capability in GitHub, expand the sections.
 
 The [Core library documentation](https://v2.ocaml.org/manual/core.html) is published in HTML. However, you can use the Merlin editor service that provides modern IDE features for OCaml. Merlin provides type hints and code navigation, like Go To Definition. Note that Merlin works only if your code compiles. 
 


### PR DESCRIPTION
The core library that is referenced in Node Developers > Codebase Overview > [Documentation](https://docs.minaprotocol.com/node-developers/codebase-overview#documentation) is vague.

Updated Codebase Overview > [Documentation](https://docs2-git-core-library-fix-minadocs.vercel.app/node-developers/codebase-overview#open-source-library-documentation ) 

This PR removes ambiguous references to "the core library"
This issue is follow-up work required on the core library references for questions that came up in a non-technical docs PR [](https://github.com/o1-labs/docs2/pull/332#discussion_r1152139248)

for https://github.com/o1-labs/docs2/issues/339 