### PR TITLE
Adv SnarkyJS edits, timeless docs, editorial grooming 

### DIFF
--- a/docs/zkapps/advanced-snarkyjs/custom-tokens.mdx
+++ b/docs/zkapps/advanced-snarkyjs/custom-tokens.mdx
@@ -17,7 +17,7 @@ This section shows you how to perform common token operations, such as minting, 
 
 Minting generates new tokens whereby the zkApp updates the balance of an account by adding the newly created tokens to it. Minted tokens can be sent to any existing account in the ledger.
 
-To mint new tokens using a zkApp, we access the `this.token` property on our `SmartContract` class. See the example below of how a zkApp can mint tokens to another account:
+To mint new tokens using a zkApp, this example of the `this.token` property on the `SmartContract` class to show how a zkApp can mint tokens to another account:
 
 ```ts
 class MintExample extends SmartContract {
@@ -31,11 +31,11 @@ class MintExample extends SmartContract {
 }
 ```
 
-In the snippet above, we define a smart contract called `MintExample` with a method called `mintNewTokens`. Using `this.token`, the smart contract specifies the address to mint new tokens for as well as the amount.
+The example snippet defines a smart contract called `MintExample` with a method called `mintNewTokens`. Using `this.token`, the smart contract specifies the address to mint new tokens for as well as the amount.
 
 ## Burning
 
-Burning tokens is the opposite of minting. Burning tokens deducts the balance of a certain address by the specified amount. See the example below of how a zkApp can burn tokens of another account:
+Burning tokens is the opposite of minting. Burning tokens deducts the balance of a certain address by the specified amount. The following examples show how a zkApp can burn tokens of another account:
 
 ```ts
 class BurnExample extends SmartContract {
@@ -49,7 +49,7 @@ class BurnExample extends SmartContract {
 }
 ```
 
-In the snippet above, we define a smart contract called `BurnExample` with a method called `burnTokens`. Similar to minting, we use the `this.token` property to call the `burn` method. This specifies the amount of tokens to burn for the specified address.
+This example snippet defines a smart contract called `BurnExample` with a method called `burnTokens`. Similar to minting, the `this.token` property calls the `burn` method. This specifies the amount of tokens to burn for the specified address.
 
 :::note
 
@@ -59,7 +59,7 @@ A zkApp cannot burn more tokens than the specified account has. If there is such
 
 ## Sending
 
-To send a custom token, use the `send()` method available on `this.token`. See the example below of how a zkApp can approve sending tokens between two accounts:
+To send a custom token, use the `send()` method available on `this.token`. This example shows how a zkApp can approve sending tokens between two accounts:
 
 ```ts
 class SendExample extends SmartContract {
@@ -78,21 +78,21 @@ class SendExample extends SmartContract {
 }
 ```
 
-In the snippet above, we define a smart contract called `SendExample` with a method called `sendTokens`. Then, in the same fashion, as minting and burning, we use the `this.token` property to call the `send` method.
+This example snippet defines a smart contract called `SendExample` with a method called `sendTokens`. Then, in the same fashion, as minting and burning, the `this.token` property calls the `send` method.
 
-For a more comprehensive example of how to use custom tokens with a zkApp, please see this [custom token example](https://github.com/o1-labs/snarkyjs/blob/main/src/lib/token.test.ts)
+For a more comprehensive example of how to use custom tokens with a zkApp, see this [custom token example](https://github.com/o1-labs/snarkyjs/blob/main/src/lib/token.test.ts).
 
-## Authorization
+## Proof Authorization
 
 When a zkApp interacts with a custom token that it did not originally create, the calling zkApp must get authorization from the [token owner](/zkapps/advanced-snarkyjs/custom-tokens#token-owner).
 
-There are two ways for a token owner to approve a transaction, one being a **signature** and the other being a **proof**.
+There are two ways for a token owner to approve a transaction: a **signature** and a **proof**.
 
 ### Signature Authorization
 
 Signature authorization is the simplest way for a token owner to approve a custom token transfer; however, it is the least flexible. If two separate accounts want to trade a specific custom token, the token owner must sign the transaction before the transaction can be broadcast.
 
-Token zkApps must provide a `send()` method, like the one described above. By providing a `send()` method, the token zkApp can approve a transaction between two seperate accounts and sign it as the token owner.
+Token zkApps must provide a `send()` method. By providing a `send()` method, the token zkApp can approve a transaction between two seperate accounts and sign it as the token owner.
 
 ```ts
 let tx = await Mina.transaction(feePayerKey, () => {
@@ -102,7 +102,7 @@ let tx = await Mina.transaction(feePayerKey, () => {
 await tx.send();
 ```
 
-This sort of authorization is simple and easy to use but it is not flexible. If two accounts wanted to trade a custom token, the token owner must sign the transaction before the transaction can be broadcasted. To allow zkApps to get authorization from a token owner without a signature, we can let the token owner approve with a proof.
+This signature authorization is simple and easy to use, but it is not flexible. If two accounts wanted to trade a custom token, the token owner must sign the transaction before the transaction can be broadcasted. To allow zkApps to get authorization from a token owner without a signature, it makes more sense to let the token owner approve with a proof.
 
 ### Proof Authorization
 
@@ -112,7 +112,7 @@ To allow for proof authorization by the token owner, the child zkApp that is req
 
 Token owner contracts can inspect the updates that a child zkApp wants to make by using a combination of `Experimental.Callback` and `this.approve`. The first thing that a token contract must do is generate the account updates that a child zkApp wants to make. The child zkApp wraps a function around `Experimental.Callback` which contains the changes it wants to make. The token owner can then execute that function with `this.approve` and inspect the changes that the child zkApp wants to make.
 
-Here are examples of how a zkApp can approve a transaction between two accounts. The first example shows how to approve a transaction by calling a specified `SmartContract` method.
+This example shows how a zkApp can approve a transaction between two accounts by calling a specified `SmartContract` method:
 
 ```ts
 /**
@@ -185,21 +185,21 @@ await tx.send();
 
 The result of this example is `zkAppB` sending tokens to `account1Address` and `account1Address` receiving tokens from `zkAppB`. The transaction is approved by the token owner without the token owner having to sign the transaction.
 
-For more examples of how to approve a transaction with a zkApp, please see this [authorization example](https://github.com/o1-labs/snarkyjs/blob/main/src/examples/zkapps/token_with_proofs.ts).
+For another example of how to approve a transaction with a zkApp, see this [authorization example](https://github.com/o1-labs/snarkyjs/blob/main/src/examples/zkapps/token_with_proofs.ts).
 
 ## Understanding Important Terms
 
-If you are writing your zkApp to interact with custom tokens, you should understand the following essential terms:
+If you are writing your zkApp to interact with custom tokens, be sure you understand the following essential terms:
 
 ### Token Id
 
-Token Ids are unique identifiers that are used to distinguish between different types of custom tokens. Custom token identifiers are globally unique across the entire network, meaning no two custom tokens can have the same token id.
+Token ids are unique identifiers that are used to distinguish between different types of custom tokens. Custom token identifiers are globally unique across the entire network. 
 
-Token Ids themeselves are derived from a zkApp. To check the token id of a zkApp, you can use the `this.token.id` property.
+Token ids are derived from a zkApp. To check the token id of a zkApp, use the `this.token.id` property.
 
 ### Token Accounts
 
-Token accounts are like regular accounts, but they hold a balance of a specific custom token instead of MINA. A token account is created from an existing account but is instead specified by a public key _and_ token id.
+Token accounts are like regular accounts, but they hold a balance of a specific custom token instead of MINA. A token account is created from an existing account but is specified by a public key _and_ a token id.
 If an existing account receives a transaction that is specified by a custom token, a token account for that public key and token id is created if it does not exist.
 
 Token accounts are specific for each type of custom token, meaning that a single public key can have many different types of token accounts.
@@ -218,6 +218,6 @@ Aside from sending custom tokens, custom tokens can be minted and burned by a **
 
 A token owner is an account that creates, facilitates, and governs how a custom token is to be used. Concretely, the token owner is the account that created the custom token and is the only account that can mint and burn tokens.
 
-In addition to being the only account that can mint and burn tokens, the token owner is also the only account that can approve sending tokens between two accounts, by either using signature authorization or proof authorization.
+In addition to being the only account that can mint and burn tokens, the token owner is the only account that can approve sending tokens between two accounts.
 If two accounts want to send tokens to each other, the token owner must approve the transaction. The token owner generates the changes the two accounts want to make and can then make assertions about those changes.
 The token owner can approve the transaction with a signature or proof.

--- a/docs/zkapps/advanced-snarkyjs/custom-tokens.mdx
+++ b/docs/zkapps/advanced-snarkyjs/custom-tokens.mdx
@@ -17,7 +17,7 @@ This section shows you how to perform common token operations, such as minting, 
 
 Minting generates new tokens whereby the zkApp updates the balance of an account by adding the newly created tokens to it. Minted tokens can be sent to any existing account in the ledger.
 
-To mint new tokens using a zkApp, this example of the `this.token` property on the `SmartContract` class to show how a zkApp can mint tokens to another account:
+To mint new tokens using a zkApp, this example of the `this.token` property on the `SmartContract` class shows how a zkApp can mint tokens to another account:
 
 ```ts
 class MintExample extends SmartContract {
@@ -31,7 +31,7 @@ class MintExample extends SmartContract {
 }
 ```
 
-The example snippet defines a smart contract called `MintExample` with a method called `mintNewTokens`. Using `this.token`, the smart contract specifies the address to mint new tokens for as well as the amount.
+This example snippet defines a smart contract called `MintExample` with a method called `mintNewTokens`. Using `this.token`, the smart contract specifies the address to mint new tokens for as well as the amount.
 
 ## Burning
 
@@ -92,7 +92,7 @@ There are two ways for a token owner to approve a transaction: a **signature** a
 
 Signature authorization is the simplest way for a token owner to approve a custom token transfer; however, it is the least flexible. If two separate accounts want to trade a specific custom token, the token owner must sign the transaction before the transaction can be broadcast.
 
-Token zkApps must provide a `send()` method. By providing a `send()` method, the token zkApp can approve a transaction between two seperate accounts and sign it as the token owner.
+Token zkApps must provide a `send()` method. By providing a `send()` method, the token zkApp can approve a transaction between two separate accounts and sign it as the token owner. For example:
 
 ```ts
 let tx = await Mina.transaction(feePayerKey, () => {
@@ -185,11 +185,11 @@ await tx.send();
 
 The result of this example is `zkAppB` sending tokens to `account1Address` and `account1Address` receiving tokens from `zkAppB`. The transaction is approved by the token owner without the token owner having to sign the transaction.
 
-For another example of how to approve a transaction with a zkApp, see this [authorization example](https://github.com/o1-labs/snarkyjs/blob/main/src/examples/zkapps/token_with_proofs.ts).
+For another example of how to approve a transaction with a zkApp, see this [authorization example](https://github.com/o1-labs/snarkyjs/blob/main/src/examples/zkapps/token_with_proofs.ts) provided.
 
 ## Understanding Important Terms
 
-If you are writing your zkApp to interact with custom tokens, be sure you understand the following essential terms:
+If your zkApp interacts with custom tokens, be sure you understand the following essential terms:
 
 ### Token Id
 

--- a/docs/zkapps/advanced-snarkyjs/custom-tokens.mdx
+++ b/docs/zkapps/advanced-snarkyjs/custom-tokens.mdx
@@ -78,7 +78,7 @@ class SendExample extends SmartContract {
 }
 ```
 
-This example snippet defines a smart contract called `SendExample` with a method called `sendTokens`. Then, in the same fashion, as minting and burning, the `this.token` property calls the `send` method.
+This example snippet defines a smart contract called `SendExample` with a method called `sendTokens()`. Then, in the same fashion, as minting and burning, the `this.token` property calls the `send()` method.
 
 For a more comprehensive example of how to use custom tokens with a zkApp, see this [custom token example](https://github.com/o1-labs/snarkyjs/blob/main/src/lib/token.test.ts).
 

--- a/docs/zkapps/advanced-snarkyjs/custom-tokens.mdx
+++ b/docs/zkapps/advanced-snarkyjs/custom-tokens.mdx
@@ -49,7 +49,7 @@ class BurnExample extends SmartContract {
 }
 ```
 
-This example snippet defines a smart contract called `BurnExample` with a method called `burnTokens`. Similar to minting, the `this.token` property calls the `burn` method. This specifies the amount of tokens to burn for the specified address.
+This example snippet defines a smart contract called `BurnExample` with a method called `burnTokens`. Similar to minting, the `this.token` property calls the `burn()` method. This specifies the amount of tokens to burn for the specified address.
 
 :::note
 
@@ -86,7 +86,7 @@ For a more comprehensive example of how to use custom tokens with a zkApp, see t
 
 When a zkApp interacts with a custom token that it did not originally create, the calling zkApp must get authorization from the [token owner](/zkapps/advanced-snarkyjs/custom-tokens#token-owner).
 
-There are two ways for a token owner to approve a transaction: a **signature** and a **proof**.
+A token owner can approve a transaction using a **signature** or a **proof**.
 
 ### Signature Authorization
 

--- a/docs/zkapps/advanced-snarkyjs/merkle-tree.mdx
+++ b/docs/zkapps/advanced-snarkyjs/merkle-tree.mdx
@@ -13,31 +13,30 @@ Please note that zkApp programmability is not yet available on Mina Mainnet, but
 
 #### Referencing off-chain data
 
-We already learned that zkApps can only store a small amount of data on-chain, the reason for that is we want Mina to stay succinct and not become bloated.
+zkApps can store only a small amount of data on-chain so that Mina stays succinct and does not become bloated.
 But some zkApps might require you to access more than what you can store on-chain in a zkApp account.
-But how can we achieve that? The answer is a Merkle tree! Merkle trees (or similar structures such as Verkle trees) allow us to _reference_ off-chain data by
-only storing one single hash on-chain!
+But how can you achieve that? The answer is a Merkle tree! Merkle trees (or similar structures such as Verkle trees) allow you to _reference_ off-chain data by storing only a single hash on-chain!
 
 #### How does that work?
 
 Merkle trees are special binary trees in which every leaf (the nodes at the very bottom of the tree!) are cryptographic hashes of the underlying pieces of data and the internal nodes are labelled with the cryptographic hash of the concatenated labels (hashes) of its child nodes.
 
-By following this algorithm to the very top, we end up with one single node (the root node) that stores the root hash of the tree. The root hash is a reference to all pieces of data that were included in the tree's leaves. By doing so, we achieve that we can reference large amounts of data by only using one small hash! Another thing that Merkle trees provide is something called the witness (sometimes also called Merkle proof or Merkle path) - the witness is the path from one specific leaf node to the very top of the tree - to the root! Merkle witnesses are proofs of inclusion exists, they allow us to prove that one specific piece of data(an account in the ledger or the scores on a leaderboard) exists within the entire tree.
+By following this algorithm to the very top, you end up with one single node (the root node) that stores the root hash of the tree. The root hash is a reference to all pieces of data that were included in the tree's leaves so you can reference large amounts of data by using one small hash! Another benefit of Merkle trees provide is something called the witness (sometimes also called Merkle proof or Merkle path). The witness is the path from one specific leaf node to the very top of the tree to the root! Merkle witnesses are proofs of inclusion that prove that one specific piece of data (an account in the ledger or the scores on a leaderboard) exists within the entire tree.
 
-#### How will that be useful for zkApps?
+#### How are Merkle trees useful for zkApps?
 
-We just learned that we can reference large amounts of off-chain data and prove inclusion of very specific parts of that data only with a small hash - the root - and something called a witness.
+You can reference large amounts of off-chain data and prove inclusion of very specific parts of that data with only a small hash - the root - and a witness.
 
-When we want to use Merkle trees and reference off-chain data in our zkApps on Mina, we can simply store the root of the tree on-chain and voilà,
-we now have access to more data off-chain!
+To use Merkle trees and reference off-chain data in your zkApps on Mina, store the root of the tree on-chain and voilà,
+you now have access to more data off-chain!
 
-Let's imagine a zkApp that manages a game with a leaderboard. The zkApp has a method to update the score of a player, if the player guesses a number correctly.
-After a player reaches a threshold score, they can invoke another method to get a reward. Because we want many players to participate in our game,
-we are drastically limited by how much data we can store on-chain - and if we want to have at least 8 or more participants, we run out of on-chain space very fast!
+Imagine a zkApp that manages a game with a leaderboard. The zkApp has a method to update the score of a player if the player guesses a number correctly.
+After a player reaches a threshold score, the player can invoke another method to get a reward. Because you want many players to participate in the game,
+you are drastically limited by how much data can be stored on-chain. Eight or more participants quickly runs out of on-chain space very fast!
 
-A possible solution to that problem is to utilize the power of Merkle trees and store the public keys of each player and their corresponding scores off-chain and only reference it in our smart contract.
+A possible solution to that problem is to use the power of Merkle trees and store the public keys of each player and their corresponding scores off-chain and reference the keys in the smart contract.
 
-Lets look at our data structure first. Imagine wanting to map a player's id to score points, so this:
+Look at the data structure first. Imagine you want to map a player's id to score points, so this:
 
 ```
 
@@ -52,34 +51,33 @@ Lets look at our data structure first. Imagine wanting to map a player's id to s
 
 #### Implementing the smart contract
 
-Now it's time to look at what our leaderboard zkApp might look like. We want to have on-chain state that points to the off-chain Merkle tree - call this variable the `root`.
+Now it's time to look at what a leaderboard zkApp might look like. To have on-chain state that points to the off-chain Merkle tree, call this variable the `root`.
 
 :::info
 
-Sometimes the variable `root` is also called commitment, because we commit to something!
+Sometimes the variable `root` is also called commitment, because it commits to something!
 
 :::
 
-Additionally, we want to store a variable `z` which is the hash of the value a player has to guess: `H(guess) = z`
+Additionally, you want to store a variable `z` that is the hash of the value a player has to guess: `H(guess) = z`
 
 :::info
 
-Guessing a simple hash like in this example can easily be brute forced, especially if the preimage is something simple (like a 5 letter word or a small number with only a few digits).
+Guessing a simple hash like in this example can easily be brute forced, especially if the preimage is something simple (like a 5-letter word or a small number with only a few digits).
 
-Please make sure that your zkApps are always secure, especially when dealing with funds!
+Be sure that your zkApps are always secure, especially when dealing with funds!
 
 :::
 
 The first method allows a player to make a guess, and if the guess is correct, the player gains one point.
-The method takes the players guess and hashes it, it then checks if the hash H(guess) equals the on-chain state z and if that's the case,
-then the player gains one point on the score board.
+The method takes the players guess and hashes it, it then checks if the hash `H(guess)` equals the on-chain state `z` and if that's the case, then the player gains one point on the score board.
 
 A second method is required to take care of the reward. It checks if the players score is over a threshold and pays out a reward if that's the case.
 This method must also verify the Merkle witness and check it if it matches the on-chain stored Merkle root!
 
 :::note
 
-A fully working example, including all the necessary boilerplate code, can be found in the SnarkyJS repository in the examples folder [here](https://github.com/o1-labs/snarkyjs/tree/main/src/examples/zkapps/merkle_tree).
+The `examples` folder in the SnarkyJS repository includes a working [Merkle tree](https://github.com/o1-labs/snarkyjs/tree/main/src/examples/zkapps/merkle_tree) example with all of the required boilerplate code.
 
 :::
 
@@ -146,16 +144,16 @@ class Leaderboard extends SmartContract {
 }
 ```
 
-Merkle trees allow us to easily reference off-chain data by only adding a couple of lines of code.
-However, it is important to mention that the developer of the zkApp must make sure that the Merkle tree that is being referenced on-chain is always in-sync with the actual off-chain data structure.
+Merkle trees allow you to easily reference off-chain data by only adding a couple of lines of code.
+However, it is the responsibility of the developer of the zkApp to make sure that the Merkle tree that is being referenced on-chain is always in sync with the actual off-chain data structure.
 
-You can look at [this example in the SnarkyJS repository](https://github.com/o1-labs/snarkyjs/tree/main/src/examples/zkapps/merkle_tree) to get a better understanding of how you can utilize the power of Merkle trees.
+You can look at [this example in the SnarkyJS repository](https://github.com/o1-labs/snarkyjs/tree/main/src/examples/zkapps/merkle_tree) to get a better understanding of how you can leverage the power of Merkle trees.
 
 :::info
 
-Merkle trees are great for _referencing_ off-chain state. But just referencing our state is not enough - we also need to actually store it somewhere.
+Merkle trees are great for _referencing_ off-chain state. But just referencing our state is not enough - you also need to actually store it somewhere.
 
-Where and how to store the data off-chain storage is left up to the developer. We are  exploring solutions and are very interested to see and hear about approaches from others in the community.
+Where and how to store the data off-chain storage is left up to you, the developer. O(1) Labs is exploring solutions and are very interested to see and hear about approaches from others in the community.
 
 :::
 

--- a/docs/zkapps/advanced-snarkyjs/merkle-tree.mdx
+++ b/docs/zkapps/advanced-snarkyjs/merkle-tree.mdx
@@ -13,7 +13,7 @@ Please note that zkApp programmability is not yet available on Mina Mainnet, but
 
 #### Referencing off-chain data
 
-zkApps can store only a small amount of data on-chain so that Mina stays succinct and does not become bloated.
+zkApp accounts can store only a limited amount of data on chain so that Mina's chain remains succinct and does not become bloated. 
 But some zkApps might require you to access more than what you can store on-chain in a zkApp account.
 But how can you achieve that? The answer is a Merkle tree! Merkle trees (or similar structures such as Verkle trees) allow you to _reference_ off-chain data by storing only a single hash on-chain.
 
@@ -153,7 +153,7 @@ You can look at the [Merkle tree example](https://github.com/o1-labs/snarkyjs/tr
 
 Merkle trees are great for _referencing_ off-chain state. But just referencing the state is not enough - you also need to actually store it somewhere.
 
-Where and how to store the data off-chain storage is left up to you, the developer. O(1) Labs is exploring solutions and are very interested to see and hear about approaches from others in the community.
+Where and how to store the data off-chain storage is left up to you, the developer. We are exploring solutions and are very interested to see and hear about approaches from others in the community.
 
 :::
 

--- a/docs/zkapps/advanced-snarkyjs/merkle-tree.mdx
+++ b/docs/zkapps/advanced-snarkyjs/merkle-tree.mdx
@@ -15,24 +15,24 @@ Please note that zkApp programmability is not yet available on Mina Mainnet, but
 
 zkApps can store only a small amount of data on-chain so that Mina stays succinct and does not become bloated.
 But some zkApps might require you to access more than what you can store on-chain in a zkApp account.
-But how can you achieve that? The answer is a Merkle tree! Merkle trees (or similar structures such as Verkle trees) allow you to _reference_ off-chain data by storing only a single hash on-chain!
+But how can you achieve that? The answer is a Merkle tree! Merkle trees (or similar structures such as Verkle trees) allow you to _reference_ off-chain data by storing only a single hash on-chain.
 
 #### How does that work?
 
 Merkle trees are special binary trees in which every leaf (the nodes at the very bottom of the tree!) are cryptographic hashes of the underlying pieces of data and the internal nodes are labelled with the cryptographic hash of the concatenated labels (hashes) of its child nodes.
 
-By following this algorithm to the very top, you end up with one single node (the root node) that stores the root hash of the tree. The root hash is a reference to all pieces of data that were included in the tree's leaves so you can reference large amounts of data by using one small hash! Another benefit of Merkle trees provide is something called the witness (sometimes also called Merkle proof or Merkle path). The witness is the path from one specific leaf node to the very top of the tree to the root! Merkle witnesses are proofs of inclusion that prove that one specific piece of data (an account in the ledger or the scores on a leaderboard) exists within the entire tree.
+By following this algorithm to the very top, you end up with one single node (the root node) that stores the root hash of the tree. The root hash is a reference to all pieces of data that were included in the tree's leaves so you can reference large amounts of data by using one small hash! Another benefit that Merkle trees provide is something called the witness (sometimes also called Merkle proof or Merkle path). The witness is the path from one specific leaf node to the very top of the tree to the root! Merkle witnesses are proofs of inclusion that prove that one specific piece of data (an account in the ledger or the scores on a leaderboard) exists within the entire tree.
 
 #### How are Merkle trees useful for zkApps?
 
 You can reference large amounts of off-chain data and prove inclusion of very specific parts of that data with only a small hash - the root - and a witness.
 
 To use Merkle trees and reference off-chain data in your zkApps on Mina, store the root of the tree on-chain and voilà,
-you now have access to more data off-chain!
+you now have access to more data off-chain.
 
 Imagine a zkApp that manages a game with a leaderboard. The zkApp has a method to update the score of a player if the player guesses a number correctly.
 After a player reaches a threshold score, the player can invoke another method to get a reward. Because you want many players to participate in the game,
-you are drastically limited by how much data can be stored on-chain. Eight or more participants quickly runs out of on-chain space very fast!
+you are drastically limited by how much data can be stored on-chain. With eight or more participants, you will quickly run out of on-chain space.
 
 A possible solution to that problem is to use the power of Merkle trees and store the public keys of each player and their corresponding scores off-chain and reference the keys in the smart contract.
 
@@ -55,7 +55,7 @@ Now it's time to look at what a leaderboard zkApp might look like. To have on-ch
 
 :::info
 
-Sometimes the variable `root` is also called commitment, because it commits to something!
+Sometimes the variable `root` is also called commitment, because it commits to something.
 
 :::
 
@@ -147,11 +147,11 @@ class Leaderboard extends SmartContract {
 Merkle trees allow you to easily reference off-chain data by only adding a couple of lines of code.
 However, it is the responsibility of the developer of the zkApp to make sure that the Merkle tree that is being referenced on-chain is always in sync with the actual off-chain data structure.
 
-You can look at [this example in the SnarkyJS repository](https://github.com/o1-labs/snarkyjs/tree/main/src/examples/zkapps/merkle_tree) to get a better understanding of how you can leverage the power of Merkle trees.
+You can look at the [Merkle tree example](https://github.com/o1-labs/snarkyjs/tree/main/src/examples/zkapps/merkle_tree)  in the SnarkyJS repository to get a better understanding of how you can leverage the power of Merkle trees.
 
 :::info
 
-Merkle trees are great for _referencing_ off-chain state. But just referencing our state is not enough - you also need to actually store it somewhere.
+Merkle trees are great for _referencing_ off-chain state. But just referencing the state is not enough - you also need to actually store it somewhere.
 
 Where and how to store the data off-chain storage is left up to you, the developer. O(1) Labs is exploring solutions and are very interested to see and hear about approaches from others in the community.
 

--- a/docs/zkapps/advanced-snarkyjs/on-chain-values.mdx
+++ b/docs/zkapps/advanced-snarkyjs/on-chain-values.mdx
@@ -11,20 +11,20 @@ Please note that zkApp programmability is not yet available on Mina Mainnet, but
 
 # On-Chain Values
 
-We already saw how you can access the current [on-chain state](/zkapps/how-to-write-a-zkapp#on-chain-state) of a zkApp account. Similarly, you can access many other on-chain values in a zkApp.
+You can access the current [on-chain state](/zkapps/how-to-write-a-zkapp#on-chain-state) of a zkApp account. Similarly, you can access many other on-chain values in a zkApp.
 
 Just to give you an idea, here are two possible use cases:
 
 - Say you want to let users vote on a proposal, but only within a specific timespan. To do that, you can make your zkApp require that the current timestamp lies in a certain range.
 - In DeFi, you might need to compute amounts relative to a balance. For example, paying a yield of `0.001` times the account balance requires you to get the current on-chain balance.
 
-We group on-chain values in two categories:
+There are two categories of on-chain values:
 
-- **Network**: includes the current timestamp, block height, total Mina in circulation and other network state
-- **Account**: includes fields and properties of the zkApp account, such as balance, nonce and delegate
+- **Network**: includes the current timestamp, block height, total Mina in circulation, and other network state
+- **Account**: includes fields and properties of the zkApp account, such as balance, nonce, and delegate
 
-The subfields of both categories are are accessible on `this.network` and `this.account` in your smart contract.
-For example, the timestamp is on `this.network.timestamp`, and it has four methods on it:
+The subfields of both categories are accessible on `this.network` and `this.account` in a smart contract.
+For example, the timestamp on `this.network.timestamp` has four methods:
 
 ```ts
 this.network.timestamp.get();
@@ -32,11 +32,11 @@ this.network.timestamp.assertEquals(timestamp);
 this.network.timestamp.assertBetween(lower, upper);
 ```
 
-With two of them you are already familiar: On-chain state has the same `get()` and `assertEquals()` methods. `assertBetween()` gives you even more power: it allows you to make assert that the timestamp is between `lower` and `upper` (inclusive).
+The familiar on-chain state has the same `get()` and `assertEquals()` methods. The `assertBetween()` method has even more power: it allows you to make assert that the timestamp is between `lower` and `upper` (inclusive).
 
 ### Example: restricting timestamps
 
-Let's see how `assertBetween()` can be used in the voting example mentioned earlier. Assume we want to allow voting throughout September 2022. Timestamps are represented as a `UInt64` in milliseconds since the [UNIX epoch](https://en.wikipedia.org/wiki/Unix_time). We can use the JS `Date` object to easily convert to this representation. In the simplest case, our zkApp could just hard-code the dates:
+You can see how to use the `assertBetween()` method in the voting example that was mentioned earlier. Assume you want to allow voting throughout September 2022. Timestamps are represented as a `UInt64` in milliseconds since the [UNIX epoch](https://en.wikipedia.org/wiki/Unix_time). You can use the JS `Date` object to easily convert to this representation. In the simplest case, a zkApp could just hard-code the dates:
 
 ```ts
 const startDate = UInt64.from(Date.UTC(2022, 9, 1));
@@ -52,9 +52,9 @@ class VotingApp extends SmartContract {
 }
 ```
 
-A more refined example could store the current start date in an on-chain state variable, which can be reset by some process which is also encoded by the zkApp.
+A more refined example could store the current start date in an on-chain state variable, which can then be reset by some process which is also encoded by the zkApp.
 
-In addition to using a predefined range, you can also construct a range that depends on another variable, such as the current time. For example, a DEX with an order book could support orders that expire after an hour. So, the range should be `[now, now + 1h]`, such as below:
+In addition to using a predefined range, you can also construct a range that depends on another variable, such as the current time. For example, a DEX with an order book could support orders that expire after an hour. In this case, the range would be `[now, now + 1h]`:
 
 ```ts
 const now = this.network.timestamp.get();
@@ -63,12 +63,12 @@ this.network.timestamp.assertBetween(now, now.add(60 * 60 * 1000));
 
 ### Network reference
 
-For completeness, below is the full list of network states you can use and make assertions about in your zkApp.
+For completeness, here is the full list of network states you can use and make assertions about in your zkApp.
 
-All of those fields have a `get()` and an `assertEquals()` method, and the subset that represent
-"ordered values" (those that are `UInt32` or `UInt64`), also have `assertBetween()`.
+All of these fields have a `get()` and an `assertEquals()` method. The subset that represents
+"ordered values" (those that are `UInt32` or `UInt64`) also have `assertBetween()`.
 
-Of course, there's no need to remember this -- just type `this.network.` and let IntelliSense guide you!
+Of course, there's no need to remember this -- just type `this.network.` and let intelligent code complete guide you!
 
 ```ts
 // current UNIX time in milliseconds, as measured by the block producer
@@ -124,7 +124,7 @@ this.account.receiptChainHash.get(): Field;
 ### Bailing out
 
 In some rare cases, you might, for whatever reason, want to `get()` an on-chain value _without_ constraining it to any value.
-If you try this, you'll see that SnarkyJS throws a helpful error reminding you to use `assertEquals()` and `asserBetween()`.
+If you try this, SnarkyJS throws a helpful error reminding you to use `assertEquals()` and `asserBetween()`.
 As an escape hatch, if you want to `get()` a value and are really sure you want to not constrain the on-chain value in any way,
 there's `assertNothing()` on all of these fields (including on-chain state). **Use at your own risk.**
 
@@ -153,7 +153,7 @@ And here's how you can set the delegate (the account that your smart contract de
 this.account.delegate.set(delegatePublicKey);
 ```
 
-The fields that you can set are not the same as those that you can make assertions about. This is the full list that have a `.set()`, with short descriptions:
+The fields that you can set are not the same as the fields that you can make assertions about. Here is the full list of fields that have a `.set()`:
 
 ```ts
 // the account that this account delegates its MINA stake to
@@ -170,10 +170,10 @@ this.account.tokenSymbol.set(value: string);
 this.account.timing.set(value: Timing);
 ```
 
-### Accessing other accounts than the zkApp's
+### Accessing other accounts than the zkApp's account
 
-The API described in this section (get / set / assertEquals / ...) can not only be used to access the zkApp account itself, but also any other account.
-To do so, just create an [account update](/zkapps/how-to-write-a-zkapp#transactions-and-account-updates) — you'll find the same `account` / `network` fields API on it:
+The API described in this section (get / set / assertEquals / ...) can be used to access the zkApp account itself, but also any other account.
+To do so, create an [account update](/zkapps/how-to-write-a-zkapp#transactions-and-account-updates) to find the same `account` / `network` fields API:
 
 ```ts
 let accountUpdate = AccountUpdate.create(address);
@@ -191,7 +191,7 @@ accountUpdate.account.permissions.set(permissions);
 
 :::tip
 When setting fields on an account update, you have to make sure that this _same_ account update has the correct authorization to perform those actions.
-For example, to initially set the verification key, the update will likely need a signature from the account owner:
+For example, to initially set the verification key, the update requires a signature from the account owner:
 
 ```ts
 // use createSigned to require a signature

--- a/docs/zkapps/advanced-snarkyjs/on-chain-values.mdx
+++ b/docs/zkapps/advanced-snarkyjs/on-chain-values.mdx
@@ -15,7 +15,7 @@ You can access the current [on-chain state](/zkapps/how-to-write-a-zkapp#on-chai
 
 Just to give you an idea, here are two possible use cases:
 
-- Say you want to let users vote on a proposal, but only within a specific timespan. To do that, you can make your zkApp require that the current timestamp lies in a certain range.
+- You want to let users vote on a proposal, but only within a specific timespan. To restrict the dates, you can make your zkApp require that the current timestamp lies in a certain range.
 - In DeFi, you might need to compute amounts relative to a balance. For example, paying a yield of `0.001` times the account balance requires you to get the current on-chain balance.
 
 There are two categories of on-chain values:
@@ -52,7 +52,7 @@ class VotingApp extends SmartContract {
 }
 ```
 
-A more refined example could store the current start date in an on-chain state variable, which can then be reset by some process which is also encoded by the zkApp.
+A more refined example could store the current start date in an on-chain state variable, which can then be reset by some process that is also encoded by the zkApp.
 
 In addition to using a predefined range, you can also construct a range that depends on another variable, such as the current time. For example, a DEX with an order book could support orders that expire after an hour. In this case, the range would be `[now, now + 1h]`:
 
@@ -102,7 +102,7 @@ this.network.nextEpochData.startCheckpoint.get(): Field;
 
 ### Account reference
 
-Here's the full list of values you can access on the zkApp account. Like the network states, these have `get()` and `assertEquals()`.
+Here's the full list of values you can access on the zkApp account. Like the network states, these values have `get()` and `assertEquals()`.
 Balance and nonce also have `assertBetween()`.
 
 ```ts
@@ -138,7 +138,7 @@ there's `assertNothing()` on all of these fields (including on-chain state). **U
 
 Just like on-chain state, some account fields can be written to. Again, the API is consistent with state: `this.account.<field>.set(newValue)`.
 
-For example, here's how you can change permissions on an account:
+For example, here's how to change permissions on an account:
 
 ```ts
 this.account.permissions.set({
@@ -147,7 +147,7 @@ this.account.permissions.set({
 });
 ```
 
-And here's how you can set the delegate (the account that your smart contract delegates its stake to):
+And here's how to set the delegate (the account that your smart contract delegates its stake to):
 
 ```ts
 this.account.delegate.set(delegatePublicKey);
@@ -170,7 +170,7 @@ this.account.tokenSymbol.set(value: string);
 this.account.timing.set(value: Timing);
 ```
 
-### Accessing other accounts than the zkApp's account
+### Accessing accounts other than the zkApp's account
 
 The API described in this section (get / set / assertEquals / ...) can be used to access the zkApp account itself, but also any other account.
 To do so, create an [account update](/zkapps/how-to-write-a-zkapp#transactions-and-account-updates) to find the same `account` / `network` fields API:

--- a/docs/zkapps/advanced-snarkyjs/permissions.mdx
+++ b/docs/zkapps/advanced-snarkyjs/permissions.mdx
@@ -20,7 +20,7 @@ Permissions live on-chain, which means they are a part of the account representa
 
 There are 11 different types of permissions that a developer can access and adjust to guard a zkApp account:
 
-- `editState`: The permission corresponding to the eight state fields of on-chain state that are associated with an account. This permission describes how the on-chate state fields can be manipulated.
+- `editState`: The permission describing how the zkApp account's eight on-chain state fields are allowed to be manipulated. This permission describes how the on-chate state fields can be manipulated.
 
 - `send`: The permission corresponding to the ability to send transactions from this account. This permission determines whether someone can send a transaction, for example, transfer MINA from this particular account. 
 
@@ -168,10 +168,10 @@ await tx.sign([account1Key]).send();
 ```
 
 This malicious example transaction creates a new account update for our smart contract address. Right after that, the new account update sends 1 MINA to the address of the fee payer (`account1Address`).
-At the end of the transaction block, the transaction is signed only with the private key of the fee payer - not the private key of the smart contract!
+At the end of the transaction block, the transaction is signed only with the private key of the fee payer -- not the private key of the smart contract!
 Because the permissions for sending funds away from a smart contract are set to `none`, this transaction succeeds and drains 1 MINA from the smart contract.
 
-Now, if you change the `send` permission to something else, like `signature`, the manual account update fails with `Update_not_permitted_balance` that prevents withdrawing funds from the smart contract since the authorization does not fit the permission for `send` that now requires a valid signature!
+Now, if you change the `send` permission to something else, like `signature`, the manual account update fails with `Update_not_permitted_balance` that prevents withdrawing funds from the smart contract since the authorization does not fit the permission for `send` that now requires a valid signature.
 
 You can slightly modify the withdraw-transaction to include a valid signature by adding requesting a signature on the `withdrawal` account update and providing the private key of the smart contract account to `tx.send([zkappKey]) `
 
@@ -194,7 +194,7 @@ By using permissions, you can make our smart contract not upgradeable at all or 
 On Mina, when you deploy a smart contract you generate a verification key from the contract source code. The verification key and the smart contract are stored on-chain and used to verify proofs that belong to that smart contract.
 Remember the permission called `setVerificationKey`? You can modify the authorization for this permission to set the upgradability of the smart contract. 
 
-#### Impossible to upgrade example
+#### Example: Impossible to upgrade
 
 This simple example ensures that the smart contract is not upgradeable. After a verification key is deployed, it cannot be changed.
 
@@ -235,7 +235,7 @@ Using the `LocalBlockchain`, you get the following (expected) error:
 
 For the sake of security, it is important to note that you must also set the field `setPermissions` to `impossible` to make the smart contract truly impossible to upgrade. This permission prevents a zkApp developer from changing the permission `setVerificationKey` to, for example, `signature` - which allows an actor to manipulate the verification key again.
 
-#### Upgradeable with a proof
+#### Example: Upgradeable with a proof
 
 There are situations where you might want the smart contract to be upgradeable.
 Modify the method `updateVerificationKey` to do some checks before you can update the verification key (as the result of a vote or other conditions).
@@ -270,9 +270,7 @@ await tx.prove();
 await tx.sign([feePayerKey, zkappKey]).send();
 ```
 
-
 ## Where to learn more
-
 
 Integration tests exercise the behavior of different permissions, including upgradeability. 
 If you want to take a look, check out the [voting integration test](https://github.com/o1-labs/snarkyjs/blob/main/src/examples/zkapps/voting/test.ts#L50) as well as the [DEX integration test](https://github.com/o1-labs/snarkyjs/blob/main/src/examples/zkapps/dex/upgradability.ts).

--- a/docs/zkapps/advanced-snarkyjs/permissions.mdx
+++ b/docs/zkapps/advanced-snarkyjs/permissions.mdx
@@ -12,62 +12,65 @@ zkApps can now be deployed to Berkeley Testnet.
 
 # Permissions
 
-Permissions are an integral part of zkApp development - they determine who has the authority to interact and make changes to a specific part of a smart contract.
-Naturally, it's important for every smart contract to have a set of sound permissions to prevent any attacks or security holes.
-Permissions live on-chain, that means they are a part of the account representation on the network, and are checked every time an account updates tries to interact with an account.
+Permissions are an integral part of zkApp development because they determine who has the authority to interact and make changes to a specific part of a smart contract.
+Naturally, every smart contract must have proper permissions to prevent attacks or security holes.
+Permissions live on-chain, which means they are a part of the account representation on the network. Permissions are checked every time an account update tries to interact with an account.
 
 ## Types of Permissions
 
+There are 11 different types of permissions that a developer can access and adjust to guard a zkApp account:
 
-Currently, there are 11 different types of permissions that guard a zkApp account and a developer can access and adjust.
+- `editState`: The permission corresponding to the eight state fields of on-chain state that are associated with an account. This permission describes how the on-chate state fields can be manipulated.
 
-`editState`: The Permission corresponding to the 8 state fields associated with an account.
-Every smart contract account has 8 fields of on-chain state. This permissions describes how those 8 fields can be manipulated.
+- `send`: The permission corresponding to the ability to send transactions from this account. This permission determines whether someone can send a transaction, for example, transfer MINA from this particular account. 
 
-`send`: The Permission corresponding to the ability to send transactions from this account.
-This permission determines whether or not someone is able to send transaction (e.g. transfer MINA) from this particular account. 
+- `receive`: Similar to `send`, the `receive` permission determines whether a particular account can receive transactions, for example, depositing MINA.
 
-`receive`: Similar to `send`, the Permission corresponding to the ability to receive transactions to this account.
-Similar to send, it determines whether or not a particular account can receive transactions - for example, depositing MINA.
+- `setDelegate`: The permission corresponding to the ability to set the delegate field of the account. The delegate field is the address of another account to whom this account is delegating its MINA for staking.
 
-`setDelegate`: The Permission corresponding to the ability to set the delegate field of the account.
-The delegate field is the address of another account, to whom this account is delegating its MINA to for staking.
+- `setPermissions`: The permission corresponding to the ability to change the permissions of the account. As the name suggests, this type of permission describes how already set permissions can be changed.
 
-`setPermissions`: The Permission corresponding to the ability to change the permissions of the account.
-As the name might suggest, this type of permission describes how already set permissions can be changed.
+- `setVerificationKey`: The permission corresponding to the ability to change the verification key of the account. Every smart contract has a verification key stored on-chain. The verification key is used to verify off-chain proofs. This permission essentially describes if the verification key can be changed; you can also think of it as the "upgradeability" of smart contracts.
 
-`setVerificationKey`: The Permission corresponding to the ability to change the verification key of the account.
-Every smart contract has a verification key stored on-chain. The verification key is used to verify off-chain proofs. This permission essentially describes if the verification key can be changed or not - we can also think of it as "upgradeability" of smart contracts.
+- `setZkappUri`: The permission corresponding to the ability to change the zkapp uri field of the account. The `zkappUri` field can be used to store metadata about the smart contract, for example, link to the source code. 
 
-`setZkappUri`:  The Permission corresponding to the ability to change the zkapp uri field of the account.
-The `zkappUri` is a field that can be used to store some meta data about the smart contract (e.g. link to the source code). The permission determines how this field can be changed.
+- `editActionsState`: The permission that corresponds to the ability to change the actions state of the associated account. Every smart contract can dispatch actions that are committed on-chain. This type of permission describes who can change the actions state.
 
-`editActionsState`: The Permission corresponding to the ability to change the actions state of the associated account.
-Every smart contract can dispatch actions, which are committed to on-chain. This type of permission describes who can change that value.
+- `setTokenSymbol`: The permission corresponding to the ability to set the token symbol for this account. The `tokenSymbol` field stores the symbol of a token.
 
-`setTokenSymbol`: The Permission corresponding to the ability to set the token symbol for this account.
-Similar to `setZkappUri` and `zkappUri`, this field stored the symbol of a token.
+- `incrementNonce`: The permission that determines whether to increment the nonce with an account update and who can increment the nonce on this account with a transaction.
 
-`incrementNonce`: The Permission that determine whether or not the nonce should be incremented with an account update.
-This Permission determines who can increment the nonce on this account with a transaction.
+- `setVotingFor`: The permission corresponding to the ability to set the chain hash for this account. The `votingFor` field is an on-chain mechanism to set the chain hash of the hard fork this account is voting for. 
 
-`setVotingFor`: The permissions corresponding to the ability to set the chain hash for this account. 
-The `votingFor` field is an on-chain mechanism to set the chain hash of the hard fork this account is voting for. 
+- `access`: This permission is more restrictive than all the other permissions combined! It corresponds to the ability to include any account update for this account in a transaction, even no-op account updates. Usually, the access permission is set to require no authorization. However, for [token manager contracts](custom-tokens), `access` requires at least proof authorization so that token interactions are approved by calling one of the token manager's methods.
 
-`access`: This Permission is more restrictive than all the others combined! It corresponds to the ability to include any account update for this account in a transaction, even no-op account updates. Usually, this can be set to require no authorization. However, for [token manager contracts](custom-tokens), `access` should require at least proof authorization, so that token interactions must be approved by calling one of the token manager's methods.
-
-`setTiming`: The permission corresponding to the ability to control the vesting schedule of time-locked accounts.
+- `setTiming`: The permission corresponding to the ability to control the vesting schedule of time-locked accounts.
 
 ## Authorization
 
-Permissions just describe who has the ability to execute an action, but they don't authorize it.
-Currently, we have 5 types of authorizations: `none`, `impossible`, `signature`, `proof` and `proofOrSignature`.
+Authorization determines what resources can be accessed, while permissions just describe who has the ability to execute an action.
 
 A transaction consists of multiple account updates (sort of like instructions to the network) - and each account update must be authorized in one way or another.
-When you inspect an account update (either directly in SnarkyJS or using an explorer), you see a field `authorization` on the account update.
-If this field has a proof attached, it means it's authorized by a proof that is checked against the verification key of the account. If it's a signature, that means the account update was authorized by a signature.
+When you inspect an account update directly in SnarkyJS or using an explorer, you see the `authorization` field. 
 
-Here is an example of how this may look like: 
+- If the `authorization` field has a proof attached, it means the transaction is authorized by a proof that is checked against the verification key of the account. 
+- If the `authorization` field has a signature, it means the account update is authorized by a signature.
+
+### Types of Authorizations
+
+The types of authorizations are:
+
+- `none`: Everyone has access to fields with permission set to `none` - and therefore can manipulate the fields as they please. 
+
+- `impossible`: If a field permission is set to `impossible`, nothing can ever change this field!  
+
+- `signature`: Fields that have their permission set to `signature` can only be manipulated by account updates that are accompanied and authorized by a valid signature.
+
+- `proof`: Fields that have their permission set to `proof` can be manipulated only by account updates that are accompanied and authorized by a valid proof. Proofs are generated by proving the execution of a smart contract method. A proof is checked against the verification key of the account to ensure that state is changed only if the user generated a valid proof by executing a smart contract method correctly.
+
+- `proofOrSignature`: As the name might suggest, permissions with authorization set to `proofOrSignature` accept either a valid signature or a valid proof. 
+
+This example account update is authorized by a signature: 
 
 ```json
 {
@@ -96,24 +99,12 @@ Here is an example of how this may look like:
 }
 ```
 
-As you can see, this example account update has an authorization of kind `signature` provided, and you can also see it's trying to update the app state of the smart contract!
-Let's consider a smart contract that has the permission `editState` set to the authorization `none`. 
-This means, since the authorization is `none`, everyone can freely change the state of the smart contract as they please! Obviously, this is not a safe practice. To allow state changes only when a valid proof accompanies the account update (which wants to access said state), set your authorization to `proof`!
-This makes sure that state is being changed only if the user generated a valid proof by executing a smart contract method correctly!
+As you can see, this example account update has an authorization with a `signature` provided. You can also see it's trying to update the app state of the smart contract.
 
-The authorizations are:
+However, imagine if a smart contract had the the permission `editState` set to the authorization `none`. 
+When authorization is `none`, everyone can freely change the state of the smart contract as they please! Obviously, this is not a safe practice. To allow state changes only when a valid proof accompanies the account update that wants to access the state, set your authorization to `proof` so that the transaction is authorized by a proof that is checked against the verification key of the account. Using a `proof` authorization ensures that state is changed only if the user generated a valid proof by executing a smart contract method correctly.
 
-`none`: Everyone has access to fields with permission set to `none` - and therefore can manipulate the fields as they please! 
-
-`impossible`: If a fields permission is set to `impossible`, nothing can ever change this field!  
-
-`signature`: Fields that have their permission set to `signature` can only be manipulated by account updates that are accompanied and authorized by a valid signature.
-
-`proof`: Fields that have their permission set to `proof` can be manipulated only by account updates that are accompanied and authorized by a valid proof. Proofs are generated by proving the execution of a smart contract method.
-
-`proofOrSignature`: As the name might suggest, permissions with authorization set to `proofOrSignature` accept both a valid signature or a valid proof. 
-
-## The Default
+## Default Permissions
 
 Smart contracts, when first deployed, always start with this default set of permissions:
 
@@ -138,13 +129,13 @@ Smart contracts, when first deployed, always start with this default set of perm
 
 ## Example
 
-To better understand how to leverage permissions to make our smart contract more secure, look at a few examples.
+To better understand how to leverage permissions to make your smart contract more secure, look at these examples.
 
 ### Sending MINA from smart contracts
 
 Some smart contracts manage state and token, such as the native MINA token. To prevent malicious actors from withdrawing all funds, use permissions to secure them.
 
-Consider the following smart contract `UnsecureContract`, which is available [here](https://github.com/o1-labs/snarkyjs/blob/main/src/examples/zkapps/simple_zkapp_payment.ts) as well
+Consider the [`UnsecureContract`](https://github.com/o1-labs/snarkyjs/blob/main/src/examples/zkapps/simple_zkapp_payment.ts) smart contract. This example is also provided in the `examples` folder  in the `snarkyjs` codebase repo:
 
 
 ```ts
@@ -164,10 +155,8 @@ class UnsecureContract extends SmartContract {
 }
 ```
 
-
-Our `UnsecureContract` has two methods: `withdraw` for withdrawing funds from the smart contract account and `deposit` for depositing funds into the smart contract account.
-Notice permissions are specified in the `init` method and set the permission for `send` to `Permissions.none()`? 
-Because `none` means you don't have to provide *any* form of authorization, a malicious actor can easily drain all funds from the smart contract! Take a look at the following transaction that abuses that:
+This `UnsecureContract` smart contract has two methods: `withdraw` for withdrawing funds from the smart contract account and `deposit` for depositing funds into the smart contract account.
+Notice that the permissions specified in the `init` method have set the `send` permission to `Permissions.none()`. Because `none` means you don't have to provide *any* form of authorization, a malicious actor can easily drain all funds from the smart contract! Take a look at the following malicious transaction that abuses this permission:
 
 
 ```ts
@@ -178,12 +167,11 @@ tx = await Mina.transaction(account1Address, () => {
 await tx.sign([account1Key]).send();
 ```
 
-This example transaction creates a new account update for our smart contract address. Right after that, the new account update sends 1 MINA to the address of the fee payer (`account1Address`).
+This malicious example transaction creates a new account update for our smart contract address. Right after that, the new account update sends 1 MINA to the address of the fee payer (`account1Address`).
 At the end of the transaction block, the transaction is signed only with the private key of the fee payer - not the private key of the smart contract!
 Because the permissions for sending funds away from a smart contract are set to `none`, this transaction succeeds and drains 1 MINA from the smart contract.
 
-Now, if you change the `send` permission to something else, like `signature`, the manual account update fails with `Update_not_permitted_balance` which does not allow to withdraw funds from the smart contract,
-since the authorization does not fit the permission for `send` that now requires a valid signature!
+Now, if you change the `send` permission to something else, like `signature`, the manual account update fails with `Update_not_permitted_balance` that prevents withdrawing funds from the smart contract since the authorization does not fit the permission for `send` that now requires a valid signature!
 
 You can slightly modify the withdraw-transaction to include a valid signature by adding requesting a signature on the `withdrawal` account update and providing the private key of the smart contract account to `tx.send([zkappKey]) `
 
@@ -202,13 +190,13 @@ Now that you have provided a valid signature and the smart contract requires a v
 ### Upgradeability of smart contracts
 
 Another important part of smart contract development is upgradeability.
-By using permissions, we can either make our smart contract not upgradeable at all or upgradeable! 
-On Mina, when we deploy a smart contract we generate a verification key from our contract source code, which are then be stored on-chain and used to verify proofs that belong to that smart contract.
+By using permissions, you can make our smart contract not upgradeable at all or upgradeable! 
+On Mina, when you deploy a smart contract you generate a verification key from the contract source code. The verification key and the smart contract are stored on-chain and used to verify proofs that belong to that smart contract.
 Remember the permission called `setVerificationKey`? You can modify the authorization for this permission to set the upgradability of the smart contract. 
 
-#### Impossible
+#### Impossible to upgrade example
 
-Let's start simple. This example ensures that the smart contract is not upgradeable. After a verification key is deployed, it cannot be changed.
+This simple example ensures that the smart contract is not upgradeable. After a verification key is deployed, it cannot be changed.
 
 
 ```ts
@@ -227,7 +215,7 @@ class UpgradeabilityImpossible extends SmartContract {
 }
 ```
 
-The `UpgradeabilityImpossible` smart contract has only one method: `updateVerificationKey`. By invoking this method and providing a new verification key,  the verification key on-chain is expected to change.
+The `UpgradeabilityImpossible` smart contract has only one method: `updateVerificationKey`. By invoking this method and providing a new verification key, the verification key on-chain is expected to change.
 But since `setVerificationKey` permission is specified to be `impossible`, invoking that method fails - essentially making the smart contract not upgradeable.
 
 ```ts
@@ -245,12 +233,11 @@ Using the `LocalBlockchain`, you get the following (expected) error:
 
 `Error: Transaction verification failed: Cannot update field 'verificationKey' because permission for this field is 'Impossible'`
 
-For the sake of security, it is important to mention that you must also set the field `setPermissions` to `impossible` to make the smart contract truly impossible to upgrade. This permission prevents a zkApp developer from changing the permission `setVerificationKey` to, for example, `signature` - which allows an actor to manipulate the verification key again.
-
+For the sake of security, it is important to note that you must also set the field `setPermissions` to `impossible` to make the smart contract truly impossible to upgrade. This permission prevents a zkApp developer from changing the permission `setVerificationKey` to, for example, `signature` - which allows an actor to manipulate the verification key again.
 
 #### Upgradeable with a proof
 
-But there are situations where you might want the smart contract to be upgradeable!
+There are situations where you might want the smart contract to be upgradeable.
 Modify the method `updateVerificationKey` to do some checks before you can update the verification key (as the result of a vote or other conditions).
 For now, just check that you can provide an `x` that is greater than or equal to 5. If this check succeeds, then update the verification key.
 
@@ -263,7 +250,7 @@ For now, just check that you can provide an `x` that is greater than or equal to
 }
 ```
 
-You must update the permissions from `setVerificationKey`: `impossible` to `proof`, because you want to change the verification key only if a valid proof is provided.
+You must update the permissions from `setVerificationKey`: `impossible` to `proof` because you want to change the verification key only if a valid proof is provided.
 
 ```ts
 this.account.permissions.set({

--- a/docs/zkapps/advanced-snarkyjs/recursion.mdx
+++ b/docs/zkapps/advanced-snarkyjs/recursion.mdx
@@ -16,22 +16,22 @@ Specifically, we are looking into refactoring ZkProgram methods to explicitly re
 
 # Recursion
 
-Kimchi, the proof system that backs SnarkyJS, supports arbitrary infinite recursive proof construction of circuits through integration with the Pickles recursive system. Recursion is an incredibly powerful primitive that has a wide-array of uses. Here's a few of them:
+Kimchi, the proof system that backs SnarkyJS, supports arbitrary infinite recursive proof construction of circuits through integration with the Pickles recursive system. Recursion is an incredibly powerful primitive that has a wide-array of uses, including:
 
 1. Mina uses linear recursive proofs to compress the blockchain, an infinitely growing structure, down to a constant size.
 2. Mina also uses "rollup-like" tree-based recursive proofs to _in parallel_ compress transactions within blocks down to a constant size.
-3. The [Mastermind game](link to example) uses linear recursive proofs, an example of an application-specific rollup, to progress the state-machine of the application without needing to sync back to the game.
+3. A Mastermind game that uses linear recursive proofs, an example of an application-specific rollup, to progress the state-machine of the application without needing to sync back to the game.
 4. App-specific rollups can use recursion to communicate to each other, sort like app chains using IBC or parachains using XCVM to send messages.
 
-More generally, we can use recursion to verify any zero knowledge program as part of our zkApp.
+More generally, you can use recursion to verify any zero-knowledge program as part of your zkApp.
 
 ## Overview
 
-In SnarkyJS, we can use `ZkProgram()` to define the steps of our recursive program. Just like `SmartContract`s, `ZkProgram()`s have any number of methods and execute off-chain.
+In SnarkyJS, you can use `ZkProgram()` to define the steps of our recursive program. Just like `SmartContract()` methods, `ZkProgram()` methods have any number of methods and execute off-chain.
 
-After performing your desired recursive steps, you'll likely want to settle the interaction on Mina's blockchain and can do this by embedding the  `ZkProgram` within a `SmartContract` method verifying the underlying proof of execution and extracting the output which can be used elsewhere in the method (like storing the output in app-state for example).
+After performing your desired recursive steps, you can settle the interaction on Mina's blockchain and by embedding the  `ZkProgram` within a `SmartContract` method that verifys the underlying proof of execution and extracts the output that can be used elsewhere in the method (like storing the output in app-state, for example).
 
-Similar to methods within the `SmartContract` class, inputs to `ZkProgram` are _private by default_ and never seen by the Mina network.  Unlike `SmartContract`s, the developer can choose the shape of the public input to all the methods within a `ZkProgram`.
+Similar to methods within the `SmartContract` class, inputs to `ZkProgram` are _private by default_ and never seen by the Mina network.  Unlike `SmartContract` methods, as the zkApp developer you choose the shape of the public input to all the methods within a `ZkProgram`.
 
 ## Recursively Verifying a simple program within a zkApp
 
@@ -79,13 +79,13 @@ And verify this proof from within any method of your `SmartContract` class:
 }
 ```
 
-What we're doing in `foo` is taking the `SimpleProgram` proof as a private argument to the method, verifying that the execution was valid, and then using the output.
+In this excample, `foo` is taking the `SimpleProgram` proof as a private argument to the method, verifying that the execution was valid, and then using the output.
 
-## Recursively Verifying a linear recursive program within a zkApp
+## Recursively verifying a linear recursive program within a zkApp
 
-This time we are going to write a recursive `ZkProgram` which we can use to create recursive zero-knowledge proofs. In other proof systems, this is extremely difficult to construct if it is even possible, but in SnarkyJS we can describe a recursive ZkProgram with a simple recursive function.
+This example shows a recursive `ZkProgram` that you can use to create recursive zero-knowledge proofs. In other proof systems, this is extremely difficult to construct if it is even possible. However, in SnarkyJS you can describe a recursive ZkProgram with a simple recursive function.
 
-Here, write a program that describes a recursive operation of adding one repeatedly to a number. Note that we recursively depend on the older proof as a private argument to our method.
+This program describes a recursive operation of adding one repeatedly to a number. Note that you recursively depend on the older proof as a private argument to your method.
 
 ```typescript
 import { SelfProof, Field, Experimental, verify } from 'snarkyjs';
@@ -114,7 +114,7 @@ const AddOne = Experimental.ZkProgram({
 });
 ```
 
-First we compile this program and make the base proof as before:
+First, compile this program and make the base proof as before:
 
 ```typescript
 const { verificationKey } = await AddOne.compile();
@@ -122,19 +122,19 @@ const { verificationKey } = await AddOne.compile();
 const proof = await AddOne.baseCase(Field(0));
 ```
 
-This time we can use this proof as input to recursively add one again:
+This time use this proof as input to recursively add one again:
 
 ```typescript
 const proof1 = await AddOne.step(Field(1), proof);
 ```
 
-And we can repeat this as many times as we want:
+And repeat this as many times as you want:
 
 ```typescript
 const proof2 = await AddOne.step(Field(2), proof1);
 ```
 
-Finally we can verify the proof from within a SmartContract like we did above:
+Finally, verify the proof from within a SmartContract like the earlier example:
 
 ```typescript
 @method foo(proof: Proof) {
@@ -144,11 +144,11 @@ Finally we can verify the proof from within a SmartContract like we did above:
 }
 ```
 
-## Recursively Verifying a tree-based recursive program within a zkApp
+## Recursively verifying a tree-based recursive program within a zkApp
 
 Tree recursion is even more rarely seen in other proof systems and zk toolkits. This is used internally within Mina as part of its decentralized prover and sequencing mechanism for rollups, so it's supported very robustly by Kimchi.
 
-Here we'll write a program that describes a very simple rollup for adding numbers:
+This example program describes a very simple rollup for adding numbers:
 
 ```typescript
 import { SelfProof, Field, Experimental, verify } from 'snarkyjs';
@@ -183,7 +183,7 @@ let RollupAdd = Experimental.ZkProgram({
 
 ## Bonus: Using ZkPrograms outside of zkApps
 
-You can also use ZkProgram directly to prove and verify arbitrary zero-knowledge programs (a.k.a. circuits).
+You can also use ZkProgram directly to prove and verify arbitrary zero-knowledge programs (also known as circuits).
 
 ```typescript
 const { verificationKey } = await MyProgram.compile();
@@ -191,7 +191,7 @@ const { verificationKey } = await MyProgram.compile();
 const proof = await MyProgram.base(Field(0));
 ```
 
-Now we can directly verify a JSON-encoded version of the proof to get back a boolean value telling us if the proof is valid.
+Now you can directly verify a JSON-encoded version of the proof to get back a boolean value that tells you if the proof is valid:
 
 ```typescript
 import { verify } from 'snarkyjs';


### PR DESCRIPTION
This PR includes technical clarity edits made during timeless doc checks for the Advanced SnarkyJS content

I fixed a few typos along the way

This issue is part 1 of the work for the [zkApp Developers](https://docs.minaprotocol.com/zkapps/tutorials/hello-world#) section of the docs.

Excludes [Time-Locked Accounts](https://docs.minaprotocol.com/zkapps/advanced-snarkyjs/time-locked-accounts) because that page requires technical updates