### PR TITLE
Improve permissions docs

### DIFF
--- a/docs/zkapps/snarkyjs/permissions.mdx
+++ b/docs/zkapps/snarkyjs/permissions.mdx
@@ -33,7 +33,7 @@ There are 11 different types of permissions that a developer can access and adju
 
 - `editState`: The permission describing how the zkApp account's eight on-chain state fields are allowed to be manipulated. This permission describes how the on-chate state fields can be manipulated.
 
-- `send`: The permission corresponding to the ability to send transactions from this account. This permission determines whether someone can send a transaction, for example, transfer MINA from this particular account. 
+- `send`: The permission corresponding to the ability to send transactions from this account. This permission determines whether someone can send a transaction, for example, transfer MINA from this particular account.
 
 - `receive`: Similar to `send`, the `receive` permission determines whether a particular account can receive transactions, for example, depositing MINA.
 
@@ -43,7 +43,7 @@ There are 11 different types of permissions that a developer can access and adju
 
 - `setVerificationKey`: The permission corresponding to the ability to change the verification key of the account. Every smart contract has a verification key stored on-chain. The verification key is used to verify off-chain proofs. This permission essentially describes if the verification key can be changed; you can also think of it as the "upgradeability" of smart contracts.
 
-- `setZkappUri`: The permission corresponding to the ability to change the zkapp uri field of the account. The `zkappUri` field can be used to store metadata about the smart contract, for example, link to the source code. 
+- `setZkappUri`: The permission corresponding to the ability to change the zkapp uri field of the account. The `zkappUri` field can be used to store metadata about the smart contract, for example, link to the source code.
 
 - `editActionsState`: The permission that corresponds to the ability to change the actions state of the associated account. Every smart contract can dispatch actions that are committed on-chain. This type of permission describes who can change the actions state.
 
@@ -51,7 +51,7 @@ There are 11 different types of permissions that a developer can access and adju
 
 - `incrementNonce`: The permission that determines whether to increment the nonce with an account update and who can increment the nonce on this account with a transaction.
 
-- `setVotingFor`: The permission corresponding to the ability to set the chain hash for this account. The `votingFor` field is an on-chain mechanism to set the chain hash of the hard fork this account is voting for. 
+- `setVotingFor`: The permission corresponding to the ability to set the chain hash for this account. The `votingFor` field is an on-chain mechanism to set the chain hash of the hard fork this account is voting for.
 
 - `access`: This permission is more restrictive than all the other permissions combined! It corresponds to the ability to include any account update for this account in a transaction, even no-op account updates. Usually, the access permission is set to require no authorization. However, for [token manager contracts](custom-tokens), `access` requires at least proof authorization so that token interactions are approved by calling one of the token manager's methods.
 
@@ -62,57 +62,48 @@ There are 11 different types of permissions that a developer can access and adju
 Authorization determines what resources can be accessed, while permissions just describe who has the ability to execute an action.
 
 A transaction consists of multiple account updates (sort of like instructions to the network) - and each account update must be authorized in one way or another.
-When you inspect an account update directly in SnarkyJS or using an explorer, you see the `authorization` field. 
+When you inspect an account update directly in SnarkyJS or using an explorer, you see the `authorization` field.
 
-- If the `authorization` field has a proof attached, it means the transaction is authorized by a proof that is checked against the verification key of the account. 
+- If the `authorization` field has a proof attached, it means the transaction is authorized by a proof that is checked against the verification key of the account.
 - If the `authorization` field has a signature, it means the account update is authorized by a signature.
 
 ### Types of Authorizations
 
 The types of authorizations are:
 
-- `none`: Everyone has access to fields with permission set to `none` - and therefore can manipulate the fields as they please. 
+- `none`: Everyone has access to fields with permission set to `none` - and therefore can manipulate the fields as they please.
 
-- `impossible`: If a field permission is set to `impossible`, nothing can ever change this field!  
+- `impossible`: If a field permission is set to `impossible`, nothing can ever change this field!
 
 - `signature`: Fields that have their permission set to `signature` can only be manipulated by account updates that are accompanied and authorized by a valid signature.
 
 - `proof`: Fields that have their permission set to `proof` can be manipulated only by account updates that are accompanied and authorized by a valid proof. Proofs are generated by proving the execution of a smart contract method. A proof is checked against the verification key of the account to ensure that state is changed only if the user generated a valid proof by executing a smart contract method correctly.
 
-- `proofOrSignature`: As the name might suggest, permissions with authorization set to `proofOrSignature` accept either a valid signature or a valid proof. 
+- `proofOrSignature`: As the name might suggest, permissions with authorization set to `proofOrSignature` accept either a valid signature or a valid proof.
 
-This example account update is authorized by a signature: 
+This example account update is authorized by a signature:
 
 ```json
 {
-    "authorization": {
-        "proof": null,
-        "signature": "7mXAcTFeybdZkFmYmfoRYRzVeMxQsGU5Uxq1RpRpGSkHEa5ZEraTRJ4cNKMnAS1n3NCmVqDnHUyraJs131dcdFi3sZH1Qzos"
-    },
+  "authorization": {
+    "proof": null,
+    "signature": "7mXAcTFeybdZkFmYmfoRYRzVeMxQsGU5Uxq1RpRpGSkHEa5ZEraTRJ4cNKMnAS1n3NCmVqDnHUyraJs131dcdFi3sZH1Qzos"
+  },
+  // ...
+  "body": {
     // ...
-    "body": {
-        // ...
-        "update": {
-            "appState": [
-                "1",
-                "0",
-                "0",
-                "0",
-                "0",
-                "0",
-                "0",
-                "0"
-            ],
-            // ...
-        },
-        // ...
+    "update": {
+      "appState": ["1", "0", "0", "0", "0", "0", "0", "0"]
+      // ...
     }
+    // ...
+  }
 }
 ```
 
 As you can see, this example account update has an authorization with a `signature` provided. You can also see it's trying to update the app state of the smart contract.
 
-However, imagine if a smart contract had the the permission `editState` set to the authorization `none`. 
+However, imagine if a smart contract had the the permission `editState` set to the authorization `none`.
 When authorization is `none`, everyone can freely change the state of the smart contract as they please! Obviously, this is not a safe practice. To allow state changes only when a valid proof accompanies the account update that wants to access the state, set your authorization to `proof` so that the transaction is authorized by a proof that is checked against the verification key of the account. Using a `proof` authorization ensures that state is changed only if the user generated a valid proof by executing a smart contract method correctly.
 
 ## Default Permissions
@@ -137,7 +128,6 @@ Smart contracts, when first deployed, always start with this default set of perm
 
 `setTokenSymbol`: `signature`
 
-
 ## Example
 
 To better understand how to leverage permissions to make your smart contract more secure, look at these examples.
@@ -146,8 +136,7 @@ To better understand how to leverage permissions to make your smart contract mor
 
 Some smart contracts manage state and token, such as the native MINA token. To prevent malicious actors from withdrawing all funds, use permissions to secure them.
 
-Consider the UnsecureContract smart contract example provided in [simple_zkapp_payment.ts](https://github.com/o1-labs/snarkyjs/blob/main/src/examples/zkapps/simple_zkapp_payment.ts) in the `snarkyjs` codebase repo:
-
+Consider the following `UnsecureContract` smart contract. [A similar example](https://github.com/o1-labs/snarkyjs/blob/main/src/examples/zkapps/simple_zkapp_payment.ts) is also provided in the `examples` folder in the `snarkyjs` codebase repo:
 
 ```ts
 class UnsecureContract extends SmartContract {
@@ -159,20 +148,15 @@ class UnsecureContract extends SmartContract {
     });
   }
 
-  @method deposit(amount: UInt64) {
-    let senderUpdate = AccountUpdate.createSigned(this.sender);
-    senderUpdate.send({ to: this, amount });
+  @method withdraw(amount: UInt64) {
+    this.send({ to: this.sender, amount });
   }
 }
 ```
 
-This `UnsecureContract` smart contract has two methods: 
+This `UnsecureContract` has just one method: `withdraw()` for withdrawing funds from the smart contract account. We will use that method later.
 
-- `withdraw` for withdrawing funds from the smart contract account
-- `deposit` for depositing funds into the smart contract account
-
-Notice that the permissions specified in the `init` method have set the `send` permission to `Permissions.none()`. Because `none` means you don't have to provide *any* form of authorization, a malicious actor can easily drain all funds from the smart contract! Take a look at the following malicious transaction that abuses this permission:
-
+But first, notice that the permissions specified in the `init()` method have set the `send` permission to `Permissions.none()`. Because `none` means you don't have to provide _any_ form of authorization, a malicious actor can easily drain all funds from the smart contract! Take a look at the following malicious transaction that abuses this permission:
 
 ```ts
 tx = await Mina.transaction(account1Address, () => {
@@ -182,13 +166,20 @@ tx = await Mina.transaction(account1Address, () => {
 await tx.sign([account1Key]).send();
 ```
 
-This malicious example transaction creates a new account update for our smart contract address. Right after that, the new account update sends 1 MINA to the address of the fee payer (`account1Address`).
+This transaction creates a new account update for our smart contract address. Right after that, the new account update sends 1 MINA to the address of the fee payer (`account1Address`).
 At the end of the transaction block, the transaction is signed only with the private key of the fee payer -- not the private key of the smart contract!
 Because the permissions for sending funds away from a smart contract are set to `none`, this transaction succeeds and drains 1 MINA from the smart contract.
 
-Now, if you change the `send` permission to something else, like `signature`, the manual account update fails with `Update_not_permitted_balance` that prevents withdrawing funds from the smart contract since the authorization does not fit the permission for `send` that now requires a valid signature.
+Now, let's change the `send` permission to `signature` instead:
 
-You can slightly modify the withdraw-transaction to include a valid signature by adding requesting a signature on the `withdrawal` account update and providing the private key of the smart contract account to `tx.send([zkappKey]) `
+```diff
+-      send: Permissions.none(),
++      send: Permissions.signature(),
+```
+
+If we try to run the same transaction as before, the manual account update fails with `Update_not_permitted_balance`. This prevents withdrawing funds from the smart contract, since the authorization does not fit the permission for `send` that now requires a valid signature.
+
+You can slightly modify the withdraw-transaction to include a valid signature by adding `.requireSignature()` on the withdrawal account update and providing the private key of the smart contract account to `tx.send([zkappKey]) `
 
 ```ts
 tx = await Mina.transaction(account1Address, () => {
@@ -199,20 +190,59 @@ tx = await Mina.transaction(account1Address, () => {
 await tx.sign([account1Key, zkappKey]).send();
 ```
 
-Now that you have provided a valid signature and the smart contract requires a valid signatures for sending funds from the smart contract, the transaction succeeds!
+Now that you have provided a valid signature, the transaction succeeds!
 
+However, this way of authorizing a transaction is not what we would expect from a smart contract. If we set a permission to `signature`, only the owner of the zkApp's private key (`zkappKey`) will be able to perform the interaction. However, the point of a smart contract is that anyone can interact, by trustlessly executing the smart contract code. For enabling this, we have `Permissions.proof()`.
+
+Let's try to make `UnsecureContract` a proper smart contract by setting the `send` permission to `proof`:
+
+```diff
+-      send: Permissions.signature(),
++      send: Permissions.proof(),
+```
+
+Alternatively, we can just delete the entire `init()` method, since a `send` permission of `proof` is already the default:
+
+```diff
+-  init() {
+-    super.init();
+-    this.account.permissions.set({
+-      ...Permissions.default(),
+-      send: Permissions.signature(),
+-    });
+-  }
+-
+```
+
+If you try running one of the two transactions from before, which created account updates manually, you'll find that they both fail with `Update_not_permitted_balance`.
+
+Setting the `send` permission to `proof` means that, to send MINA from this account, we need to execute one of the contract's `@method`s.
+
+In fact, our contract already has a `@method` which we can use: `withdraw()`. We create a withdrawal transaction containing a valid proof like this:
+
+```ts
+tx = await Mina.transaction(account1Address, () => {
+  let zkapp = new UnsecureContract(zkappAddress);
+  zkapp.withdraw(UInt64.from(1e9));
+});
+await tx.prove();
+await tx.sign([account1Key, zkappKey]).send();
+```
+
+As opposed to the other examples, we don't explicitly create an `AccountUpdate`. Instead, we instantiate `UnsecureContract` and call its `withdraw()` method. Each method call is automatically associated with an account update, for which it will create a valid proof. You can access and modify this account update by using `this` inside the method; in our example, we use `this.send(...)` to send MINA. So, by calling the method and doing `tx.prove()`, we satisfy the `proof` authorization requirement for sending MINA.
+
+You might have noticed that the contract is still not very secure: Anyone can call the `withdraw()` method to drain any amount of MINA from the contract. That's why it's called `UnsecureContract`. In a real contract, we would add some conditions to the `withdraw()` code, that restrict which users that can successfully call the method. See [our page about signatures in zkApps](./signatures-in-zkapps), where we continue this example by adding user authorization to the smart contract code.
 
 ### Upgradeability of smart contracts
 
 Another important part of smart contract development is upgradeability.
-By using permissions, you can make our smart contract not upgradeable at all or upgradeable! 
+By using permissions, you can make our smart contract not upgradeable at all or upgradeable!
 On Mina, when you deploy a smart contract you generate a verification key from the contract source code. The verification key and the smart contract are stored on-chain and used to verify proofs that belong to that smart contract.
-Remember the permission called `setVerificationKey`? You can modify the authorization for this permission to set the upgradability of the smart contract. 
+Remember the permission called `setVerificationKey`? You can modify the authorization for this permission to set the upgradability of the smart contract.
 
 #### Example: Impossible to upgrade
 
 This simple example ensures that the smart contract is not upgradeable. After a verification key is deployed, it cannot be changed.
-
 
 ```ts
 class UpgradeabilityImpossible extends SmartContract {
@@ -248,7 +278,7 @@ Using the `LocalBlockchain`, you get the following (expected) error:
 
 `Error: Transaction verification failed: Cannot update field 'verificationKey' because permission for this field is 'Impossible'`
 
-For the sake of security, it is important to note that you must also set the field `setPermissions` to `impossible` to make the smart contract truly impossible to upgrade. This permission prevents a zkApp developer from changing the permission `setVerificationKey` to, for example, `signature` - which allows an actor to manipulate the verification key again.
+For the sake of security, it is important to note that you must also set the `setPermissions` permission to `impossible` to make the smart contract truly impossible to upgrade. This permission prevents a zkApp developer from changing the permission `setVerificationKey` to, for example, `signature` - which allows them to manipulate the verification key again.
 
 #### Example: Upgradeable with a proof
 
@@ -258,10 +288,10 @@ For now, just check that you can provide an `x` that is greater than or equal to
 
 ```ts
 @method updateVerificationKey(vk: VerificationKey, x: Field) {
-    let y = Field(5);
-    x.gte(y).assertTrue();
+  let y = Field(5);
+  x.gte(y).assertTrue();
 
-    this.account.verificationKey.set(vk);
+  this.account.verificationKey.set(vk);
 }
 ```
 
@@ -269,8 +299,8 @@ You must update the permissions from `setVerificationKey`: `impossible` to `proo
 
 ```ts
 this.account.permissions.set({
-    ...Permissions.default(),
-    setVerificationKey: Permissions.proof(),
+  ...Permissions.default(),
+  setVerificationKey: Permissions.proof(),
 });
 ```
 
@@ -279,7 +309,7 @@ Now when you invoke the `updateVerificationKey` method, the transaction generate
 ```ts
 console.log('try upgrading vk');
 tx = await Mina.transaction(feePayer, () => {
-    zkapp.updateVerificationKey(newVerificationKey);
+  zkapp.updateVerificationKey(newVerificationKey);
 });
 await tx.prove();
 await tx.sign([feePayerKey, zkappKey]).send();
@@ -287,5 +317,5 @@ await tx.sign([feePayerKey, zkappKey]).send();
 
 ## Where to learn more
 
-Integration tests exercise the behavior of different permissions, including upgradeability. 
+Integration tests exercise the behavior of different permissions, including upgradeability.
 If you want to take a look, check out the [voting integration test](https://github.com/o1-labs/snarkyjs/blob/main/src/examples/zkapps/voting/test.ts#L50) as well as the [DEX integration test](https://github.com/o1-labs/snarkyjs/blob/main/src/examples/zkapps/dex/upgradability.ts) examples.

--- a/docs/zkapps/snarkyjs/permissions.mdx
+++ b/docs/zkapps/snarkyjs/permissions.mdx
@@ -170,14 +170,14 @@ This transaction creates a new account update for our smart contract address. Ri
 At the end of the transaction block, the transaction is signed only with the private key of the fee payer -- not the private key of the smart contract!
 Because the permissions for sending funds away from a smart contract are set to `none`, this transaction succeeds and drains 1 MINA from the smart contract.
 
-Now, let's change the `send` permission to `signature` instead:
+Now, change the `send` permission to `signature` instead:
 
 ```diff
 -      send: Permissions.none(),
 +      send: Permissions.signature(),
 ```
 
-If we try to run the same transaction as before, the manual account update fails with `Update_not_permitted_balance`. This prevents withdrawing funds from the smart contract, since the authorization does not fit the permission for `send` that now requires a valid signature.
+If you try to run the same transaction as before, the manual account update fails with `Update_not_permitted_balance`. This check prevents withdrawing funds from the smart contract, since the authorization does not fit the permission for `send` that now requires a valid signature.
 
 You can slightly modify the withdraw-transaction to include a valid signature by adding `.requireSignature()` on the withdrawal account update and providing the private key of the smart contract account to `tx.send([zkappKey]) `
 
@@ -192,16 +192,16 @@ await tx.sign([account1Key, zkappKey]).send();
 
 Now that you have provided a valid signature, the transaction succeeds!
 
-However, this way of authorizing a transaction is not what we would expect from a smart contract. If we set a permission to `signature`, only the owner of the zkApp's private key (`zkappKey`) will be able to perform the interaction. However, the point of a smart contract is that anyone can interact, by trustlessly executing the smart contract code. For enabling this, we have `Permissions.proof()`.
+However, this way of authorizing a transaction is not what you expect from a smart contract. If you set a permission to `signature`, only the owner of the zkApp's private key (`zkappKey`) is able to perform the interaction. However, the point of a smart contract is that anyone can interact, by trustlessly executing the smart contract code. For enabling a trustless execution, we have `Permissions.proof()`.
 
-Let's try to make `UnsecureContract` a proper smart contract by setting the `send` permission to `proof`:
+Now, try to make `UnsecureContract` a proper smart contract by setting the `send` permission to `proof`:
 
 ```diff
 -      send: Permissions.signature(),
 +      send: Permissions.proof(),
 ```
 
-Alternatively, we can just delete the entire `init()` method, since a `send` permission of `proof` is already the default:
+Alternatively, you can just delete the entire `init()` method, since a `send` permission of `proof` is already the default:
 
 ```diff
 -  init() {
@@ -216,9 +216,9 @@ Alternatively, we can just delete the entire `init()` method, since a `send` per
 
 If you try running one of the two transactions from before, which created account updates manually, you'll find that they both fail with `Update_not_permitted_balance`.
 
-Setting the `send` permission to `proof` means that, to send MINA from this account, we need to execute one of the contract's `@method`s.
+Setting the `send` permission to `proof` means that, to send MINA from this account, you need to execute one of the contract's `@method`s.
 
-In fact, our contract already has a `@method` which we can use: `withdraw()`. We create a withdrawal transaction containing a valid proof like this:
+In fact, our contract already has a `@method` which you can use: `withdraw()`. You create a withdrawal transaction containing a valid proof like this:
 
 ```ts
 tx = await Mina.transaction(account1Address, () => {
@@ -229,14 +229,17 @@ await tx.prove();
 await tx.sign([account1Key, zkappKey]).send();
 ```
 
-As opposed to the other examples, we don't explicitly create an `AccountUpdate`. Instead, we instantiate `UnsecureContract` and call its `withdraw()` method. Each method call is automatically associated with an account update, for which it will create a valid proof. You can access and modify this account update by using `this` inside the method; in our example, we use `this.send(...)` to send MINA. So, by calling the method and doing `tx.prove()`, we satisfy the `proof` authorization requirement for sending MINA.
+As opposed to the other examples, you don't explicitly create an `AccountUpdate`. Instead, you instantiate `UnsecureContract` and call its `withdraw()` method. Each method call is automatically associated with an account update, for which it creates a valid proof. You can access and modify this account update by using `this` inside the method; in our example, you use `this.send(...)` to send MINA. So, by calling the method and doing `tx.prove()`, you satisfy the `proof` authorization requirement for sending MINA.
 
-You might have noticed that the contract is still not very secure: Anyone can call the `withdraw()` method to drain any amount of MINA from the contract. That's why it's called `UnsecureContract`. In a real contract, we would add some conditions to the `withdraw()` code, that restrict which users that can successfully call the method. See [our page about signatures in zkApps](./signatures-in-zkapps), where we continue this example by adding user authorization to the smart contract code.
+You might have noticed that the contract is still not very secure: Anyone can call the `withdraw()` method to drain any amount of MINA from the contract. That's why it's called `UnsecureContract`. In a real contract, you would add some conditions to the `withdraw()` code, that restrict which users that can successfully call the method.
+
+<!-- TODO: commented until we add the signature page -->
+<!-- To learn about signatures in zkApps, see [Signatures in a smart contract](./signatures-in-zkapps) for a continuation of this example that adds user authorization to the smart contract code. -->
 
 ### Upgradeability of smart contracts
 
 Another important part of smart contract development is upgradeability.
-By using permissions, you can make our smart contract not upgradeable at all or upgradeable!
+By using permissions, you can make a smart contract upgradeable or not upgradeable at all.
 On Mina, when you deploy a smart contract you generate a verification key from the contract source code. The verification key and the smart contract are stored on-chain and used to verify proofs that belong to that smart contract.
 Remember the permission called `setVerificationKey`? You can modify the authorization for this permission to set the upgradability of the smart contract.
 


### PR DESCRIPTION
This enhances the permissions docs. Originally the plan was to add additional docs for using signatures in smart contract methods which build on the permissions example, but that plan was deprioritized