### PR TITLE
zkApp timeless docs and edit grooms part 2

### DIFF
--- a/docs/exchange-operators/faq.mdx
+++ b/docs/exchange-operators/faq.mdx
@@ -77,7 +77,7 @@ These funds are <u>NOT lost</u>. The exchanges have received the funds at the ex
 
 To avoid this above issue, we recommend that exchanges <u>do NOT require a memo</u> for deposits. At the same time, we also recommend that exchanges and wallet creators <u>expose an optional memo field</u> during a Mina send transaction.
 
-### What is the current maximum number of rollback blocks?
+### What is the maximum number of rollback blocks?
 
 The table in [Lifecycle of a Payment](../node-operators/lifecycle-of-a-payment) describes how many blocks you wait for a transaction to be confirmed.
 
@@ -120,11 +120,11 @@ fi
 
 Archive node operators often choose to run redundant archive nodes to store block data to one or more locations of their choice (e.g. PostgreSQL, GCP, local files, a logging service, etc) and to backfill any missed block data if needed.
 
-For convenience, O(1) Labs makes data from its archive node available [here](https://console.cloud.google.com/storage/browser/mina_network_block_data) to help others in the community backfill any missing information.
+For convenience, [mina_network_block_data](https://console.cloud.google.com/storage/browser/mina_network_block_data) from the archive node is available to help others in the community backfill any missing information.
 
 This bucket contains blocks from various Mina networks — e.g. Mainnet & the most recent Devnet named devnet2. Filter the file names to find those for the network you desire. (Note that this bucket contains blocks for various other networks too, such as QAnet, which we recommend against using for your testing. QAnet is used by O(1) Labs during their iterative development.)
 
-File names contain the network name, block height, and state hash of the block. Block height was added to the filename more recently, so blocks older than height 25,705 can include only the network name and state hash in the filename.
+File names contain the network name, block height, and state hash of the block. Blocks older than height 25,705 include only the network name and state hash in the filename.
 
 Example file names:
 
@@ -204,7 +204,7 @@ Since the timing is based on a combination of consensus timing (epochs) and snar
 
 A conservative estimate is that delegations sent 3 days before the epoch transition can take effect in the upcoming epoch. This means that, for any given delegation, there is an average of 18 to 29 days delay before this delegation updates block production.
 
-You can use this Delegation Calculator tool built by Carbonara to see when the next staking ledger cutoff:
+You can use this Delegation Calculator tool built by Carbonara to see the next staking ledger cutoff:
 [https://epoch.mina.tools](https://epoch.mina.tools/).
 
 ## Testing

--- a/docs/zkapps/faq.mdx
+++ b/docs/zkapps/faq.mdx
@@ -12,7 +12,7 @@ This has some implications:
 
 - To turn your logic into a proof, you must use SnarkyJS built-in datatypes such as `Field` and use the SnarkyJS functions that operate on them, like `Field.mul()`.
   - A statement like `x.mul(y)` adds a generic PLONK gate to your circuit and returns a variable that you can use in further statements that get wired to the multiplication gate.
-  - Some SnarkyJS functions allow you to turn normal JS datatypes into `Field` elements and back, such as `Encoding.stringToFields()`. Functions that don't add anything to your circuit are typically clarified in a doc-comment.
+  - Some SnarkyJS methods allow you to convert normal JavaScript datatypes into `Field` elements and back, such as `Encoding.stringToFields()`. Methods like this that don't add anything to your circuit are typically clarified in a doc comment.
 - Conventional JS code such as `'hello world'.split('').join(' ')` that doesn't use SnarkyJS built-ins are not included in your zk proof in any way since it does add anything to your circuit.
   - Why? Because it doesn't call any of the functions that build the circuit.
   - There's nothing wrong with having non-circuit code inside your method, as long as you're aware of what it's (not) doing.

--- a/docs/zkapps/faq.mdx
+++ b/docs/zkapps/faq.mdx
@@ -10,13 +10,13 @@ This works because SnarkyJS sets up some global state - a "circuit" - where it c
 
 This has some implications:
 
-- In order to turn your logic into a proof, you must use SnarkyJS built-in datatypes such as `Field` and use the SnarkyJS functions that operate on them, like `Field.mul()`.
+- To turn your logic into a proof, you must use SnarkyJS built-in datatypes such as `Field` and use the SnarkyJS functions that operate on them, like `Field.mul()`.
   - A statement like `x.mul(y)` adds a generic PLONK gate to your circuit and returns a variable that you can use in further statements that get wired to the multiplication gate.
-  - Some SnarkyJS functions allow you to turn normal JS datatypes into `Field` elements and back, such as `Encoding.stringToFields()`. These functions don't add anything to your circuit are typically clarified in a doc-comment.
+  - Some SnarkyJS functions allow you to turn normal JS datatypes into `Field` elements and back, such as `Encoding.stringToFields()`. Functions that don't add anything to your circuit are typically clarified in a doc-comment.
 - Conventional JS code such as `'hello world'.split('').join(' ')` that doesn't use SnarkyJS built-ins are not included in your zk proof in any way since it does add anything to your circuit.
   - Why? Because it doesn't call any of the functions that build the circuit.
   - There's nothing wrong with having non-circuit code inside your method, as long as you're aware of what it's (not) doing.
-- It's fine to use if-statements, for-loops, arrays, objects, and any other JS language constructs, to facilitate writing circuits. But beware: these flexible constructs don't allow you to overcome the static nature of circuits.
+- It's fine to use if-statements, for-loops, arrays, objects, and any other JS language constructs to facilitate writing circuits. But beware: these flexible constructs don't allow you to overcome the static nature of circuits.
 
 This example asserts that a Field element `x` is not equal to `5`, `10` or `15`:
 
@@ -42,4 +42,4 @@ The previous for-loop example just stitches together a fixed number of SnarkyJS 
 This example fails for two reasons:
 
 1. `n.toString()` can't be used in circuit code at all. It throws an error during `SmartContract.compile()` because during `compile()`, variables like `n` don't have any JS values attached to them; they represent abstract variables used to build up an abstract arithmetic circuit. So, in general, you can't use any of the methods that read out the JS value of your Field elements: `Field.toString()`, `Field.toBigInt()`, `Bool.toBoolean()` etc.
-2. More subtly, your methods must create the same constraints every time because a proof cannot be verified against a verification key for a differing set of constraints. The code above adds `x.equals(y).assertFalse()` _on condition of_ the value of `n`which leads to constraints varying between executions of the proof.
+2. More subtly, your methods must create the same constraints every time because a proof cannot be verified against a verification key for a differing set of constraints. The code above adds `x.equals(y).assertFalse()` _on condition of_ the value of `n` which leads to constraints varying between executions of the proof.

--- a/docs/zkapps/how-to-deploy-a-zkapp.mdx
+++ b/docs/zkapps/how-to-deploy-a-zkapp.mdx
@@ -13,8 +13,8 @@ Please note that zkApp programmability is not yet available on Mina Mainnet, but
 
 ## Add a deploy alias to config.json
 
-Before deploying, you must first define a few settings, such as which network you are deploying to. Create a "deploy alias" within your smart contract project's
-`config.json`.
+Before deploying, you must first define a few settings, such as which network you are deploying to. Create a "deploy alias" in the `config.json` file in your smart contract project.
+.
 
 First, change into the directory containing your smart contract and then run the
 following command:
@@ -27,19 +27,17 @@ When prompted, specify a name (can be anything), URL to deploy to, and fee (in
 MINA) to be used when sending your deploy transaction. The URL is the Mina GraphQL API
 that receives your deploy transaction and broadcasts it to the Mina network.
 Note that this URL is significant because it also determines which network you're
-be deploying to (e.g. QANet, Testnet, Mainnet, etc).
+be deploying to (for example, QANet, Testnet, or Mainnet).
 
-For Berkeley Testnet, use the following values:
+To deploy a zkApp to the Berkeley Testnet, use the following values:
 
 - **Name**: `berkeley`
 - **URL**: `https://proxy.berkeley.minaexplorer.com/graphql` or `https://berkeley.minascan.io/graphql`
 - **Fee**: `0.1`
 
 :::tip
-  If your project contains multiple smart contracts (e.g. `Foo` and `Bar`) that
-  you intend to deploy to the same network, a best practice is to follow a naming
-  pattern such as `berkeley-foo` and `berkeley-bar` when naming your deploy
-  aliases. You can change these alias names at anytime within `config.json`.
+If your project contains multiple smart contracts (for example, `Foo` and `Bar`) that
+you intend to deploy to the same network, use a naming pattern such as `berkeley-foo` and `berkeley-bar` when naming your deploy aliases. You can change these alias names at anytime in `config.json`.
 :::
 
 <br/>
@@ -69,7 +67,7 @@ Next steps:
 
 To deploy your zkApp, you must have funds to pay for transaction fees.
 
-To get funds on the Berkeley Testnet, use the URL that was shown from the CLI output. Visit `https://faucet.minaprotocol.com/?address=<YOUR-ADDRESS>` and click **Request**.
+To get funds on the Berkeley Testnet, use the URL that was shown from the zkApp CLI output. Visit `https://faucet.minaprotocol.com/?address=<YOUR-ADDRESS>` and click **Request**.
 
 Before proceeding to the next step, wait a few minutes for the next block to include your transaction, so tMINA is available.
 
@@ -83,7 +81,7 @@ zk deploy berkeley
 
 When running the deploy command, the zkApp CLI computes a verification key for your zkApp CLI. Computing the verification key can take 1-2 minutes, so please be patient. The zkApp CLI shows the details of the transaction, such as the network name, the URL, and the smart contract to deploy.
 
-Finally, enter `yes` or `y` when prompted, to confirm and send the transaction.
+Finally, enter `yes` or `y` when prompted to confirm and send the transaction.
 
 You see the following output:
 

--- a/docs/zkapps/how-to-deploy-a-zkapp.mdx
+++ b/docs/zkapps/how-to-deploy-a-zkapp.mdx
@@ -37,7 +37,7 @@ To deploy a zkApp to the Berkeley Testnet, use the following values:
 
 :::tip
 If your project contains multiple smart contracts (for example, `Foo` and `Bar`) that
-you intend to deploy to the same network, use a naming pattern such as `berkeley-foo` and `berkeley-bar` when naming your deploy aliases. You can change these alias names at anytime in `config.json`.
+you intend to deploy to the same network, a best practice is to follow a naming convention such as `berkeley-foo` and `berkeley-bar` when naming your deploy aliases. You can change these alias names at anytime in `config.json`.
 :::
 
 <br/>

--- a/docs/zkapps/how-to-test-a-zkapp.mdx
+++ b/docs/zkapps/how-to-test-a-zkapp.mdx
@@ -12,17 +12,23 @@ zkApps can now be deployed to Berkeley Testnet.
 
 # How to Test a zkApp
 
-Writing automated tests for your smart contract is of crucial importance. The <a href="https://jestjs.io/">Jest testing framework</a> is included in all projects created by the Mina zkApp CLI via `zk project <name>` and `zk example <name`. We recommend Jest, but any testing framework can be used.
+Writing automated tests for your smart contract is essential to ensure your code is well-tested during development. All projects created using the Mina zkApp CLI include the [Jest](https://jestjs.io/) JavaScript testing framework. Although you can use any testing framework, the instructions in this document are supported for Jest.
 
-## Running tests
+## Writing tests for your smart contract
 
-To run all test files within your project, run `npm run test` or `npm run testw` (for watch mode) from your project’s root directory.
+Use the Mina zkApp CLI to create tests for your smart contract.
 
-To generate a test coverage report for your project, run `npm run coverage`. Coverage reports show the % of your code that is tested. The result is output to your terminal. This can be helpful to ensure your code is well tested.
+To scaffold a TypeScript file with a corresponding test file, run:
 
-## Writing tests
+- `zk file foo`
 
-Creating tests for your smart contract is easy using the Mina zkApp CLI. To scaffold a TypeScript file with a corresponding test file, run the command `zk file foo` to generate two files named `foo.ts` and `foo.test.ts`. The `foo.test.ts` file is a great place to start writing all your smart contract test code. To write good unit tests, it's vital that you concretely understand the functionality your smart contract provides. An example is shown below of a basic test written in Jest:
+The `foo.ts` and `foo.test.ts` files are generated.
+
+The `foo.test.ts` file is a great place to start writing your smart contract test code. To write valid unit tests, be sure you understand your smart contract functionality.
+
+It's good practice to break down the functionality of your smart contract into `describe` blocks to organize your test groupings in the same file. By mapping out your unit tests using the `describe` convention, you provide documentation to developers who read your smart contract.
+
+The following example shows the describe block for `test` in the `foo.test.ts` file:
 
 ```ts
 describe('foo.test.ts', () => {
@@ -32,32 +38,54 @@ describe('foo.test.ts', () => {
 });
 ```
 
-Because we are using Jest, it's helpful to break down all functionality of your smart contract into `describe` blocks. Mapping out your unit tests like this is also a good way of providing documentation to other developers reading your smart contract. An excellent place to start testing your smart contract is in the areas your smart contract modifies its state. Make sure to verify that your state updates in the way you expect.
+Create `describe` blocks for all areas where your smart contract modifies its state so you can verify that your state updates as expected.
 
-For examples of existing tests, a best practice is to create a template example using the Mina zkApp CLI by using `zk project <name>` and examining the test file there. See a few [basic examples of tests](https://github.com/o1-labs/zkapp-cli/blob/main/templates/project-ts/src/Add.test.ts) that deploy and update the state on a smart contract using Jest.
+To generate existing tests, create a template example using the Mina zkApp CLI:
 
-#### Creating a local blockchain
+- `zk project <name>` 
+- `zk example <name` 
 
-It's helpful to run your smart contract locally on a mock blockchain to quickly test it.
-The `Mina.LocalBlockchain()` method specifies a mock Mina ledger of accounts that runs locally on your machine. It contains logic for updating the ledger that can be used to test your smart contract.
+Examine the generated test files. 
 
-:::tip
+For basic test examples that deploy and update the state on a smart contract using Jest, see the [Add.test.ts](https://github.com/o1-labs/zkapp-cli/blob/main/templates/project-ts/src/Add.test.ts) template.
 
-`Mina.LocalBlockchain()` takes an optional parameter `{ proofsEnabled: true }` with default value `true`, which lets you specify whether to generate and verify proofs.
-If you set `proofsEnabled: false`, the local instance behaves exactly the same as before, but it won't generate proofs or verify them.
-This can be very useful when you want to run tests in the CI or quickly debug your smart contract without having to wait for proofs to be generated.
+## Running tests
 
-You can also programmatically enable and disable the `proofsEnabled` flag within your test flow by calling `Local.setProofsEnabled(x: boolean)`.
-:::
+To run all test files in your project, run these commands from your project's root directory:
+
+- `npm run test` 
+- `npm run testw` for watchmode
+
+To generate a test coverage report for your project, run:
+
+- `npm run coverage`
+
+The code coverage result is output to your terminal and shows the percentage of tested code.
+
+### Creating a local blockchain
+
+You can quickly test your smart contract by running it locally on a mock blockchain.
+
+The `Mina.LocalBlockchain()` method specifies a mock Mina ledger of accounts and contains logic for updating the ledger that can be used to test your smart contract.
 
 ```ts
 let Local = Mina.LocalBlockchain();
 Mina.setActiveInstance(Local);
 ```
 
-#### Deploying a contract locally
+:::tip
 
-The mock Mina local blockchain contains test accounts that can be used to deploy smart contracts and pay transaction fees.
+To specify whether to generate and verify proofs, you can provide the optional `proofsEnabled` parameter to the `Mina.LocalBlockchain()` method:
+
+- `{ proofsEnabled: true }` - default value, the local instance generates and verifies proofs
+- `{ proofsEnabled: false }` - the local instance does not generate or verify proofs when you want to run tests in the CI or quickly debug your smart contract without waiting for proofs to be generated
+
+You can also programmatically enable and disable the `proofsEnabled` flag in your test flow by calling `Local.setProofsEnabled(x: boolean)`.
+:::
+
+### Deploying a contract locally
+
+The mock Mina local blockchain contains test accounts you can use to deploy smart contracts and pay transaction fees.
 
 First, access a test account provided by the local blockchain.
 
@@ -94,9 +122,11 @@ await txPromise.wait();
 
 ```
 
-#### Writing integration tests
+## Writing integration tests
 
-Jest can be used to write unit and integration tests. A well-written integration test verifies the flow of your smart contract's expected behavior and ensures the correctness of state updates. After you test the expected behavior, it's beneficial to verify the preconditions of your methods and test edge cases of your smart contract. This example is a basic integration test script.
+A well-written integration test verifies the flow of expected behavior for your smart contract and confirms the correctness of state updates. After you test the expected behavior, be sure to verify the preconditions of your methods and test the edge cases of your smart contract.
+
+The following example is a basic integration test script:
 
 ```ts
 describe('Add smart contract integration test', () => {
@@ -153,10 +183,8 @@ describe('Add smart contract integration test', () => {
 
 ## Learn more
 
-Please see the <a href="https://jestjs.io/docs/getting-started">Jest docs</a> for further information on how to use Jest.
-
-We will be adding blockchain-specific testing functionality in the future. Keep an eye on this section for updates.
+See the [Jest](https://jestjs.io/docs/getting-started) documentation.
 
 ## Next Steps
 
-Now that you've learn how to test a smart contract, you can now learn [how to deploy a zkApp](how-to-deploy-a-zkapp).
+Now that you know how to test a smart contract, you can learn [How to deploy a zkApp](/how-to-deploy-a-zkapp).

--- a/docs/zkapps/how-to-test-a-zkapp.mdx
+++ b/docs/zkapps/how-to-test-a-zkapp.mdx
@@ -12,7 +12,7 @@ zkApps can now be deployed to Berkeley Testnet.
 
 # How to Test a zkApp
 
-Writing automated tests for your smart contract is essential to ensure your code is well-tested during development. All projects created using the Mina zkApp CLI include the [Jest](https://jestjs.io/) JavaScript testing framework. Although you can use any testing framework, the instructions in this document are supported for Jest.
+Writing automated tests for your smart contract is essential to ensure your code is well tested during development. All projects created using the Mina zkApp CLI include the [Jest](https://jestjs.io/) JavaScript testing framework. Although you can use any testing framework, the instructions in this document are supported for Jest.
 
 ## Writing tests for your smart contract
 
@@ -38,16 +38,9 @@ describe('foo.test.ts', () => {
 });
 ```
 
-Create `describe` blocks for all areas where your smart contract modifies its state so you can verify that your state updates as expected.
+When you start testing with the Jest testing framework, it is helpful to create `describe` blocks for all areas where your smart contract modifies its state so you can verify that your state updates as expected.
 
-To generate existing tests, create a template example using the Mina zkApp CLI:
-
-- `zk project <name>` 
-- `zk example <name` 
-
-Examine the generated test files. 
-
-For basic test examples that deploy and update the state on a smart contract using Jest, see the [Add.test.ts](https://github.com/o1-labs/zkapp-cli/blob/main/templates/project-ts/src/Add.test.ts) template.
+For basic test examples that deploy and update the state on a smart contract using Jest, see the [Add.test.ts](https://github.com/o1-labs/zkapp-cli/blob/main/templates/project-ts/src/Add.test.ts) file. You can also find this file inside every new project that is created using `zk project <name>`.
 
 ## Running tests
 
@@ -69,7 +62,7 @@ You can quickly test your smart contract by running it locally on a mock blockch
 The `Mina.LocalBlockchain()` method specifies a mock Mina ledger of accounts and contains logic for updating the ledger that can be used to test your smart contract.
 
 ```ts
-let Local = Mina.LocalBlockchain();
+const Local = Mina.LocalBlockchain();
 Mina.setActiveInstance(Local);
 ```
 
@@ -187,4 +180,4 @@ See the [Jest](https://jestjs.io/docs/getting-started) documentation.
 
 ## Next Steps
 
-Now that you know how to test a smart contract, you can learn [How to deploy a zkApp](/how-to-deploy-a-zkapp).
+Now that you know how to test a smart contract, you can learn [How to deploy a zkApp](how-to-deploy-a-zkapp).

--- a/docs/zkapps/how-to-write-a-zkapp-ui.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp-ui.mdx
@@ -12,20 +12,19 @@ zkApps can now be deployed to Berkeley Testnet.
 
 # How to Write a zkApp UI
 
-To allow users to interact with your smart contract, you typically want to build a website UI.
+A zkApp consists of a smart contract and a UI to interact with it. To allow users to interact with your smart contract in a web browser, you typically want to build a website UI.
 
-This UI can be written with any framework (e.g. React, Vue, Svelte, etc.) or plain HTML and JavaScript.
+You can write the UI with any framework like React, Vue, or Svelte, or with plain HTML and JavaScript.
 
 ## Using one of the provided UI framework scaffolds
 
-When creating a new project with the zkApp CLI, you can directly choose a supported frameworks to be scaffolded as a part of your new zkApp project. For example, NuxtJS, Svelte Kit, and NextJS. 
+When you create a project using the zkApp CLI, you are prompted to choose a supported frameworks to be scaffolded as a part of your new zkApp project. For example, NuxtJS, Svelte Kit, and NextJS. 
 
 Adding the `--ui=<framework>` flag to the `zk project <myproj>` command: `zk project <myproj> --ui=<framework>`, where `<framework>` stands for a supported framework like `nuxt`, `svelte` and `next`.
 
 ## Adding your smart contract as a dependency of the UI
 
-To use one of the provided scaffolding options and add your smart contract to an existing frontend, a different UI framework or simply a plain HTML and JavaScript website, you can do so as well. 
-
+To use one of the provided scaffolding options and add your smart contract to an existing frontend, a different UI framework or simply a plain HTML and JavaScript website, you can do so as well.
 
 #### Setup
 


### PR DESCRIPTION
This PR includes technical clarity edits made during timeless doc checks for the zkApp content
For https://github.com/o1-labs/docs2/issues/287 

This PR is part 2 of the work for the [zkApp Developers](https://docs.minaprotocol.com/zkapps/tutorials/hello-world#) section of the docs.

I'll continue the next set of updates in a separate PR because I made substantial updates to improve the flow and quality of the https://docs.minaprotocol.com/zkapps/how-to-test-a-zkapp doc 
