### PR TITLE
 Docs do not use descriptive link text [Welcome & MINA sections]

### DIFF
--- a/docs/about-mina/consensus.mdx
+++ b/docs/about-mina/consensus.mdx
@@ -6,7 +6,7 @@ title: Consensus
 
 Mina Protocol uses a proof-of-stake consensus mechanism called **Ouroboros Samasika**. 
 
-Consensus is the process by which the network determines which information is retained in the blockchain. You can read about the difference between proof of stake (PoS) vs proof of work (PoW) consensus mechanisms in this blog post <a href="https://minaprotocol.com/blog/proof-of-work-vs-proof-of-stake">here</a>.
+Consensus is the process by which the network determines which information is retained in the blockchain. You can read about the difference between proof of stake (PoS) vs proof of work (PoW) consensus mechanisms in the [Proof-of-Work vs Proof-of-Stake](https://minaprotocol.com/blog/proof-of-work-vs-proof-of-stake) blog post.
 
 Learn more about how Ouroboros Samasika works in this video:
 
@@ -17,6 +17,6 @@ Based on Cardano’s PoS Ouroboros, Ouroboros Samisika is a secure PoS protocol 
 
 - Can resolve long-range forks without relying on third parties to provide history
 - **No staking minimum** — You can produce blocks and receive block rewards based on your % of the MINA staked on the network. Any user with any amount of MINA can receive these rewards.
-- **No slashing** — the protocol does not need explicit slashing, since the protocol already enforces the required level of correctness.
+- **No slashing** — The protocol does not need explicit slashing, since the protocol already enforces the required level of correctness.
 
-Learn about <a href="https://minaprotocol.com/blog/how-ouroboros-samasika-upholds-minas-goals-of-decentralization"> how Ouroboros Samasika upholds Mina’s goals of decentralization</a>.
+Learn about [how Ouroboros Samasika upholds Mina’s goals of decentralization](https://minaprotocol.com/blog/how-ouroboros-samasika-upholds-minas-goals-of-decentralization).

--- a/docs/about-mina/faq.mdx
+++ b/docs/about-mina/faq.mdx
@@ -31,6 +31,6 @@ The Mina node can run with an optional flag to make it an archive node. This mea
 
 ### What ZK proof system does Mina use?
 
-Mina Protocol uses a custom proof system called Kimchi, which was developed by [O(1) Labs](https://o1labs.org/), and is the only blockchain offering infinite recursion.
+Mina Protocol uses a custom proof system called Kimchi that was developed by [O(1) Labs](https://o1labs.org/). Mina is the only blockchain offering infinite recursion.
 
 Check out the [Mina Book](https://o1-labs.github.io/proof-systems/plonk/overview.html) to learn more about Kimchi and the cryptography powering Mina Protocol.

--- a/docs/about-mina/index.mdx
+++ b/docs/about-mina/index.mdx
@@ -1,12 +1,8 @@
 ---
-title: Overview
+title: About Mina
 ---
 
-# Overview
-
-### What is Mina?
-
-Mina is an L1 blockchain based on zero-knowledge proofs (“ZKP”) with smart contracts written in TypeScript. It is the first cryptocurrency protocol with a succinct blockchain (22KB).
+Mina is an L1 blockchain based on zero-knowledge proofs with smart contracts written in TypeScript. It is the first cryptocurrency protocol with a succinct blockchain (22KB).
 
 ### Why Mina?
 
@@ -22,20 +18,20 @@ Learn more about [Mina’s unique protocol architecture](about-mina/protocol-arc
 
 Mina’s unique characteristics are made possible using zero-knowledge proofs.
 
-Watch this [video to learn about zero-knowledge proofs](about-mina/what-are-zero-knowledge-proofs).
+Watch the [What are Zero-Knowledge Proofs?](about-mina/what-are-zero-knowledge-proofs) video to learn about zero-knowledge proofs.
 
 ### What are zkApps?
 
-Mina’s zero-knowledge smart contracts are referred to as “zkApps”. zkApps provide powerful and unique characteristics such as unlimited off-chain execution, privacy for private data inputs that are never seen by the blockchain, the ability to write smart contracts in TypeScript, & more.
+Mina’s zero-knowledge smart contracts are referred to as zkApps. zkApps provide powerful and unique characteristics such as unlimited off-chain execution, privacy for private data inputs that are never seen by the blockchain, the ability to write smart contracts in TypeScript, and more.
 
 Learn more about how [zkApps work](/zkapps).
 
 ### How does consensus work on Mina?
 
-The Mina network is secured by proof-of-stake (“PoS”) consensus called Ouroboros Samisika.
+The Mina network is secured by proof of stake (PoS) consensus called Ouroboros Samisika.
 
-Based on Cardano’s Ouroboros, Ouroboros Samisika is a PoS consensus mechanism that requires far less computing power than Bitcoin’s proof-of-work (“PoW”) protocol.
+Based on Cardano’s Ouroboros, Ouroboros Samisika is a PoS consensus mechanism that requires far less computing power than Bitcoin’s proof of work (PoW) protocol.
 
-With this model of consensus, you don't need expensive and energy consuming mining equipment to participate in consensus. By simply holding MINA in our wallet, we can choose to either stake it ourselves if running a block producing node, or we can delegate it to another node.
+With this model of consensus, you don't need expensive and energy consuming mining equipment to participate in consensus. By simply holding MINA in your wallet, you can choose to either stake it yourself if running a block producing node, or you can delegate it to another node.
 
-Read more about [Mina’s consensus mechanism](./about-mina/consensus).
+To learn more, see [Mina Consensus Mechanism](./about-mina/consensus).

--- a/docs/exchange-operators/faq.mdx
+++ b/docs/exchange-operators/faq.mdx
@@ -26,7 +26,7 @@ The latest third-party audit reports are publicly available here:
 
 :::note
 
-Any news and updates related to exchange listing shared by the Mina Foundation can be found on [www.minaprotocol.com](https://minaprotocol.com) or on the [official Twitter account](https://twitter.com/MinaProtocol). Mina Foundation can not individually answer any listing questions.
+Any news and updates related to exchange listings shared by the Mina Foundation is available on [www.minaprotocol.com](https://minaprotocol.com) or on the official [Mina Protocol](https://twitter.com/MinaProtocol) Twitter account. Mina Foundation cannot answer any listing questions.
 
 :::
 
@@ -40,13 +40,13 @@ You can learn more about Mina’s implementation of Rosetta here (coming soon).
 
 ### What if I have a question about Rosetta?
 
-You can post your questions in [Mina’s Github Discussions](https://github.com/MinaProtocol/mina/discussions).
+You can post your questions in GitHub [Mina Discussions](https://github.com/MinaProtocol/mina/discussions/9518).
 
 ## Accounts
 
 ### Is there an account creation fee?
 
-Yes, Mina Protocol charges a fee of 1 MINA when you create a new account. This fee helps protect the network from denial of service-type attacks and the amount may be reduced over time.
+Yes, Mina Protocol charges a fee of 1 MINA when you create an account. This fee helps protect the network from denial of service-type attacks and the amount may be reduced over time.
 
 ## Transactions
 

--- a/docs/participate/bugs-and-feature-requests.mdx
+++ b/docs/participate/bugs-and-feature-requests.mdx
@@ -11,19 +11,19 @@ If you notice a bug, issue, or missing feature, please follow the steps below:
 
 ### 1. Search existing issues
 
-Before making a report, first search through [existing issues](https://github.com/MinaProtocol/mina/issues) to see if something similar has been reported.
+Before making a report, first search through existing issues on the [Mina Protocol GitHub repository](https://github.com/MinaProtocol/mina/issues) to see if something similar has been reported.
 
 ### 2. Found a bug?
 
-If your issue is a bug, related to the Mina website, or you have feedback about user experience, you can report it on the [Mina Protocol repo on Github](https://github.com/MinaProtocol/mina/issues/new/choose).
+If your issue is a bug, related to the Mina website, or you have feedback about user experience, you can report a new issue on the [Mina Protocol GitHub repository](https://github.com/MinaProtocol/mina/issues/new/choose).
 
 ### 3. Found a vulnerability?
 
-If your issue is a vulnerability that may be putting other people’s funds at risk or related to the protocol infrastructure, please report the issue via Mina’s Bounty Program at [hackerone.com/o1-labs](https://hackerone.com/o1-labs).
+If your issue is a vulnerability that may be putting other people’s funds at risk or related to the protocol infrastructure, please report the issue by using Mina’s Bounty Program at [hackerone.com/o1-labs](https://hackerone.com/o1-labs).
 
 ### 4. Found an urgent issue?
 
-If your issue is time-sensitive that needs immediate attention, please send more details and your contact information to security@o1labs.org. A member of Mina’s engineering team will reach out promptly.
+If your issue is time-sensitive that needs immediate attention, please send more details and your contact information to security@o1labs.org. A member of the Mina engineering team will reach out promptly.
 
 :::note
 


### PR DESCRIPTION
Effective, [descriptive link text](https://developers.google.com/style/link-text) helps to improve accessibility and scannability for our users.

Our docs have many `click here` instances and do not provide the benefit of descriptive phrases that provide helpful context.

This issue applies only to these docs sections:

[Welcome](https://docs.minaprotocol.com/zkapps/tutorials/hello-world#)
[About MINA](https://docs.minaprotocol.com/zkapps/tutorials/hello-world#)
[Using MINA](https://docs.minaprotocol.com/zkapps/tutorials/hello-world#)

Work for issue #292 
Companion issue [#291](https://github.com/o1-labs/docs2/issues/291)

Excluded are the Node Operator-related sections, as these sections are undergoing improvement separately. We will also want to address tense in the content there eventually but now is not the time.