### PR TITLE
remove warning message and revert back to old way to sending back rew…

### DIFF
--- a/docs/node-operators/foundation-delegation-program.mdx
+++ b/docs/node-operators/foundation-delegation-program.mdx
@@ -136,18 +136,9 @@ See the following uptime leaderboards for the latest uptime performance scores:
 
 #### Payout Addresses
 
-You must send computed rewards as described below to a Mina Foundation address - however, beginning in Cycle 9, Mina Foundation changed the method of returning rewards to the Foundation.
+You must send computed rewards as described below to the same address that was delegated to you.
 
-Previously, Block Producers were asked to send rewards to the same address that delegated to them, however this is no longer the case.  In the new system, once a Block Producer is selected as one of the 240 to participate in the Delegation Program for an upcoming cycle, they will receive an email listing a specific wallet to send their rewards to.
-
-Each Block Producer will receive an individual email containing one wallet address, so all payments to that address throughout the cycle can be tracked specifically to that Block Producer.  The full list of all Block Producers and their corresponding return wallets will also be publicly available on Mina Foundation’s Github page.
-
-
-:::caution
-
-Please note that Block Producers, beginning in Cycle 9, should NOT be sending their rewards to the Mina Foundation wallet that is delegating to them.
-
-:::
+The full list of all Block Producers and their corresponding return wallets will also be publicly available on Mina Foundation’s Github page.
 
 #### Payout Frequency
 


### PR DESCRIPTION
Purpose of this PR: Originally, the foundation DP had a set up where bps need to send rewards back to a specific address. However, now, they are reverting back to the original set up where BPs send back to the address that was delegated to them.
