### PR TITLE
Fix newsletter footer form submission to properly submit email to MinaProtocol Newsletter

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,36 +1,33 @@
-import React from "react";
+import React from 'react';
 
-import styles from "./Button.module.scss";
+import styles from './Button.module.scss';
 
-type Color = "orange" | "teal" | "dark" | "custom";
+type Color = 'orange' | 'teal' | 'dark' | 'custom';
 
 interface Props {
   children: React.ReactNode;
-  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   color: Color;
-  customStyles?: any;
+  customStyles?: string;
+  type: string;
 }
 
-export const Button: React.FC<Props> = ({
-  children,
-  onClick,
-  color = "orange",
-  customStyles,
-}) => {
+export const Button: React.FC<Props> = (
+  props: React.ComponentPropsWithoutRef<'button'> & Props
+) => {
+  const { color, customStyles, ...rest } = props;
   let stylesColor = undefined;
-  if (color === "orange") {
+  if (color === 'orange') {
     stylesColor = styles.minaButtonOrange;
-  } else if (color === "teal") {
+  } else if (color === 'teal') {
     stylesColor = styles.minaButtonTeal;
-  } else if (color === "dark") {
+  } else if (color === 'dark') {
     stylesColor = styles.minaButtonDark;
-  } else if (color === "custom") {
+  } else if (color === 'custom' && customStyles) {
     stylesColor = customStyles;
   }
-
   return (
-    <button type="button" className={stylesColor} onClick={onClick}>
-      {children}
+    <button {...rest} className={stylesColor}>
+      {props.children}
     </button>
   );
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,12 @@
 export const SocialLinks = {
-  Github: "https://github.com/MinaProtocol/mina",
-  Twitter: "https://twitter.com/minaprotocol",
-  WeChat: "https://forums.minaprotocol.com/",
-  Youtube: "https://www.youtube.com/channel/UCWzKMFfIlMzHUXKSnYot5HA",
-  Facebook: "http://bit.ly/MinaProtocolFacebook",
-  Discord: "https://bit.ly/MinaDiscord",
-  Telegram: "http://bit.ly/MinaTelegram",
-  Support: "https://support.minaprotocol.com",
+  Github: 'https://github.com/MinaProtocol/mina',
+  Twitter: 'https://twitter.com/minaprotocol',
+  WeChat: 'https://forums.minaprotocol.com/',
+  Youtube: 'https://www.youtube.com/channel/UCWzKMFfIlMzHUXKSnYot5HA',
+  Facebook: 'http://bit.ly/MinaProtocolFacebook',
+  Discord: 'https://bit.ly/MinaDiscord',
+  Telegram: 'http://bit.ly/MinaTelegram',
+  Support: 'https://support.minaprotocol.com',
 };
+
+export const FormSubmitUrl = 'https://minaprotocol.com/docs-footer-subscribe';

--- a/src/theme/Footer/index.tsx
+++ b/src/theme/Footer/index.tsx
@@ -24,19 +24,19 @@ function Footer(): JSX.Element | null {
     if (!email) {
       return;
     }
-    let response = await fetch(FormSubmitUrl, {
+    const response = await fetch(FormSubmitUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
-      body: `email=${email}`,
+      body: `input_1=${email}`, // Seems like this is the input field name for the email field on minaprotocol.com
     });
-
     if (!response.ok) {
       console.error('Failed to submit form');
       return;
     }
     setIsSubmitted(true);
+    window.location.href = 'https://minaprotocol.com/newsletter-confirmation';
   };
 
   const renderForm = () => {

--- a/src/theme/Footer/index.tsx
+++ b/src/theme/Footer/index.tsx
@@ -1,31 +1,42 @@
-import React from "react";
+import React from 'react';
 
-import Button from "@site/src/components/common/Button";
-import Link from "@docusaurus/Link";
-import ArrowRightSmall from "@site/static/svg/common/arrow_right_small.svg";
+import Button from '@site/src/components/common/Button';
+import Link from '@docusaurus/Link';
+import ArrowRightSmall from '@site/static/svg/common/arrow_right_small.svg';
 
-import styles from "./Footer.module.scss";
-import { SocialLinks } from "@site/src/constants";
-import MinaLogo from "@site/static/svg/common/mina_logo.svg";
-import DiscordLogo from "@site/static/svg/socials/discord_24x24.svg";
-import TwitterLogo from "@site/static/svg/socials/twitter_24x24.svg";
-import FacebookLogo from "@site/static/svg/socials/facebook_24x24.svg";
-import TelegramLogo from "@site/static/svg/socials/telegram_24x24.svg";
-import WeChatLogo from "@site/static/svg/socials/wechat_24x24.svg";
-import YoutubeLogo from "@site/static/svg/socials/youtube_24x24.svg";
+import styles from './Footer.module.scss';
+import { SocialLinks } from '@site/src/constants';
+import MinaLogo from '@site/static/svg/common/mina_logo.svg';
+import DiscordLogo from '@site/static/svg/socials/discord_24x24.svg';
+import TwitterLogo from '@site/static/svg/socials/twitter_24x24.svg';
+import FacebookLogo from '@site/static/svg/socials/facebook_24x24.svg';
+import TelegramLogo from '@site/static/svg/socials/telegram_24x24.svg';
+import WeChatLogo from '@site/static/svg/socials/wechat_24x24.svg';
+import YoutubeLogo from '@site/static/svg/socials/youtube_24x24.svg';
+import { FormSubmitUrl } from '@site/src/constants';
 
 function Footer(): JSX.Element | null {
-  const [email, setEmail] = React.useState("");
+  const [email, setEmail] = React.useState('');
   const [isSubmitted, setIsSubmitted] = React.useState(false);
 
-  // TODO: add email to newsletter
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!email) {
       return;
     }
+    let response = await fetch(FormSubmitUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: `email=${email}`,
+    });
+
+    if (!response.ok) {
+      console.error('Failed to submit form');
+      return;
+    }
     setIsSubmitted(true);
-    // console.log(event, email);
   };
 
   const renderForm = () => {
@@ -34,19 +45,20 @@ function Footer(): JSX.Element | null {
     }
     return (
       <form
+        id="newletter_form"
         onSubmit={handleSubmit}
         className={styles.minaFooter_form__submitContainer}
       >
         <input
           value={email}
           onChange={(event) => setEmail(event.target.value)}
-          type="email"
+          type={isSubmitted ? 'hidden' : 'email'}
           name="email"
           id="email"
           placeholder="Enter Email"
           className={styles.minaFooter_form_input}
         />
-        <Button color="orange">
+        <Button type="submit" color="orange">
           <span>Submit</span>
           <ArrowRightSmall />
         </Button>


### PR DESCRIPTION
# Description

Updates the footer to handle the proper form submission.

## Quick Question
When submitting to the newsletter on the `minaprotocol.com` website, the passed-in form data is encoded as the following:

![image](https://user-images.githubusercontent.com/9512405/234132356-54ee8555-1ed3-45b3-af01-b13f3209f598.png)
The email is encoded as `input_1` for the React form submission as well.
https://github.com/o1-labs/docs2/pull/369/files#diff-f68519d7699db406dc369adc092d9efc0c065428f57c44b780f8378a5c19d163R32 . 

I am not sure if this will work as I cannot test locally since I run into CORS issues when submitting to the newsletter from localhost.