### PR TITLE
Add `ignore` flag to docs tutorial runner and add better error message

### DIFF
--- a/docs/zkapps/tutorials/01-hello-world.mdx
+++ b/docs/zkapps/tutorials/01-hello-world.mdx
@@ -9,13 +9,6 @@ sidebar_label: 'Tutorial 1: Hello World'
 Please note that zkApp programmability is not yet available on Mina Mainnet, but
 zkApps can now be deployed to Berkeley Testnet.
 
-```ts ignore
-const { privateKey: deployerKey, publicKey: deployerAccount } =
-  Local.testAccounts[0];
-const { privateKey: senderKey, publicKey: senderAccount } =
-  Local.testAccounts[1];
-```
-
 :::
 
 :::note

--- a/docs/zkapps/tutorials/01-hello-world.mdx
+++ b/docs/zkapps/tutorials/01-hello-world.mdx
@@ -9,6 +9,13 @@ sidebar_label: 'Tutorial 1: Hello World'
 Please note that zkApp programmability is not yet available on Mina Mainnet, but
 zkApps can now be deployed to Berkeley Testnet.
 
+```ts ignore
+const { privateKey: deployerKey, publicKey: deployerAccount } =
+  Local.testAccounts[0];
+const { privateKey: senderKey, publicKey: senderAccount } =
+  Local.testAccounts[1];
+```
+
 :::
 
 :::note

--- a/scripts/tutorial-runner.ts
+++ b/scripts/tutorial-runner.ts
@@ -118,7 +118,7 @@ function regexMatchToCodeBlock(match: RegExpMatchArray): CodeBlock {
 
       return { lang, startLineNum, filePath, codeLines };
     } else {
-      throw 'Code blocks describing file modifications must include a file path in their info string';
+      throw `Code blocks describing file modifications must include a file path in their info string. InfoString: '${infoString}', Code: '${code}'`;
     }
   } else if (lang === 'sh') {
     const extractCommands = (shellCode: string[]): string[] =>

--- a/scripts/tutorial-runner.ts
+++ b/scripts/tutorial-runner.ts
@@ -91,6 +91,14 @@ function regexMatchToCodeBlock(match: RegExpMatchArray): CodeBlock {
   if (lang === 'ts') {
     const filePath: string | undefined = infoStringSegments[1];
 
+    // If the code block is tagged with 'ignore', it's meant to be ignored by the tutorial runner.
+    if (filePath === 'ignore') {
+      return {
+        lang: 'sh',
+        commands: [],
+      };
+    }
+
     if (filePath) {
       const getLineNum = (codeLineWithNum: string): number =>
         parseInt(codeLineWithNum.match(/\d+/)[0]);


### PR DESCRIPTION
# Description
If we use a generic TypeScript code block with a ts annotation, the tutorial checker expects a file path to verify if the code is valid TypeScript. However, sometimes we only want to show generic TypeScript code blocks as examples of using an API. In this case, the tutorial runner will detect the TypeScript code block and produce an error because it expects a file path.

In this update, we add an ignore flag that can be used when we want to include generic TypeScript code blocks in tutorials without causing errors. We also improve the error messages to help identify which code block is causing the problem.