### PR TITLE
Fix SnarkyJS API Reference Github Action

### DIFF
--- a/.github/workflows/snarkyjs-api-reference.yml
+++ b/.github/workflows/snarkyjs-api-reference.yml
@@ -28,7 +28,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Install dependencies and build SnarkyJS
-          cd snarkyjs && npm ci && npm run build
+          cd snarkyjs
+          git submodule update --init --recursive
+          npm ci && npm run build
           cd src/mina-signer && npm ci && npm run build && cd ../../
 
           # Install markdown-plugin for typedoc and build the SnarkyJS API reference


### PR DESCRIPTION
# Description
Fixes the Github Action that generates the API reference docs for SnarkyJS. The change was to add a step to update any git submodules before attempting to build SnarkyJS.