### PR TITLE
Improve docs metadata

### DIFF
--- a/docs/zkapps/advanced-snarkyjs/actions-and-reducer.mdx
+++ b/docs/zkapps/advanced-snarkyjs/actions-and-reducer.mdx
@@ -1,6 +1,16 @@
 ---
 title: Actions & Reducer
 hide_title: true
+description: Deep dive into actions and reducers used in smart contract development. Explore how they enable concurrent state updates and act as an off-chain storage layer in zkApps.
+keywords:
+  - smart contracts
+  - actions
+  - reducers
+  - zkapps
+  - snarkyjs
+  - blockchain development
+  - concurrent state updates
+  - off-chain storage
 ---
 
 :::info

--- a/docs/zkapps/advanced-snarkyjs/custom-tokens.mdx
+++ b/docs/zkapps/advanced-snarkyjs/custom-tokens.mdx
@@ -1,6 +1,17 @@
 ---
 title: Custom Tokens
 hide_title: true
+description: Learn how to use SnarkyJS for common token operations like minting, burning, and sending tokens. Understand the concepts of Token ID, Token Accounts, and Token Owners in the context of custom tokens.
+keywords:
+  - custom tokens
+  - snarkyjs
+  - token operations
+  - minting tokens
+  - burning tokens
+  - sending tokens
+  - token id
+  - token accounts
+  - token owner
 ---
 
 :::info

--- a/docs/zkapps/advanced-snarkyjs/events.mdx
+++ b/docs/zkapps/advanced-snarkyjs/events.mdx
@@ -1,6 +1,18 @@
 ---
 title: Events
 hide_title: true
+description: Learn about events in zkApps, how they serve as a light-weight way of attaching information about your smart contract execution. It also covers the use cases of events, how to declare and emit them.
+keywords:
+  - smart contracts
+  - zkapp
+  - events
+  - merkle tree
+  - emit event
+  - snarkyjs
+  - blockchain
+  - mina
+  - archive nodes
+  - transaction
 ---
 
 :::info

--- a/docs/zkapps/advanced-snarkyjs/fetch-events-and-actions.mdx
+++ b/docs/zkapps/advanced-snarkyjs/fetch-events-and-actions.mdx
@@ -1,5 +1,17 @@
 ---
 title: How to Fetch Events and Actions
+description: A guide on how to retrieve previously emitted events and actions from Mina Archive Node using SnarkyJS. Learn the steps to connect your zkApp smart contract to an Archive Node API endpoint and fetch and use events and actions.
+keywords:
+  - mina archive node
+  - snarkyjs
+  - fetch events
+  - fetch actions
+  - smart contracts
+  - zkapp
+  - archive node api
+  - graphql api
+  - minascan
+  - blockchain
 ---
 
 :::info

--- a/docs/zkapps/advanced-snarkyjs/merkle-tree.mdx
+++ b/docs/zkapps/advanced-snarkyjs/merkle-tree.mdx
@@ -1,7 +1,7 @@
 ---
 title: Merkle Tree
 hide_title: true
-description: A comprehensive guide on how to use Merkle Trees to reference off-chain data in zkApps on Mina. Understand its algorithm, implementation, and significance in managing large data.
+description: A comprehensive guide on how to use Merkle Trees to reference off-chain data in zkApps on Mina. Understand the Merkle Tree algorithm, implementation, and significance in managing large data.
 keywords:
   - merkle tree
   - zkapps

--- a/docs/zkapps/advanced-snarkyjs/merkle-tree.mdx
+++ b/docs/zkapps/advanced-snarkyjs/merkle-tree.mdx
@@ -1,6 +1,14 @@
 ---
 title: Merkle Tree
 hide_title: true
+description: A comprehensive guide on how to use Merkle Trees to reference off-chain data in zkApps on Mina. Understand its algorithm, implementation, and significance in managing large data.
+keywords:
+  - merkle tree
+  - zkapps
+  - mina blockchain
+  - off-chain data
+  - blockchain technology
+  - data structures
 ---
 
 :::info

--- a/docs/zkapps/advanced-snarkyjs/on-chain-values.mdx
+++ b/docs/zkapps/advanced-snarkyjs/on-chain-values.mdx
@@ -1,6 +1,16 @@
 ---
 title: On-Chain Values
 hide_title: true
+description: Learn about accessing and manipulating on-chain values in a zkApp, including network and account-level data. Understand potential use cases such as timestamp restrictions, on-chain balances, and account properties.
+keywords:
+  - on-chain values
+  - zkapp
+  - smart contract
+  - mina protocol
+  - blockchain
+  - defi
+  - zkapp account
+  - network state
 ---
 
 :::info

--- a/docs/zkapps/advanced-snarkyjs/permissions.mdx
+++ b/docs/zkapps/advanced-snarkyjs/permissions.mdx
@@ -1,6 +1,18 @@
 ---
 title: Permissions
 hide_title: true
+description: Detailed guide on permissions in zkApp development including types of permissions, authorization, default permissions, and real-world examples.
+keywords:
+  - permissions
+  - zkapp development
+  - smart contracts
+  - mina
+  - smart contract security
+  - smart contract upgradeability
+  - snarkyjs
+  - mina transaction
+  - blockchain
+  - authorization
 ---
 
 :::info

--- a/docs/zkapps/advanced-snarkyjs/recursion.mdx
+++ b/docs/zkapps/advanced-snarkyjs/recursion.mdx
@@ -1,6 +1,17 @@
 ---
 title: Recursion
 hide_title: true
+description: An in-depth look at using recursion and recursive proofs in SnarkyJS to create efficient, infinitely growing structures for applications like Mina. Learn how to use SnarkyJS for constructing and verifying simple and complex recursive programs in your zkApp.
+keywords:
+  - recursion
+  - snarkyjs
+  - zero-knowledge proofs
+  - mina blockchain
+  - smart contract
+  - zkapp
+  - recursive proofs
+  - proof systems
+  - blockchain compression
 ---
 
 :::info

--- a/docs/zkapps/advanced-snarkyjs/time-locked-accounts.mdx
+++ b/docs/zkapps/advanced-snarkyjs/time-locked-accounts.mdx
@@ -1,7 +1,7 @@
 ---
 title: Time-Locked Accounts
 hide_title: true
-description: This guide dives into the feature of time-locking in Mina, explaining how you can use it to implement vesting schedules. It further provides practical examples of setting up a time-lock for MINA tokens using SnarkyJS.
+description: This guide dives into the feature of time-locking in Mina to implement vesting schedules and practical examples of setting up a time-lock for MINA tokens using SnarkyJS.
 keywords:
   - time-locked accounts
   - mina blockchain

--- a/docs/zkapps/advanced-snarkyjs/time-locked-accounts.mdx
+++ b/docs/zkapps/advanced-snarkyjs/time-locked-accounts.mdx
@@ -1,6 +1,15 @@
 ---
 title: Time-Locked Accounts
 hide_title: true
+description: This guide dives into the feature of time-locking in Mina, explaining how you can use it to implement vesting schedules. It further provides practical examples of setting up a time-lock for MINA tokens using SnarkyJS.
+keywords:
+  - time-locked accounts
+  - mina blockchain
+  - vesting schedules
+  - snarkyjs
+  - mina tokens
+  - zkapp
+  - account timing
 ---
 
 :::info

--- a/docs/zkapps/faq.mdx
+++ b/docs/zkapps/faq.mdx
@@ -7,7 +7,6 @@ keywords:
   - zk circuits
   - smart contract
   - proof generation
-image: TODO
 ---
 
 ## Does SnarkyJS compile my JavaScript code to an arithmetic circuit?

--- a/docs/zkapps/faq.mdx
+++ b/docs/zkapps/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: FAQ
-description: This FAQ addresses common questions about SnarkyJS, a library that creates zk circuits from user code. Learn about the use of built-in SnarkyJS datatypes, functions, and the implications for proof generation.
+description: Answers to common questions about SnarkyJS, a library that creates zk circuits from user code. Learn about the use of built-in SnarkyJS datatypes, functions, and the implications for proof generation.
 keywords:
   - SnarkyJS
   - FAQ

--- a/docs/zkapps/faq.mdx
+++ b/docs/zkapps/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: FAQ
-description: 'This FAQ addresses common questions about SnarkyJS, a library that creates zk circuits from user code. Learn about the use of built-in SnarkyJS datatypes, functions, and the implications for proof generation.'
+description: This FAQ addresses common questions about SnarkyJS, a library that creates zk circuits from user code. Learn about the use of built-in SnarkyJS datatypes, functions, and the implications for proof generation.
 keywords:
   - SnarkyJS
   - FAQ

--- a/docs/zkapps/faq.mdx
+++ b/docs/zkapps/faq.mdx
@@ -1,5 +1,13 @@
 ---
 title: FAQ
+description: 'This FAQ addresses common questions about SnarkyJS, a library that creates zk circuits from user code. Learn about the use of built-in SnarkyJS datatypes, functions, and the implications for proof generation.'
+keywords:
+  - SnarkyJS
+  - FAQ
+  - zk circuits
+  - smart contract
+  - proof generation
+image: TODO
 ---
 
 ## Does SnarkyJS compile my JavaScript code to an arithmetic circuit?

--- a/docs/zkapps/faq.mdx
+++ b/docs/zkapps/faq.mdx
@@ -1,5 +1,6 @@
 ---
-title: FAQ
+title: SnarkyJS FAQ
+sidebar_label: FAQ
 description: Answers to common questions about SnarkyJS, a library that creates zk circuits from user code. Learn about the use of built-in SnarkyJS datatypes, functions, and the implications for proof generation.
 keywords:
   - SnarkyJS

--- a/docs/zkapps/how-to-deploy-a-zkapp.mdx
+++ b/docs/zkapps/how-to-deploy-a-zkapp.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to Deploy a zkApp
 hide_title: true
-description: A step-by-step guide on how to deploy a zkApp to the Berkeley Testnet. The guide covers configuring your smart contract project, requesting funds from the faucet, and deploying your smart contract.
+description: Guided steps to deploy a zkApp to the Berkeley Testnet to configure your smart contract project, request funds from the faucet, and deploy your smart contract.
 keywords:
   - zkApp
   - deploy a smart contact

--- a/docs/zkapps/how-to-deploy-a-zkapp.mdx
+++ b/docs/zkapps/how-to-deploy-a-zkapp.mdx
@@ -4,10 +4,9 @@ hide_title: true
 description: A step-by-step guide on how to deploy a zkApp to the Berkeley Testnet. The guide covers configuring your smart contract project, requesting funds from the faucet, and deploying your smart contract.
 keywords:
   - zkApp
-  - Deployment
-  - Berkeley Testnet
-  - Smart contract
-  - Configuration
+  - deploy a smart contact
+  - smart contract
+  - configure a zkapp
 image: TODO
 ---
 

--- a/docs/zkapps/how-to-deploy-a-zkapp.mdx
+++ b/docs/zkapps/how-to-deploy-a-zkapp.mdx
@@ -1,6 +1,14 @@
 ---
 title: How to Deploy a zkApp
 hide_title: true
+description: A step-by-step guide on how to deploy a zkApp to the Berkeley Testnet. The guide covers configuring your smart contract project, requesting funds from the faucet, and deploying your smart contract.
+keywords:
+  - zkApp
+  - Deployment
+  - Berkeley Testnet
+  - Smart contract
+  - Configuration
+image: TODO
 ---
 
 :::info

--- a/docs/zkapps/how-to-deploy-a-zkapp.mdx
+++ b/docs/zkapps/how-to-deploy-a-zkapp.mdx
@@ -7,7 +7,6 @@ keywords:
   - deploy a smart contact
   - smart contract
   - configure a zkapp
-image: TODO
 ---
 
 :::info

--- a/docs/zkapps/how-to-test-a-zkapp.mdx
+++ b/docs/zkapps/how-to-test-a-zkapp.mdx
@@ -4,7 +4,7 @@ hide_title: true
 description: This guide provides a detailed walkthrough on how to write and run tests for your zkApp using the Jest JavaScript testing framework. It includes creating tests for your smart contract, running tests, creating a local blockchain, deploying a contract locally, and writing integration tests.
 keywords:
   - zkApp
-  - Testing
+  - test a zkapp
   - Smart contract
   - Jest
   - Local blockchain

--- a/docs/zkapps/how-to-test-a-zkapp.mdx
+++ b/docs/zkapps/how-to-test-a-zkapp.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to Test a zkApp
 hide_title: true
-description: This guide provides a detailed walkthrough on how to write and run tests for your zkApp using the Jest JavaScript testing framework. It includes creating tests for your smart contract, running tests, creating a local blockchain, deploying a contract locally, and writing integration tests.
+description: Guided steps to write and run tests for your zkApp using the Jest JavaScript testing framework, create and run tests, create a local blockchain, deploy a contract locally, and write integration tests.
 keywords:
   - zkApp
   - test a zkapp

--- a/docs/zkapps/how-to-test-a-zkapp.mdx
+++ b/docs/zkapps/how-to-test-a-zkapp.mdx
@@ -1,6 +1,13 @@
 ---
 title: How to Test a zkApp
 hide_title: true
+description: This guide provides a detailed walkthrough on how to write and run tests for your zkApp using the Jest JavaScript testing framework. It includes creating tests for your smart contract, running tests, creating a local blockchain, deploying a contract locally, and writing integration tests.
+keywords:
+  - zkApp
+  - Testing
+  - Smart contract
+  - Jest
+  - Local blockchain
 ---
 
 :::info

--- a/docs/zkapps/how-to-write-a-zkapp-ui.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp-ui.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to Write a zkApp UI
 hide_title: true
-description: This guide outlines how to write a user interface for a zkApp, which includes a smart contract and a UI to interact with it. It covers
+description: Guides steps to write a user interface for a zkApp that includes a smart contract and a UI to interact with it.
 keywords:
   - zkApp
   - UI

--- a/docs/zkapps/how-to-write-a-zkapp-ui.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp-ui.mdx
@@ -1,6 +1,16 @@
 ---
 title: How to Write a zkApp UI
 hide_title: true
+description: This guide outlines how to write a user interface for a zkApp, which includes a smart contract and a UI to interact with it. It covers
+keywords:
+  - zkApp
+  - UI
+  - smart contract
+  - npm
+  - COOP
+  - COEP
+  - wallet
+  - Auro Wallet
 ---
 
 :::info

--- a/docs/zkapps/how-to-write-a-zkapp.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to Write a zkApp
 hide_title: true
-description: A comprehensive guide on writing a zkApp which includes smart contracts and a UI for interacting with them. This guide will walk you through the process from installation to creating smart contracts with SnarkyJS for Mina Protocol.
+description: Guided steps to write a zkApp that includes a smart contract and a UI. Create a smart contract with SnarkyJS for Mina Protocol.
 keywords:
   - zkApp
   - smart contract

--- a/docs/zkapps/how-to-write-a-zkapp.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp.mdx
@@ -1,6 +1,14 @@
 ---
 title: How to Write a zkApp
 hide_title: true
+description: A comprehensive guide on writing a zkApp which includes smart contracts and a UI for interacting with them. This guide will walk you through the process from installation to creating smart contracts with SnarkyJS for Mina Protocol.
+keywords:
+  - zkApp
+  - smart contract
+  - typescript
+  - snarkyjs
+  - mina protocol
+  - zero knowledge proofs
 ---
 
 :::info

--- a/docs/zkapps/how-zkapps-work.mdx
+++ b/docs/zkapps/how-zkapps-work.mdx
@@ -1,7 +1,7 @@
 ---
 title: How zkApps Work
 hide_title: true
-description: Provides an in-depth explanation of how zkApps work, including their structure, the principles of zero-knowledge based smart contracts, the prover and verifier functions, the deployment and interaction processes, and the state management on-chain and off-chain.
+description: In-depth explanation of how zkApps work. The structure of a zkApp, zero knowledge (zk) principles, zero knowledge-based smart contracts, prover function, verifier function, how to deploy and interact with a zkApp, and on-chain and off-chain state management.
 keywords:
   - zkApps
   - smart contracts

--- a/docs/zkapps/how-zkapps-work.mdx
+++ b/docs/zkapps/how-zkapps-work.mdx
@@ -1,6 +1,17 @@
 ---
 title: How zkApps Work
 hide_title: true
+description: Provides an in-depth explanation of how zkApps work, including their structure, the principles of zero-knowledge based smart contracts, the prover and verifier functions, the deployment and interaction processes, and the state management on-chain and off-chain.
+keywords:
+  - zkApps
+  - smart contracts
+  - zero-knowledge proofs
+  - prover function
+  - verifier function
+  - mina network
+  - zkApp account
+  - on-chain state
+  - off-chain state
 ---
 
 :::info

--- a/docs/zkapps/index.mdx
+++ b/docs/zkapps/index.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: zkApp Overview
+sidebar_label: Overview
 hide_title: true
 description: Get an understanding of zkApps, the smart contracts of Mina Protocol. zkApps are powered by zero knowledge proofs and off-chain execution. A quickstart guide to deploy zkApps and resources for learning TypeScript.
 keywords:

--- a/docs/zkapps/index.mdx
+++ b/docs/zkapps/index.mdx
@@ -1,6 +1,15 @@
 ---
 title: Overview
 hide_title: true
+description: Get an understanding of zkApps, the smart contracts of Mina Protocol, powered by zero-knowledge proofs and off-chain execution. The page also provides a quickstart guide for deploying zkApps and additional resources for learning TypeScript.
+keywords:
+  - zkapps
+  - mina protocol
+  - smart contracts
+  - zero-knowledge proofs
+  - off-chain execution
+  - typescript
+  - quickstart zkapps
 ---
 
 :::info

--- a/docs/zkapps/index.mdx
+++ b/docs/zkapps/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Overview
 hide_title: true
-description: Get an understanding of zkApps, the smart contracts of Mina Protocol, powered by zero-knowledge proofs and off-chain execution. The page also provides a quickstart guide for deploying zkApps and additional resources for learning TypeScript.
+description: Get an understanding of zkApps, the smart contracts of Mina Protocol. zkApps are powered by zero knowledge proofs and off-chain execution. A quickstart guide to deploy zkApps and resources for learning TypeScript.
 keywords:
   - zkapps
   - mina protocol

--- a/docs/zkapps/roadmap.mdx
+++ b/docs/zkapps/roadmap.mdx
@@ -2,6 +2,16 @@
 title: zkApps Roadmap
 hide_title: true
 sidebar_label: Roadmap
+description: Explore the zkApps roadmap detailing available features, upcoming enhancements, and future developments. This page provides insights on Mina zkApp CLI, SnarkyJS, data availability, and more.
+keywords:
+	- zkapps
+	- mina protocol
+	- roadmap
+	- snarkyjs
+	- zkapps development
+	- zkapps features
+	- smart contracts
+	- zero-knowledge proofs
 ---
 
 import Subhead from '@site/src/components/common/Subhead';

--- a/docs/zkapps/roadmap.mdx
+++ b/docs/zkapps/roadmap.mdx
@@ -2,7 +2,7 @@
 title: zkApps Roadmap
 hide_title: true
 sidebar_label: Roadmap
-description: Explore the zkApps roadmap detailing available features, upcoming enhancements, and future developments. This page provides insights on Mina zkApp CLI, SnarkyJS, data availability, and more.
+description: zkApps roadmap, zkApp features, enhancements, and future development plans. Insights on Mina zkApp CLI, SnarkyJS, data availability, and more.
 keywords:
   - zkapps
   - mina protocol

--- a/docs/zkapps/roadmap.mdx
+++ b/docs/zkapps/roadmap.mdx
@@ -4,14 +4,14 @@ hide_title: true
 sidebar_label: Roadmap
 description: Explore the zkApps roadmap detailing available features, upcoming enhancements, and future developments. This page provides insights on Mina zkApp CLI, SnarkyJS, data availability, and more.
 keywords:
-	- zkapps
-	- mina protocol
-	- roadmap
-	- snarkyjs
-	- zkapps development
-	- zkapps features
-	- smart contracts
-	- zero-knowledge proofs
+  - zkapps
+  - mina protocol
+  - roadmap
+  - snarkyjs
+  - zkapps development
+  - zkapps features
+  - smart contracts
+  - zero-knowledge proofs
 ---
 
 import Subhead from '@site/src/components/common/Subhead';

--- a/docs/zkapps/zkapps-for-ethereum-developers.mdx
+++ b/docs/zkapps/zkapps-for-ethereum-developers.mdx
@@ -1,7 +1,7 @@
 ---
 title: zkApps for Ethereum Developers
 hide_title: true
-description: Provides a comprehensive comparison between zkApps and Ethereum smart contracts, discussing differences in language, execution environment, transaction cost, application storage, developer tooling, scaling, and consensus.
+description: How zkApps and Ethereum smart contracts compare, differences in language, execution environment, transaction costs, application storage, developer tooling, scaling, and consensus.
 keywords:
   - ethereum
   - mina protocol

--- a/docs/zkapps/zkapps-for-ethereum-developers.mdx
+++ b/docs/zkapps/zkapps-for-ethereum-developers.mdx
@@ -1,6 +1,18 @@
 ---
 title: zkApps for Ethereum Developers
 hide_title: true
+description: Provides a comprehensive comparison between zkApps and Ethereum smart contracts, discussing differences in language, execution environment, transaction cost, application storage, developer tooling, scaling, and consensus.
+keywords:
+  - ethereum
+  - mina protocol
+  - zkapps
+  - smart contracts
+  - snarkyjs
+  - typescript
+  - blockchain
+  - scalability
+  - privacy
+  - decentralization
 ---
 
 :::info

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -270,11 +270,23 @@ module.exports = {
         },
         {
           name: 'image',
-          content: '/svg/common/mina_logo.svg',
+          property: 'image',
+          content: 'https://docs.minaprotocol.com/svg/common/mina_logo.svg',
         },
         {
           name: 'og:image',
-          content: '/svg/common/mina_logo.svg',
+          property: 'og:image',
+          content: 'https://docs.minaprotocol.com/svg/common/mina_logo.svg',
+        },
+        {
+          name: 'twitter:image',
+          property: 'twitter:image',
+          content: 'https://docs.minaprotocol.com/svg/common/mina_logo.svg',
+        },
+        { name: 'twitter:title', content: 'Mina Documentation' },
+        {
+          name: 'twitter:description',
+          content: 'Website for documentation about Mina Protocol',
         },
       ],
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -262,6 +262,14 @@ module.exports = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      metadata: [
+        {
+          name: 'keywords',
+          content:
+            'Snarkyjs, ZkApps, Zero Knowledge Proofs, Zkp, Smart Contracts',
+        },
+      ],
+
       navbar: {
         logo: {
           alt: 'Mina Logo',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -268,6 +268,14 @@ module.exports = {
           content:
             'Snarkyjs, ZkApps, Zero Knowledge Proofs, Zkp, Smart Contracts',
         },
+        {
+          name: 'image',
+          content: '/svg/common/mina_logo.svg',
+        },
+        {
+          name: 'og:image',
+          content: '/svg/common/mina_logo.svg',
+        },
       ],
 
       navbar: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -271,17 +271,17 @@ module.exports = {
         {
           name: 'image',
           property: 'image',
-          content: 'https://docs.minaprotocol.com/svg/common/mina_logo.svg',
+          content: 'https://docs.minaprotocol.com/img/common/mina-logo.png',
         },
         {
           name: 'og:image',
           property: 'og:image',
-          content: 'https://docs.minaprotocol.com/svg/common/mina_logo.svg',
+          content: 'https://docs.minaprotocol.com/img/common/mina-logo.png',
         },
         {
           name: 'twitter:image',
           property: 'twitter:image',
-          content: 'https://docs.minaprotocol.com/svg/common/mina_logo.svg',
+          content: 'https://docs.minaprotocol.com/img/common/mina-logo.png',
         },
         { name: 'twitter:title', content: 'Mina Documentation' },
         {


### PR DESCRIPTION
# Description

This Pull Request is targeted towards enhancing the metadata for each documentation page to boost SEO and provide more informative link previews.

To achieve this, we propose two strategies:

1. Implementation of a global metatag applicable to all pages in `docusaurus.config.js`. This metatag should be as universal as possible.
2. Adapting the frontmatter of individual pages to integrate metadata that is more page-specific.

Our plan for updating the frontmatter of each page involves incorporating the following fields:

```yaml
---
title
description
keywords:
  - entry1
  - entry2
---
```

Including `title`, `description`, and `keywords` will significantly enhance the quality of link previews. Moreover, it will also contribute to improving our SEO!

Related issue: :link: https://github.com/o1-labs/docs2/issues/360

# Link Previews
As a comparison of link previews, this is the current information using https://opengraph.dev/

## Before
![image](https://github.com/o1-labs/docs2/assets/9512405/b8b7daa1-b750-410d-aa62-12e86fa24e42)

## After
![image](https://github.com/o1-labs/docs2/assets/9512405/39fb1500-7f87-4b2e-8beb-b9f057300ece)