### PR TITLE
style(reset_docusaurus.scss): add paragraph mixin to list items for markdown container

### DIFF
--- a/src/scss/base/_reset_docusaurus.scss
+++ b/src/scss/base/_reset_docusaurus.scss
@@ -34,6 +34,10 @@ We must use `!important` at times to override some default styles.
     @include mixins.minaHeader1;
   }
 
+  & li {
+    @include mixins.minaParagraph;
+  }
+
   & a {
     color: variables.$mina-orange;
   }


### PR DESCRIPTION
now the list items are the same size as the text, thank you @MartinMinkov  for the quick response 
<img width="547" alt="image" src="https://github.com/o1-labs/docs2/assets/10067215/ce59d5b2-5c29-4df2-87bc-8f344154481d">
 