### PR TITLE
revise zkapp not yet here statement for clarity

### DIFF
--- a/docs/zkapps/how-to-test-a-zkapp.mdx
+++ b/docs/zkapps/how-to-test-a-zkapp.mdx
@@ -12,8 +12,7 @@ keywords:
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/how-to-write-a-zkapp-ui.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp-ui.mdx
@@ -15,8 +15,7 @@ keywords:
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/how-to-write-a-zkapp.mdx
+++ b/docs/zkapps/how-to-write-a-zkapp.mdx
@@ -13,8 +13,7 @@ keywords:
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/how-zkapps-work.mdx
+++ b/docs/zkapps/how-zkapps-work.mdx
@@ -16,8 +16,7 @@ keywords:
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/index.mdx
+++ b/docs/zkapps/index.mdx
@@ -15,8 +15,7 @@ keywords:
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/roadmap.mdx
+++ b/docs/zkapps/roadmap.mdx
@@ -18,8 +18,7 @@ import Subhead from '@site/src/components/common/Subhead';
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/snarkyjs/basic-concepts.md
+++ b/docs/zkapps/snarkyjs/basic-concepts.md
@@ -5,8 +5,7 @@ hide_title: true
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/snarkyjs/index.md
+++ b/docs/zkapps/snarkyjs/index.md
@@ -6,9 +6,7 @@ description: SnarkyJS is a general-purpose zk framework that gives you the tools
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
-
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 :::
 
 # SnarkyJS

--- a/docs/zkapps/snarkyjs/interact-with-mina.md
+++ b/docs/zkapps/snarkyjs/interact-with-mina.md
@@ -5,8 +5,7 @@ hide_title: true
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/snarkyjs/permissions.mdx
+++ b/docs/zkapps/snarkyjs/permissions.mdx
@@ -17,8 +17,7 @@ keywords:
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/snarkyjs/recursion.mdx
+++ b/docs/zkapps/snarkyjs/recursion.mdx
@@ -16,14 +16,13 @@ keywords:
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
+
+:::
 
 Experimental. This API may change.
 
 Specifically, we are looking into refactoring ZkProgram methods to explicitly return values rather than requiring them to be passed as further inputs.
-
-:::
 
 # Recursion
 

--- a/docs/zkapps/snarkyjs/smart-contracts.md
+++ b/docs/zkapps/snarkyjs/smart-contracts.md
@@ -5,8 +5,9 @@ hide_title: true
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+Experimental. This API may change.
+
+Specifically, we are looking into refactoring ZkProgram methods to explicitly return values rather than requiring them to be passed as further inputs.
 
 :::
 

--- a/docs/zkapps/tutorials/01-hello-world.mdx
+++ b/docs/zkapps/tutorials/01-hello-world.mdx
@@ -6,8 +6,7 @@ sidebar_label: 'Tutorial 1: Hello World'
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/tutorials/02-private-inputs-hash-functions.mdx
+++ b/docs/zkapps/tutorials/02-private-inputs-hash-functions.mdx
@@ -6,8 +6,7 @@ sidebar_label: 'Tutorial 2: Private Inputs and Hash Functions'
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
+++ b/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
@@ -6,8 +6,7 @@ sidebar_label: 'Tutorial 3: Deploying to a Live Network'
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/tutorials/04-zkapp-ui-with-react.mdx
+++ b/docs/zkapps/tutorials/04-zkapp-ui-with-react.mdx
@@ -8,8 +8,7 @@ sidebar_label: 'Tutorial 4: Building a zkApp UI in the Browser with React'
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/tutorials/05-common-types-and-functions.mdx
+++ b/docs/zkapps/tutorials/05-common-types-and-functions.mdx
@@ -6,8 +6,7 @@ sidebar_label: 'Tutorial 5: Common Types and Functions'
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/tutorials/06-offchain-storage.mdx
+++ b/docs/zkapps/tutorials/06-offchain-storage.mdx
@@ -6,8 +6,7 @@ sidebar_label: 'Tutorial 6: Off-Chain Storage'
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/tutorials/07-oracle.mdx
+++ b/docs/zkapps/tutorials/07-oracle.mdx
@@ -6,8 +6,7 @@ sidebar_label: 'Tutorial 7: Oracles'
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/tutorials/08-custom-tokens.mdx
+++ b/docs/zkapps/tutorials/08-custom-tokens.mdx
@@ -6,8 +6,7 @@ sidebar_label: 'Tutorial 8: Custom Tokens'
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/tutorials/09-recursion.mdx
+++ b/docs/zkapps/tutorials/09-recursion.mdx
@@ -6,8 +6,7 @@ sidebar_label: 'Tutorial 9: Recursion'
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/tutorials/10-account-updates.mdx
+++ b/docs/zkapps/tutorials/10-account-updates.mdx
@@ -6,8 +6,7 @@ sidebar_label: 'Tutorial 10: Account Updates'
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/tutorials/anonymous-message-board.mdx
+++ b/docs/zkapps/tutorials/anonymous-message-board.mdx
@@ -6,8 +6,7 @@ sidebar_label: 'Example: Anonymous Message Board'
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/tutorials/interacting-with-zkapps-server-side.mdx
+++ b/docs/zkapps/tutorials/interacting-with-zkapps-server-side.mdx
@@ -6,8 +6,7 @@ sidebar_label: 'Interacting with zkApps Server-Side'
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 

--- a/docs/zkapps/zkapps-for-ethereum-developers.mdx
+++ b/docs/zkapps/zkapps-for-ethereum-developers.mdx
@@ -17,8 +17,7 @@ keywords:
 
 :::info
 
-Please note that zkApp programmability is not yet available on Mina Mainnet, but
-zkApps can now be deployed to Berkeley Testnet.
+zkApp programmability is not yet available on the Mina Mainnet. You can get started now by deploying zkApps to the Berkeley Testnet.
 
 :::
 


### PR DESCRIPTION
I am on a mission to improve our language and elevate our editorial standards throughout the technical documentation. Way back during my interview + trial project phase, I submitted suggestions to improve the language the shows at the top of every zkApp doc page. Here is my suggested update that I have submitted for legal approval:

For our current language, see https://docs.minaprotocol.com/zkapps
The style guidance I am following for this change is to:
- always to omit mentions of future, but for zkApps there is only the future (so keeping "not yet") per https://developers.google.com/style/timeless-documentation
- omit "please" per https://developers.google.com/style/tone