### PR TITLE
follow up to improve docs metadata: add missing front matter for new topics

### DIFF
--- a/docs/zkapps/index.mdx
+++ b/docs/zkapps/index.mdx
@@ -2,7 +2,7 @@
 title: zkApps Overview
 sidebar_label: Overview
 hide_title: true
-description: Get an understanding of zkApps, the smart contracts of Mina Protocol. zkApps are powered by zero knowledge proofs and off-chain execution. A quickstart guide to deploy zkApps and resources for learning TypeScript.
+description: zkApps build the smart contracts of Mina Protocol. zkApps are powered by zero knowledge proofs and off-chain execution. A quickstart guide to deploy zkApps and resources for learning TypeScript.
 keywords:
   - zkapps
   - mina protocol

--- a/docs/zkapps/index.mdx
+++ b/docs/zkapps/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: zkApp Overview
+title: zkApps Overview
 sidebar_label: Overview
 hide_title: true
 description: Get an understanding of zkApps, the smart contracts of Mina Protocol. zkApps are powered by zero knowledge proofs and off-chain execution. A quickstart guide to deploy zkApps and resources for learning TypeScript.

--- a/docs/zkapps/index.mdx
+++ b/docs/zkapps/index.mdx
@@ -2,7 +2,7 @@
 title: zkApps Overview
 sidebar_label: Overview
 hide_title: true
-description: zkApps build the smart contracts of Mina Protocol. zkApps are powered by zero knowledge proofs and off-chain execution. A quickstart guide to deploy zkApps and resources for learning TypeScript.
+description: zkApps (zero knowledge apps) are Mina Protocol smart contracts powered by zero knowledge proofs, specifically using zk-SNARKs. Use this quickstart guide to deploy zkApps and resources for learning TypeScript.
 keywords:
   - zkapps
   - mina protocol

--- a/docs/zkapps/snarkyjs/actions-and-reducer.mdx
+++ b/docs/zkapps/snarkyjs/actions-and-reducer.mdx
@@ -11,6 +11,7 @@ keywords:
   - blockchain development
   - concurrent state updates
   - off-chain storage
+  - mina archive node
 ---
 
 :::info

--- a/docs/zkapps/snarkyjs/basic-concepts.md
+++ b/docs/zkapps/snarkyjs/basic-concepts.md
@@ -1,6 +1,22 @@
 ---
-title: Basic concepts
+title: SnarkyJS Basic Concepts
 hide_title: true
+sidebar_label: Basic Concepts
+description: Field elements are the basic unit of data in zero-knowledge proof programming. Learn about built-in data types, functions, and common methods. 
+keywords:
+  - smart contracts
+  - zkapps
+  - fields
+  - field elements
+  - zero knowledge proof programming
+  - zk proof
+  - zk
+  - data types
+  - snarkyjs
+  - blockchain
+  - mina
+  - typescript
+  - methods
 ---
 
 :::info
@@ -10,7 +26,7 @@ zkApps can now be deployed to Berkeley Testnet.
 
 :::
 
-# Basic concepts
+# SnarkyJS Basic Concepts
 
 ## Field
 
@@ -63,7 +79,7 @@ let b = Bool(true);
 
 ## Conditionals
 
-Traditional conditional statements are not yet supported by SnarkyJS:
+Traditional conditional statements are not supported by SnarkyJS:
 
 ```ts
 // this will NOT work
@@ -72,7 +88,7 @@ if (foo) {
 }
 ```
 
-Instead, use SnarkyJS’ built-in `Circuit.if()` method, which is a ternary operator:
+Instead, use the SnarkyJS built-in `Circuit.if()` method, which is a ternary operator:
 
 ```ts
 const x = Circuit.if(new Bool(foo), a, b); // behaves like `foo ? a : b`

--- a/docs/zkapps/snarkyjs/custom-tokens.mdx
+++ b/docs/zkapps/snarkyjs/custom-tokens.mdx
@@ -12,6 +12,7 @@ keywords:
   - token id
   - token accounts
   - token owner
+  - zkApps updates
 ---
 
 :::info

--- a/docs/zkapps/snarkyjs/index.md
+++ b/docs/zkapps/snarkyjs/index.md
@@ -1,7 +1,21 @@
 ---
 title: Introduction to SnarkyJS
 hide_title: true
-description: SnarkyJS is a general-purpose zk framework that gives you the tools to create zk proofs. SnarkyJS is a TypeScript library for writing general-purpose zk programs and writing zk smart contracts for Mina.
+sidebar_label: Introduction
+description: SnarkyJS is a general-purpose zk framework with the tools to create zk proofs. SnarkyJS is a TypeScript library for writing general-purpose zk programs and writing zk smart contracts for Mina.
+keywords:
+  - smart contracts
+  - zkapps
+  - zero knowledge proof programming
+  - zk proof
+  - zk
+  - mina 
+  - data types
+  - what is snarkyjs
+  - blockchain
+  - mina
+  - typescript
+  - typescript library
 ---
 
 :::info
@@ -11,7 +25,7 @@ zkApps can now be deployed to Berkeley Testnet.
 
 :::
 
-# SnarkyJS
+# Introduction to SnarkyJS
 
 SnarkyJS is a TypeScript (TS) library for:
 

--- a/docs/zkapps/snarkyjs/interact-with-mina.md
+++ b/docs/zkapps/snarkyjs/interact-with-mina.md
@@ -1,6 +1,22 @@
 ---
 title: Interacting With Mina
 hide_title: true
+description: How to create zero knowledge proofs and how users call zkApp methods. An account update can have proof, signature or none authorizations.
+keywords:
+  - smart contracts
+  - zkapps
+  - zkapp methods
+  - zero knowledge proofs
+  - zk proof
+  - zk
+  - snarkyjs
+  - blockchain
+  - transaction
+  - mina
+  - data structure
+  - account updates
+  - on-chain account
+  - authorization types
 ---
 
 :::info
@@ -82,7 +98,7 @@ Note that there a many more fields that account updates can have, but `tx.toPret
 
 As you might have noticed, these account updates weren't created in a very explicit manner. Instead, SnarkyJS gives you an imperative API, with "commands" like `state.set()`. Under the hood, these commands create and modify account updates in a transaction, like you saw above. In the end, the entire transaction is sent to the network, as one atomic update. If something fails – for example, one of the account updates has insufficient authorization – the _entire_ transaction is rejected and doesn't get applied. This is in contrast to an EVM contract, where the initial steps of a method call could succeed even if the method fails at a later step.
 
-## Creating proofs, and what they mean
+## Creating proofs and what they mean
 
 Let's finally see how to create zero-knowledge proofs!
 
@@ -248,7 +264,7 @@ This error comes about as follows:
 - That comparison check fails, because the two sets of account updates are different
 -->
 
-## Signing transactions, and explicit account updates
+## Signing transactions and explicit account updates
 
 Let's recap: We have explained how to write a SmartContract. We've seen how to create a transaction which calls that contract, and how the transaction consists of account updates which were created by SnarkyJS under the hood. Now, we'll see an example of creating an account update explicitly. We'll also learn how to use signatures, for authorizing updates to user accounts.
 

--- a/docs/zkapps/snarkyjs/smart-contracts.md
+++ b/docs/zkapps/snarkyjs/smart-contracts.md
@@ -1,6 +1,21 @@
 ---
-title: Smart Contracts
+title: Smart contracts
 hide_title: true
+description: How to create and interact with a smart contract. How to prove an on-chain value. Learn about the public state of a zkApp and private method parameters.
+keywords:
+  - smart contracts
+  - zkapps
+  - zero knowledge proof programming
+  - zk proof
+  - zk
+  - zkapp account
+  - snarkyjs
+  - blockchain
+  - mina
+  - typescript
+  - public input
+  - private input
+  - on-chain state
 ---
 
 :::info


### PR DESCRIPTION
This PR is part two of https://github.com/o1-labs/docs2/issues/360 and adds front matter metadata to the new SnarkyJS topics