### PR TITLE
Add embedded youtube links 

### DIFF
--- a/docs/about-mina/consensus.mdx
+++ b/docs/about-mina/consensus.mdx
@@ -10,7 +10,13 @@ Consensus is the process by which the network determines which information is re
 
 Learn more about how Ouroboros Samasika works in this video:
 
-[![What is Ouroboros Samisika?](https://res.cloudinary.com/marcomontalbano/image/upload/v1661971904/video_to_markdown/images/youtube--NpjuGYcJICA-c05b58ac6eb4c4700831b2b3070cd403.jpg)](https://www.youtube.com/watch?v=NpjuGYcJICA "What is Ouroboros Samisika?")
+<iframe
+  width="900"
+  height="550"
+  src="https://www.youtube.com/embed/NpjuGYcJICA"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  allowfullscreen
+></iframe>
 
 ### Decentralization properties
 Based on Cardano’s PoS Ouroboros, Ouroboros Samisika is a secure PoS protocol with some strong decentralization properties: 

--- a/docs/about-mina/what-are-zero-knowledge-proofs.mdx
+++ b/docs/about-mina/what-are-zero-knowledge-proofs.mdx
@@ -4,8 +4,14 @@ title: What are Zero-Knowledge Proofs?
 
 # What are Zero-Knowledge Proofs?
 
-Zero-knowledge proofs keep Mina's blockchain light and your personal data private. 
+Zero-knowledge proofs keep Mina's blockchain light and your personal data private.
 
 In this video, Brandon from <a href="https://o1labs.org/">O(1) Labs</a> explains what zero-knowledge proofs are by comparing them to the game of "Where's Waldo?". By the end of this video, you know what zero-knowledge proofs are, how they work, and their importance to Mina and the greater crypto community.
 
-[![What are Zero Knowledge Proofs? | Mina Protocol](https://res.cloudinary.com/marcomontalbano/image/upload/v1660337712/video_to_markdown/images/youtube--GvwYJDzzI-g-c05b58ac6eb4c4700831b2b3070cd403.jpg)](https://www.youtube.com/watch?v=GvwYJDzzI-g "What are Zero Knowledge Proofs? | Mina Protocol")
+<iframe
+  width="900"
+  height="550"
+  src="https://www.youtube.com/embed/GvwYJDzzI-g"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  allowfullscreen
+></iframe>


### PR DESCRIPTION
# Description 
Instead of the old practice of using a manual thumbnail to specify a youtube link, we add the embedded element directly in our docs. This will improve UX and SEO.

## Steps to add an embedded video
If you want to add a youtube video in our docs, we can directly add the iframe HTML in our docs! :smile: To do so, we simply need to do the following:
1. Go to the youtube video you would link to link
2. Click _Share_
![image](https://github.com/o1-labs/docs2/assets/9512405/809ebae5-7396-4f5d-99d9-0725a3bbb306)
3. Click _Embed_
![image](https://github.com/o1-labs/docs2/assets/9512405/7b2c53fe-2a7c-4c17-b224-b249b10e990c)
4. Click _Copy_
![image](https://github.com/o1-labs/docs2/assets/9512405/b9390eef-78d0-477c-9694-3d5d8245c593)
5. Paste the HTML in your clipboard directly in the docs!

### Things to note
You can resize the iframe by editing the HTML. For example, in the iframe element, there will be a height and width property. You can change these values to resize how big the iframe element is:

```html
<iframe
  width="900"
  height="550"
  src="https://www.youtube.com/embed/GvwYJDzzI-g"
 ...
></iframe>

```