### PR TITLE
embed zkOracles YouTube video in tutorial 7

### DIFF
--- a/docs/zkapps/tutorials/07-oracle.mdx
+++ b/docs/zkapps/tutorials/07-oracle.mdx
@@ -17,6 +17,16 @@ zkApps can now be deployed to Berkeley Testnet.
 
 If your smart contract needs to consume data from the outside world, you can use an oracle.
 
+Learn about zkOracles in this video:
+
+<iframe 
+  width="560" 
+  height="315" 
+  src="https://www.youtube.com/embed/lvX_l9tb_rQ" 
+  frameborder="0" 
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen>
+</iframe>
+
 In this tutorial, we’ll build an oracle that retrieves data from a REST API. We’ll also write a smart contract that consumes information from this oracle.
 
 Specifically, our oracle will retrieve data from a REST API that provides mock credit score information for two users–one with a high credit score and one with a low credit score. Our smart contract will consume this information and allow the user to prove their credit score is above a certain threshold (e.g. >700).


### PR DESCRIPTION
Preview https://docs2-git-zkoracles-tuto-video-minadocs.vercel.app/zkapps/tutorials/oracle 

This PR uses iFrame to embed this zkOracles [video](https://www.youtube.com/watch?v=lvX_l9tb_rQ) to the [zkOracles tutorial page](https://docs.minaprotocol.com/zkapps/tutorials/oracle) in the overview section.

```
<iframe 
  width="560" 
  height="315" 
  src="https://www.youtube.com/embed/lvX_l9tb_rQ" 
  frameborder="0" 
  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen>
</iframe>
```

I followed the steps kindly provided by @MartinMinkov with one change, I removed the "title" line