### PR TITLE
Replace iframes with `ResponsiveVideo` component

### DIFF
--- a/docs/about-mina/consensus.mdx
+++ b/docs/about-mina/consensus.mdx
@@ -2,6 +2,8 @@
 title: Consensus
 ---
 
+import ResponsiveVideo from '@site/src/components/common/ResponsiveVideo';
+
 # Consensus
 
 Mina Protocol uses a proof-of-stake consensus mechanism called **Ouroboros Samasika**. 
@@ -10,13 +12,7 @@ Consensus is the process by which the network determines which information is re
 
 Learn more about how Ouroboros Samasika works in this video:
 
-<iframe
-  width="900"
-  height="550"
-  src="https://www.youtube.com/embed/NpjuGYcJICA"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  allowfullscreen
-></iframe>
+<ResponsiveVideo src="https://www.youtube.com/embed/NpjuGYcJICA" />
 
 ### Decentralization properties
 Based on Cardano’s PoS Ouroboros, Ouroboros Samisika is a secure PoS protocol with some strong decentralization properties: 

--- a/docs/about-mina/protocol-architecture.mdx
+++ b/docs/about-mina/protocol-architecture.mdx
@@ -3,26 +3,21 @@ title: Protocol Architecture
 hide_title: true
 ---
 
+import ResponsiveVideo from '@site/src/components/common/ResponsiveVideo';
+
 :::note
 
 A new version of Mina Docs is coming soon! This page will be rewritten.
 
 :::
+
 # Protocol Architecture
 
 ## How Does it Work?
 
 Check out this short video explaining how the Mina protocol works in detail:
 
-<iframe
-  id="youtube-iframe"
-  width="560"
-  height="315"
-  src="https://www.youtube-nocookie.com/embed/eWVGATxEB6M?start=100&enablejsapi=1&rel=0"
-  frameborder="0"
-  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
-></iframe>
+<ResponsiveVideo src="https://www.youtube-nocookie.com/embed/eWVGATxEB6M?start=100&enablejsapi=1&rel=0" />
 
 ### Timestamps
 

--- a/docs/about-mina/what-are-zero-knowledge-proofs.mdx
+++ b/docs/about-mina/what-are-zero-knowledge-proofs.mdx
@@ -2,16 +2,12 @@
 title: What are Zero-Knowledge Proofs?
 ---
 
+import ResponsiveVideo from '@site/src/components/common/ResponsiveVideo';
+
 # What are Zero-Knowledge Proofs?
 
 Zero-knowledge proofs keep Mina's blockchain light and your personal data private.
 
 In this video, Brandon from <a href="https://o1labs.org/">O(1) Labs</a> explains what zero-knowledge proofs are by comparing them to the game of "Where's Waldo?". By the end of this video, you know what zero-knowledge proofs are, how they work, and their importance to Mina and the greater crypto community.
 
-<iframe
-  width="900"
-  height="550"
-  src="https://www.youtube.com/embed/GvwYJDzzI-g"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  allowfullscreen
-></iframe>
+<ResponsiveVideo src="https://www.youtube.com/embed/GvwYJDzzI-g" />

--- a/docs/zkapps/tutorials/07-oracle.mdx
+++ b/docs/zkapps/tutorials/07-oracle.mdx
@@ -4,6 +4,8 @@ hide_title: true
 sidebar_label: 'Tutorial 7: Oracles'
 ---
 
+import ResponsiveVideo from '@site/src/components/common/ResponsiveVideo';
+
 :::info
 
 Please note that zkApp programmability is not yet available on Mina Mainnet, but
@@ -19,13 +21,7 @@ If your smart contract needs to consume data from the outside world, you can use
 
 Learn about zkOracles in this video:
 
-<iframe 
-  width="560" 
-  height="315" 
-  src="https://www.youtube.com/embed/lvX_l9tb_rQ" 
-  frameborder="0" 
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen>
-</iframe>
+<ResponsiveVideo src="https://www.youtube.com/embed/lvX_l9tb_rQ" />
 
 In this tutorial, we’ll build an oracle that retrieves data from a REST API. We’ll also write a smart contract that consumes information from this oracle.
 

--- a/src/components/common/ResponsiveVideo.module.scss
+++ b/src/components/common/ResponsiveVideo.module.scss
@@ -1,0 +1,22 @@
+.responsiveVideoWrapper {
+  position: relative;
+  width: 100%;
+  padding-bottom: 56.25%; /* 16:9 Aspect Ratio (divide 9 by 16 = 0.5625 or 56.25%) */
+  height: 0;
+  overflow: hidden;
+}
+
+.responsiveVideo {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+@media screen and (min-width: 998px) {
+  .responsiveVideo {
+    max-width: 50vw;
+  }
+}

--- a/src/components/common/ResponsiveVideo.tsx
+++ b/src/components/common/ResponsiveVideo.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import styles from './ResponsiveVideo.module.scss';
+
+const ResponsiveVideo = ({
+  src,
+  title,
+  ...props
+}: React.ComponentPropsWithoutRef<'iframe'>) => {
+  return (
+    <div className={styles.responsiveVideoWrapper}>
+      <iframe
+        src={src}
+        title={title}
+        className={styles.responsiveVideo}
+        allowFullScreen
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        {...props}
+      />
+    </div>
+  );
+};
+
+export default ResponsiveVideo;


### PR DESCRIPTION
# Description

The current approach for embedding YouTube videos into our content uses the `iframe` directly provided by YouTube's share functionality. While this method offers a straightforward solution for desktop viewers, it falls short regarding mobile-friendliness and proper scaling. 

In response to these limitations, this Pull Request introduces a new component: `ResponsiveVideo`.

To utilize this component within a `.mdx` file, the following import statement needs to be added at the top of the file:

```ts
import ResponsiveVideo from '@site/src/components/common/ResponsiveVideo';
```

Subsequently, a responsive `iframe` can be rendered with the `ResponsiveVideo` component, as demonstrated below:

```ts
<ResponsiveVideo src="your_embed_link_here" />
```

By leveraging this new component, we aim to enhance the viewing experience across different devices, ensuring our embedded YouTube videos scale properly and maintain a mobile-friendly interface.

:link: Preview Link: https://docs2-git-feat-add-responsive-iframe-minadocs.vercel.app/
