### PR TITLE
DX: add metadata description to all tutorials

### DIFF
--- a/docs/zkapps/tutorials/01-hello-world.mdx
+++ b/docs/zkapps/tutorials/01-hello-world.mdx
@@ -3,6 +3,17 @@ title: 'Tutorial 1: Hello World'
 hide_title: true
 sidebar_label: 'Tutorial 1: Hello World'
 description: Guided steps to get started with SnarkyJS, zkApps, and programming with zero-knowledge proofs. Learn to code a zkApp from start to finish.
+keywords:
+  - smart contracts
+  - zkapps
+  - zero knowledge proof programming
+  - zk proof
+  - zk
+  - data types
+  - snarkyjs
+  - blockchain
+  - mina
+  - typescript
 ---
 
 :::info

--- a/docs/zkapps/tutorials/01-hello-world.mdx
+++ b/docs/zkapps/tutorials/01-hello-world.mdx
@@ -2,6 +2,7 @@
 title: 'Tutorial 1: Hello World'
 hide_title: true
 sidebar_label: 'Tutorial 1: Hello World'
+description: Guided steps to get started with SnarkyJS, zkApps, and programming with zero-knowledge proofs. Learn to code a zkApp from start to finish.
 ---
 
 :::info

--- a/docs/zkapps/tutorials/02-private-inputs-hash-functions.mdx
+++ b/docs/zkapps/tutorials/02-private-inputs-hash-functions.mdx
@@ -2,6 +2,7 @@
 title: 'Tutorial 2: Private Inputs and Hash Functions'
 hide_title: true
 sidebar_label: 'Tutorial 2: Private Inputs and Hash Functions'
+description: Guided steps to learn about private inputs, hash functions, and adding a second value as an input.
 ---
 
 :::info

--- a/docs/zkapps/tutorials/02-private-inputs-hash-functions.mdx
+++ b/docs/zkapps/tutorials/02-private-inputs-hash-functions.mdx
@@ -3,6 +3,19 @@ title: 'Tutorial 2: Private Inputs and Hash Functions'
 hide_title: true
 sidebar_label: 'Tutorial 2: Private Inputs and Hash Functions'
 description: Guided steps to learn about private inputs, hash functions, and adding a second value as an input.
+keywords:
+  - smart contracts
+  - zkapps
+  - inputs
+  - hash functions
+  - zero knowledge proof programming
+  - zk proof
+  - zk
+  - data types
+  - snarkyjs
+  - blockchain
+  - mina
+  - typescript
 ---
 
 :::info

--- a/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
+++ b/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
@@ -3,6 +3,15 @@ title: 'Tutorial 3: Deploying to a Live Network'
 hide_title: true
 sidebar_label: 'Tutorial 3: Deploying to a Live Network'
 description: Use the Mina zkApp CLI tool to deploy a smart contract to a live network.
+keywords:
+  - smart contracts
+  - zkapps
+  - deploy a zkapp
+  - zero knowledge proof programming
+  - zk proof
+  - zk
+  - blockchain
+  - mina
 ---
 
 :::info

--- a/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
+++ b/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
@@ -2,6 +2,7 @@
 title: 'Tutorial 3: Deploying to a Live Network'
 hide_title: true
 sidebar_label: 'Tutorial 3: Deploying to a Live Network'
+description: Use the Mina zkApp CLI tool to deploy a smart contract to a live network.
 ---
 
 :::info

--- a/docs/zkapps/tutorials/04-zkapp-ui-with-react.mdx
+++ b/docs/zkapps/tutorials/04-zkapp-ui-with-react.mdx
@@ -2,6 +2,7 @@
 title: 'Tutorial 4: Building a zkApp UI in the Browser with React'
 hide_title: true
 sidebar_label: 'Tutorial 4: Building a zkApp UI in the Browser with React'
+description: Guided steps to implement a browser UI using ReactJS that interacts with a smart contract running on the Berkeley Testnet.
 ---
 
 # Tutorial 4: Building a zkApp UI in the Browser with React

--- a/docs/zkapps/tutorials/04-zkapp-ui-with-react.mdx
+++ b/docs/zkapps/tutorials/04-zkapp-ui-with-react.mdx
@@ -3,6 +3,17 @@ title: 'Tutorial 4: Building a zkApp UI in the Browser with React'
 hide_title: true
 sidebar_label: 'Tutorial 4: Building a zkApp UI in the Browser with React'
 description: Guided steps to implement a browser UI using ReactJS that interacts with a smart contract running on the Berkeley Testnet.
+keywords:
+  - smart contracts
+  - zkapps
+  - interact with a smart contract
+  - build a smart contract user interface
+  - smart contract UI
+  - zero knowledge proof programming
+  - zk proof
+  - zk
+  - blockchain
+  - mina
 ---
 
 # Tutorial 4: Building a zkApp UI in the Browser with React

--- a/docs/zkapps/tutorials/05-common-types-and-functions.mdx
+++ b/docs/zkapps/tutorials/05-common-types-and-functions.mdx
@@ -3,6 +3,17 @@ title: 'Tutorial 5: Common Types and Functions'
 hide_title: true
 sidebar_label: 'Tutorial 5: Common Types and Functions'
 description: Higher-order types are built from Fields and are useful for your development. Learn how to create custom types.
+keywords:
+  - smart contracts
+  - zkapps
+  - types
+  - smart contract fields
+  - field types
+  - zero knowledge proof programming
+  - zk proof
+  - zk
+  - blockchain
+  - mina
 ---
 
 :::info

--- a/docs/zkapps/tutorials/05-common-types-and-functions.mdx
+++ b/docs/zkapps/tutorials/05-common-types-and-functions.mdx
@@ -2,6 +2,7 @@
 title: 'Tutorial 5: Common Types and Functions'
 hide_title: true
 sidebar_label: 'Tutorial 5: Common Types and Functions'
+description: Higher-order types are built from Fields and are useful for your development. Learn how to create custom types.
 ---
 
 :::info

--- a/docs/zkapps/tutorials/06-offchain-storage.mdx
+++ b/docs/zkapps/tutorials/06-offchain-storage.mdx
@@ -2,6 +2,7 @@
 title: 'Tutorial 6: Off-Chain Storage'
 hide_title: true
 sidebar_label: 'Tutorial 6: Off-Chain Storage'
+description: Learn options for zkApps that require trustless solutions in this implementation of a single-server off-chain storage solution.
 ---
 
 :::info

--- a/docs/zkapps/tutorials/06-offchain-storage.mdx
+++ b/docs/zkapps/tutorials/06-offchain-storage.mdx
@@ -3,6 +3,17 @@ title: 'Tutorial 6: Off-Chain Storage'
 hide_title: true
 sidebar_label: 'Tutorial 6: Off-Chain Storage'
 description: Learn options for zkApps that require trustless solutions in this implementation of a single-server off-chain storage solution.
+keywords:
+  - smart contracts
+  - zkapps
+  - off-chain storage
+  - smart contract
+  - trustless zero knowledge
+  - off-chain storage
+  - zk proof
+  - zk
+  - blockchain
+  - mina
 ---
 
 :::info

--- a/docs/zkapps/tutorials/07-oracle.mdx
+++ b/docs/zkapps/tutorials/07-oracle.mdx
@@ -2,6 +2,7 @@
 title: 'Tutorial 7: Oracles'
 hide_title: true
 sidebar_label: 'Tutorial 7: Oracles'
+description: Use an oracle when your smart contract needs to consume data from the outside world.
 ---
 
 import ResponsiveVideo from '@site/src/components/common/ResponsiveVideo';

--- a/docs/zkapps/tutorials/07-oracle.mdx
+++ b/docs/zkapps/tutorials/07-oracle.mdx
@@ -3,6 +3,15 @@ title: 'Tutorial 7: Oracles'
 hide_title: true
 sidebar_label: 'Tutorial 7: Oracles'
 description: Use an oracle when your smart contract needs to consume data from the outside world.
+keywords:
+  - smart contracts
+  - zkapps
+  - oracles
+  - zero knowledge proof programming
+  - zk proof
+  - zk
+  - blockchain
+  - mina
 ---
 
 import ResponsiveVideo from '@site/src/components/common/ResponsiveVideo';

--- a/docs/zkapps/tutorials/08-custom-tokens.mdx
+++ b/docs/zkapps/tutorials/08-custom-tokens.mdx
@@ -3,6 +3,15 @@ title: 'Tutorial 8: Custom Tokens'
 hide_title: true
 sidebar_label: 'Tutorial 8: Custom Tokens'
 description: Mina comes with native support for custom tokens.Learn the smart contract code that creates and manages new tokens.
+keywords:
+  - smart contracts
+  - zkapps
+  - custom tokens
+  - zero knowledge proof programming
+  - zk proof
+  - zk
+  - blockchain
+  - mina
 ---
 
 :::info

--- a/docs/zkapps/tutorials/08-custom-tokens.mdx
+++ b/docs/zkapps/tutorials/08-custom-tokens.mdx
@@ -2,6 +2,7 @@
 title: 'Tutorial 8: Custom Tokens'
 hide_title: true
 sidebar_label: 'Tutorial 8: Custom Tokens'
+description: Mina comes with native support for custom tokens.Learn the smart contract code that creates and manages new tokens.
 ---
 
 :::info

--- a/docs/zkapps/tutorials/09-recursion.mdx
+++ b/docs/zkapps/tutorials/09-recursion.mdx
@@ -3,6 +3,17 @@ title: 'Tutorial 9: Recursion'
 hide_title: true
 sidebar_label: 'Tutorial 9: Recursion'
 description: Use recursion on-chain and off-chain with zkApps. Learn about use cases to create high-throughput applications, use larger proof sizes, and create multi-party zero knowledge proof constructions.
+keywords:
+  - smart contracts
+  - zkapps
+  - recursion
+  - multi party zk
+  - high throughput applications
+  - zero knowledge proof programming
+  - zk proof
+  - zk
+  - blockchain
+  - mina
 ---
 
 :::info

--- a/docs/zkapps/tutorials/09-recursion.mdx
+++ b/docs/zkapps/tutorials/09-recursion.mdx
@@ -2,6 +2,7 @@
 title: 'Tutorial 9: Recursion'
 hide_title: true
 sidebar_label: 'Tutorial 9: Recursion'
+description: Use recursion on-chain and off-chain with zkApps. Learn about use cases to create high-throughput applications, use larger proof sizes, and create multi-party zero knowledge proof constructions.
 ---
 
 :::info

--- a/docs/zkapps/tutorials/10-account-updates.mdx
+++ b/docs/zkapps/tutorials/10-account-updates.mdx
@@ -2,6 +2,7 @@
 title: 'Tutorial 10: Account Updates'
 hide_title: true
 sidebar_label: 'Tutorial 10: Account Updates'
+description: Each zkApp transaction constructed by SnarkyJS is composed of one or more account updates. Use account updates to implement the core features of zkApps: permissions, preconditions, composability, and tokens.
 ---
 
 :::info

--- a/docs/zkapps/tutorials/10-account-updates.mdx
+++ b/docs/zkapps/tutorials/10-account-updates.mdx
@@ -2,7 +2,19 @@
 title: 'Tutorial 10: Account Updates'
 hide_title: true
 sidebar_label: 'Tutorial 10: Account Updates'
-description: Each zkApp transaction constructed by SnarkyJS is composed of one or more account updates. Use account updates to implement the core features of zkApps: permissions, preconditions, composability, and tokens.
+description: Each zkApp transaction constructed by SnarkyJS is composed of one or more account updates. Use account updates to implement permissions, preconditions, composability, and tokens - the core features of zkApps.
+keywords:
+  - smart contracts
+  - zkapps
+  - account updates
+  - permissions
+  - composability
+  - tokens
+  - zero knowledge proof programming
+  - zk proof
+  - zk
+  - blockchain
+  - mina
 ---
 
 :::info


### PR DESCRIPTION
This PR is part three of [#360](https://github.com/o1-labs/docs2/issues/360) and adds front matter metadata to the tutorials