### PR TITLE
DX and UX: Tutorial 3: Deploy to a Live Network

### DIFF
--- a/docs/zkapps/tutorials/01-hello-world.mdx
+++ b/docs/zkapps/tutorials/01-hello-world.mdx
@@ -122,7 +122,7 @@ Now that you have the tooling installed, you can start building your application
 
 For this tutorial, you run commands from the root of the `01-hello-world` directory as you work in the `src` directory on files that contain the TypeScript code for the smart contract. Each time you make updates, then build or deploy, the TypeScript code is compiled into JavaScript in the `build` directory.
 
-### Preparing the project
+### Prepare the project
 
 Start by deleting the default files that come with the new project.
 
@@ -283,7 +283,7 @@ You can also store data publicly on-chain when needed, like  `num` in this examp
 
 Congratulations, you have reviewed the complete smart contract code. 
 
-## Interacting with a smart contract
+## Interact with a smart contract
 
 Next, write a script that interacts with your smart contract. As before, the complete [main.ts](https://github.com/o1-labs/docs2/blob/main/examples/zkapps/01-hello-world/src/main.ts) example file is provided. Follow these steps to build the `main.ts` file so you can can interact with the smart contract.  
 
@@ -347,8 +347,8 @@ const { privateKey: senderKey, publicKey: senderAccount } = Local.testAccounts[1
 
 Tip: To preserve line numbers in your local `main.ts` file, add blank lines as needed after you copy the code snippets.
 
-### Building and running
- 
+### Build and run the smart contract
+
 Now that the Square smart contract is complete, these commands run your project as a local blockchain.
 
 To compile the TypeScript code into JavaScript:

--- a/docs/zkapps/tutorials/02-private-inputs-hash-functions.mdx
+++ b/docs/zkapps/tutorials/02-private-inputs-hash-functions.mdx
@@ -114,7 +114,7 @@ For this tutorial, you run commands from the root of the `02-private-inputs-and-
 
 Each time you make updates, then build or deploy, the TypeScript code is compiled into JavaScript in the `build` directory.
 
-### Preparing the project
+### Prepare the project
 
 Start by deleting the default files that come with the new project.
 
@@ -160,7 +160,7 @@ This tutorial relies on the completed code in the [02-private-inputs-and-hash-fu
 
 Now you are ready to review the imports in the smart contract. 
 
-## Writing the smart contract
+## Write the smart contract
 
 Now we'll build the smart contract for our application.
 
@@ -303,4 +303,4 @@ The `state` strings are different because `Field.random()` generates the salt.
 
 Congratulations! You built a smart contract that uses privacy and hash functions.
 
-To deploy zkApps to a live network, see [Tutorial 3: Deploying to a Live Network](deploying-to-a-network). 
+To deploy zkApps to a live network, see [Tutorial 3: Deploy to a Live Network](deploying-to-a-network). 

--- a/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
+++ b/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
@@ -24,21 +24,17 @@ zkApp programmability is not yet available on the Mina Mainnet. You can get star
 
 # Tutorial 3: Deploy to a Live Network
 
-In previous tutorials, you learned how to deploy and run transactions on a local network. In this tutorial, you deploy a project to a live network.
+In previous tutorials, you learned how to deploy and run transactions on a local network. 
 
-In this tutorial, you deploy a contract to the Berkeley Testnet.
+In this tutorial, you use the `zk config` command to create a deploy alias, request tMINA funds to pay for transaction fees, and deploy a project to a live network.
 
-Mina zkApps are available only on feature-complete Berkeley, Mina's public Testnet. Only minor changes and bug fixes are expected before Mainnet. 
-
-This tutorial reuses the `Square` contract that you created in [Tutorial 1: Hello World](hello-world).
+Mina zkApps are available only on feature-complete Berkeley, Mina's public Testnet. This tutorial reuses the `Square` contract that you created in [Tutorial 1: Hello World](hello-world).
 
 ## Prerequisites
 
-This tutorial has been tested with [Mina zkApp CLI](https://github.com/o1-labs/zkapp-cli) version `0.9.0` and [SnarkyJS](https://www.npmjs.com/package/snarkyjs) `0.11.0`.
+This tutorial has been tested with [Mina zkApp CLI](https://github.com/o1-labs/zkapp-cli) version `0.10.0` and [SnarkyJS](https://www.npmjs.com/package/snarkyjs) `0.11.3`.
 
 Ensure your environment meets the [Prerequisites](/zkapps/tutorials#prerequisites) for zkApp Developer Tutorials.
-
-
 
 ## Create a project
 
@@ -106,7 +102,7 @@ Start by deleting the default files that come with the new project.
   $ zk file src/Square
   ```
 
-1. Copy the `src/Square.ts` and `src/index.ts` files from the example files for first tutorial [01-hello-world/src](https://github.com/o1-labs/docs2/tree/main/examples/zkapps/01-hello-world/src) to your local `03-deploying-to-a-live-network/src` directory.
+1. Copy the `src/Square.ts` and `src/index.ts` files from the example files for first tutorial [01-hello-world/src](https://github.com/o1-labs/docs2/tree/main/examples/zkapps/01-hello-world/src) to your local `03-deploying-to-a-live-network/src` directory. If prompted, replace existing files.
 
 Now that your smart contract is in place, you are ready to deploy your smart contract to Berkeley Testnet.
 
@@ -118,29 +114,28 @@ In some cases, you might need to create a custom account for your zkApp, for exa
 
 ## Deploy the smart contract 
 
-The `config.json` configuration file was automatically scaffolded when you created your project with the `zk project` command. However, the generated configuration file does not yet contain the deploy alias. The `zk config` command prompts guide you to create or update a deploy alias in your project `config.json` file. 
+The `config.json` configuration file was automatically scaffolded when you created your project with the `zk project` command. However, the generated configuration file does not yet contain the deploy alias. 
 
 ### Deploy alias
 
-You can have one or more deploy aliases for your project. Using naming patterns is helpful when you have more than one deploy alias. 
+The `zk config` command prompts guide you to create or update a deploy alias in your project `config.json` file. 
+
+You can have one or more deploy aliases for your project.  
 
 A deploy alias consists of:
 
-- A self-describing name. This tutorial uses `berkeley`. The deploy alias name can be anything and does not have to match the network name.
-- The Mina GraphQL API URL that defines the network that receives your deploy transaction and broadcast it to the appropriate Mina network (Testnet, Devnet, Mainnet, and so on)
+- A self-describing name (can be anything). Using naming patterns is helpful when you have more than one deploy alias.
+- The Mina GraphQL API URL that defines the network that receives your deploy transaction and broadcasts it to the appropriate Mina network (Testnet, Devnet, Mainnet, and so on)
 - The transaction fee (in MINA) to use when deploying
 - Two key pairs:
 
-  - Creates a key pair for the zkApp account. Public and private keys to use in your application are automatically generated in `keys/berkeley.json`.
+  - A key pair for the zkApp account. Public and private keys to use in your application are automatically generated in `keys/berkeley.json`.
 
-  - Creates or selects an existing key pair to use as a fee payer account for updates and deployments. Public and private keys are stored on your local computer and can be used across multiple projects.
+  - A key pair to use as a fee payer account for updates and deployments. Public and private keys are stored on your local computer and can be used across multiple projects.
 
-- Fee payer account alias 
+- Fee payer account alias
 
-A fee payer account is required. If you don't have a fee payer account, you are prompted to select one of these options:
-
-- Recover fee payer account from an existing base58 private key
-- Create a new fee payer key pair
+  - A fee payer account is required, you can choose to use an existing account or create a new fee payer account.
 
 1. To configure your deployment, run the `zk config` command and respond to the prompts:
 
@@ -150,40 +145,53 @@ A fee payer account is required. If you don't have a fee payer account, you are 
 
   For this tutorial on Berkeley Testnet, use:
   
-    - name: `berkeley`
+    - Deploy alias name: `berkeley` 
+    
+      This tutorial uses `berkeley`, but the deploy alias name can be anything and does not have to match the network name.
+  
     - Mina GraphQL API URL: `https://proxy.berkeley.minaexplorer.com/graphql`
-    - transaction fee: `0.1`
-    - 
+  
+    - Transaction fee to use when deploying: `0.1`
+  
+    - Account to pay transaction fees: Create a new fee payer pair
 
-  If you have previously run `zk config` and selected a fee payer account, then you already have a fee payer account. Your prompts are: 
 
-  ```text
-    ❯ Use stored account dev (public key: <yourpublickey>)
-    Use a different account (select to see options)
+1. When prompted to choose an account to pay transaction feeds, select to use a different account:
+
+  ```sh
+  Use a different account (select to see options)
   ```
 
+1. Next, select to create a new fee payer key pair:  
 
-  ```text
-  ✔ Create a name (can be anything): · berkeley2
-✔ Set the Mina GraphQL API URL to deploy to: · https://proxy.berkeley.minaexplorer.com/graphql
+  ```sh
+  Create a new fee payer key pair
+  NOTE: the private key will be stored in plain text on this computer.
+  ```
 
-✔ Set transaction fee to use when deploying (in MINA): · 0.1
-✔ Choose an account to pay transaction fees: · Use stored account testprivatekey1 (public key: <yourhash>)
-✔ Use stored fee payer testprivatekey1 (public key: <yourhash>)
-✔ Create zkApp key pair at keys/berkeley2.json
-✔ Add deploy alias to config.json
+1. When prompted, give an alias to your new fee payer key pair. For this tutorial, use `03-deploy`:
 
-Success!
+  ```sh
+  Create an alias for this account: 03-deploy
+  ```
 
-Next steps:
-  - If this is a testnet, request tMINA at:
-    https://faucet.minaprotocol.com/?address=<yourhash>?explorer=minaexplorer
-  - To deploy, run: `zk deploy berkeley2`
-```
+  Your key pairs and deploy alias are created:
+
+  ```sh
+  ✔ Create fee payer key pair at /Users/<username>/.cache/zkapp-cli/keys/03-deploy.json
+  ✔ Create zkApp key pair at keys/berkeley2.json
+  ✔ Add deploy alias to config.json
+
+  Success!
+
+  Next steps:
+    - If this is a testnet, request tMINA at:
+      https://faucet.minaprotocol.com/?address=B62qqK5JgYAtmh2DHsQfUjUSKwQ6CFSPkGvyMZd19j1BUHfEJEqpKGo&?explorer=minaexplorer
+    - To deploy, run: `zk deploy berkeley`
 
 1. Request funds from the Testnet Faucet to fund your fee payer account.
 
-  Follow the prompts to request tMINA. For this tutorial, your MINA ADDRESS is populated on the Testnet Faucet. tMina arrives at your address when the next block is produced (~3 min).
+  Follow the prompts to request tMINA. For this tutorial, your MINA address is populated on the Testnet Faucet. tMINA arrives at your address when the next block is produced (~3 minutes).
 
 1. To deploy your project:
 
@@ -206,25 +214,29 @@ Next steps:
   ✔ Build project
   ✔ Generate build.json
   ✔ Choose smart contract
-    Only one smart contract exists in the project: Add
+    Only one smart contract exists in the project: Square
     Your config.json was updated to always use this
-    smart contract when deploying to this network.
+    smart contract when deploying to this deploy alias.
   ✔ Generate verification key (takes 10-30 sec)
+  ⠋ Build transaction...(node:25066) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
+  (Use `node --trace-warnings ...` to show where the warning was created)
   ✔ Build transaction
   ```
 
 1. Review and confirm the details of the transaction: 
   
   ```text
-  ? Confirm to send transaction
+  ✖ Confirm to send transaction
 
-  ┌────────────────┬─────────────────────────────────────────────────┐
-  │ Deploy Alias   │ berkeley                                        │
-  ├────────────────┼─────────────────────────────────────────────────┤
-  │ Url            │ https://proxy.berkeley.minaexplorer.com/graphql │
-  ├────────────────┼─────────────────────────────────────────────────┤
-  │ Smart Contract │ Square                                          │
-  └────────────────┴─────────────────────────────────────────────────┘
+    ┌─────────────────┬─────────────────────────────────────────────────┐
+    │ Deploy Alias    │ berkeley2                                       │
+    ├─────────────────┼─────────────────────────────────────────────────┤
+    │ Fee-Payer Alias │ 03-deploy                                       │
+    ├─────────────────┼─────────────────────────────────────────────────┤
+    │ URL             │ https://proxy.berkeley.minaexplorer.com/graphql │
+    ├─────────────────┼─────────────────────────────────────────────────┤
+    │ Smart Contract  │ Square                                          │
+    └─────────────────┴─────────────────────────────────────────────────┘
   ```
   
   When prompted, type `yes` to confirm and send the transaction.
@@ -248,7 +260,18 @@ Next steps:
 
 After the transaction is included in a block, your smart contract is deployed!
 
-The Mina account at this public key now contains the verification key associated with this smart contract.
+- The Mina account at this public key now contains the verification key associated with this smart contract.
+
+You ran the `zk config` command to:
+
+- Create a deploy alias
+- Create fee payer key pair at `/Users/<username>/.cache/zkapp-cli/keys/03deploy.json`
+✔ Create zkApp key pair at `keys/berkeley.json`
+✔ Add deploy alias to config.json
+
+You requested tMINA to fund your deploy transactions. Use the remaining tMINA to keep building and testing.
+
+## About the Smart Contract Transactions
 
 Because this tutorial used the smart contract for Tutorial 1: Hello World, the smart contract `editState` permissions require that a transaction must contain a valid zk proof that was created by the private key associated with this zkApp account. 
 

--- a/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
+++ b/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
@@ -38,6 +38,8 @@ This tutorial has been tested with [Mina zkApp CLI](https://github.com/o1-labs/z
 
 Ensure your environment meets the [Prerequisites](/zkapps/tutorials#prerequisites) for zkApp Developer Tutorials.
 
+
+
 ## Create a project
 
 1. Create or change to a directory where you have write privileges.
@@ -116,17 +118,33 @@ In some cases, you might need to create a custom account for your zkApp, for exa
 
 ## Deploy the smart contract 
 
-The `config.json` configuration file was automatically scaffolded when created your project with the `zk project` command. However, the generated file does not yet contain the deploy alias. 
+The `config.json` configuration file was automatically scaffolded when you created your project with the `zk project` command. However, the generated file does not yet contain the deploy alias.
 
-You can have one or more deploy aliases for your project. Using naming patterns is helpful when you have more than one deploy alias. You can change the name at anytime in the `config.json` file.
+You can have one or more deploy aliases for your project. Using naming patterns is helpful when you have more than one deploy alias. 
 
 A deploy alias consists of:
 
 - A self-describing name. This tutorial uses `berkeley`. The deploy alias name can be anything and does not have to match the network name.
 - The Mina GraphQL API URL that defines the network that receives your deploy transaction and broadcast it to the appropriate Mina network (Testnet, Devnet, Mainnet, and so on)
 - The transaction fee (in MINA) to use when deploying
+- Two key pairs:
 
-The `zk config` command helps manage your deployment. The command prompts guide you to create or update a deploy alias in your project `config.json` file. 
+  - Creates a key pair for the zkApp account
+  - Creates or selects an existing key pair to use as a fee payer for updates and deployments
+
+- Fee payer alias
+
+The command prompts guide you to create or update a deploy alias in your project `config.json` file. 
+
+A fee payer account is required. If you don't have a fee payer account, you are prompted to select one of these options:
+
+- Recover fee payer account from an existing base58 private key
+- Create a new fee payer key pair
+
+If you have previously run `zk config` and selected a fee payer account, then you already have a fee payer account. Your prompts are: 
+
+- ❯ Use stored account dev (public key: <yourpublickey>)
+  Use a different account (select to see options)
 
 1. To configure your deployment, run the `zk config` command and respond to the prompts:
 
@@ -139,8 +157,27 @@ The `zk config` command helps manage your deployment. The command prompts guide 
     - name: `berkeley`
     - Mina GraphQL API URL: `https://proxy.berkeley.minaexplorer.com/graphql`
     - transaction fee: `0.1`
+    - stored account: `testprivatekey1 (public key: <yourpublickey>)`
 
   Public and private keys to use in your application are automatically generated in `keys/berkeley.json`.
+
+  ```text
+  ✔ Create a name (can be anything): · berkeley2
+✔ Set the Mina GraphQL API URL to deploy to: · https://proxy.berkeley.minaexplorer.com/graphql
+
+✔ Set transaction fee to use when deploying (in MINA): · 0.1
+✔ Choose an account to pay transaction fees: · Use stored account testprivatekey1 (public key: <yourhash>)
+✔ Use stored fee payer testprivatekey1 (public key: <yourhash>)
+✔ Create zkApp key pair at keys/berkeley2.json
+✔ Add deploy alias to config.json
+
+Success!
+
+Next steps:
+  - If this is a testnet, request tMINA at:
+    https://faucet.minaprotocol.com/?address=<yourhash>?explorer=minaexplorer
+  - To deploy, run: `zk deploy berkeley2`
+```
 
 1. Request funds from the Testnet Faucet to fund your fee payer account.
 
@@ -149,7 +186,14 @@ The `zk config` command helps manage your deployment. The command prompts guide 
 1. To deploy your project:
 
   ```sh
-  $ zk deploy berkeley
+  $ zk deploy
+  ```
+
+1. At the interactive prompt, select the `berkeley` deploy alias:
+
+  ```text
+  ? Which deploy alias would you like to deploy to? …
+  ❯ berkeley
   ```
 
   A verification key for your smart contract is generated (takes 10-30 seconds). 

--- a/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
+++ b/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
@@ -118,7 +118,9 @@ In some cases, you might need to create a custom account for your zkApp, for exa
 
 ## Deploy the smart contract 
 
-The `config.json` configuration file was automatically scaffolded when you created your project with the `zk project` command. However, the generated file does not yet contain the deploy alias.
+The `config.json` configuration file was automatically scaffolded when you created your project with the `zk project` command. However, the generated configuration file does not yet contain the deploy alias. The `zk config` command prompts guide you to create or update a deploy alias in your project `config.json` file. 
+
+### Deploy alias
 
 You can have one or more deploy aliases for your project. Using naming patterns is helpful when you have more than one deploy alias. 
 
@@ -129,22 +131,16 @@ A deploy alias consists of:
 - The transaction fee (in MINA) to use when deploying
 - Two key pairs:
 
-  - Creates a key pair for the zkApp account
-  - Creates or selects an existing key pair to use as a fee payer for updates and deployments
+  - Creates a key pair for the zkApp account. Public and private keys to use in your application are automatically generated in `keys/berkeley.json`.
 
-- Fee payer alias
+  - Creates or selects an existing key pair to use as a fee payer account for updates and deployments. Public and private keys are stored on your local computer and can be used across multiple projects.
 
-The command prompts guide you to create or update a deploy alias in your project `config.json` file. 
+- Fee payer account alias 
 
 A fee payer account is required. If you don't have a fee payer account, you are prompted to select one of these options:
 
 - Recover fee payer account from an existing base58 private key
 - Create a new fee payer key pair
-
-If you have previously run `zk config` and selected a fee payer account, then you already have a fee payer account. Your prompts are: 
-
-- ❯ Use stored account dev (public key: <yourpublickey>)
-  Use a different account (select to see options)
 
 1. To configure your deployment, run the `zk config` command and respond to the prompts:
 
@@ -157,9 +153,15 @@ If you have previously run `zk config` and selected a fee payer account, then yo
     - name: `berkeley`
     - Mina GraphQL API URL: `https://proxy.berkeley.minaexplorer.com/graphql`
     - transaction fee: `0.1`
-    - stored account: `testprivatekey1 (public key: <yourpublickey>)`
+    - 
 
-  Public and private keys to use in your application are automatically generated in `keys/berkeley.json`.
+  If you have previously run `zk config` and selected a fee payer account, then you already have a fee payer account. Your prompts are: 
+
+  ```text
+    ❯ Use stored account dev (public key: <yourpublickey>)
+    Use a different account (select to see options)
+  ```
+
 
   ```text
   ✔ Create a name (can be anything): · berkeley2

--- a/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
+++ b/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Tutorial 3: Deploying to a Live Network'
+title: 'Tutorial 3: Deploy to a Live Network'
 hide_title: true
-sidebar_label: 'Tutorial 3: Deploying to a Live Network'
+sidebar_label: 'Tutorial 3: Deploy to a Live Network'
 description: Use the Mina zkApp CLI tool to deploy a smart contract to a live network.
 keywords:
   - smart contracts
@@ -12,6 +12,8 @@ keywords:
   - zk
   - blockchain
   - mina
+  - deploy to a live network
+  - mina testnet
 ---
 
 :::info
@@ -20,167 +22,200 @@ zkApp programmability is not yet available on the Mina Mainnet. You can get star
 
 :::
 
-:::note
+# Tutorial 3: Deploy to a Live Network
 
-This tutorial was last tested with [SnarkyJS](https://www.npmjs.com/package/snarkyjs) 0.8.0.
+In previous tutorials, you learned how to deploy and run transactions on a local network. In this tutorial, you deploy a project to a live network.
 
-:::
+In this tutorial, you deploy a contract to the Berkeley Testnet.
 
-# Tutorial 3: Deploying to a Live Network
+Mina zkApps are available only on feature-complete Berkeley, Mina's public Testnet. Only minor changes and bug fixes are expected before Mainnet. 
 
-## Overview
+This tutorial reuses the `Square` contract that you created in [Tutorial 1: Hello World](hello-world).
 
-In previous tutorials, we've seen how to deploy and run transactions on a local network. In this tutorial, we will see how to deploy against a real, live network.
+## Prerequisites
 
-Mina's zkApps are currently available on Berkeley, Mina's public testnet, which is in its final stages of testing before Mainnet. In this tutorial, we will deploy our contract to the Berkeley Testnet. Berkeley is feature complete, and only minor changes and bugfixes are expected before Mainnet.
+This tutorial has been tested with [Mina zkApp CLI](https://github.com/o1-labs/zkapp-cli) version `0.9.0` and [SnarkyJS](https://www.npmjs.com/package/snarkyjs) `0.11.0`.
 
-We will reuse the same smart contract from [Tutorial 1](hello-world), the `Square` contract.
+Ensure your environment meets the [Prerequisites](/zkapps/tutorials#prerequisites) for zkApp Developer Tutorials.
 
-## Project setup
+## Create a project
 
-First, as usual, setup a new project with
+1. Create or change to a directory where you have write privileges.
 
-```sh
-$ zk project 03-deploying-to-a-live-network
-```
+2. Create a project by using the `zk project` command:
 
-To start, delete the default generated files by running:
+  ```sh
+  $ zk project 03-deploying-to-a-live-network
+  ```
 
-```sh
-$ rm src/Add.ts
-$ rm src/Add.test.ts
-$ rm src/interact.ts
-```
+  The `zk project` command has the ability to scaffold the UI for your project. For this tutorial, select `none`:
 
-And create a new file for our smart contract:
+  ```
+  ? Create an accompanying UI project too? …
+    next
+    svelte
+    nuxt
+    empty
+  ❯ none
+  ```
+  The expected output is:
 
-```sh
-$ zk file src/Square
-```
+  ```sh
+  ✔ Create an accompanying UI project too? · none
+  ✔ UI: Set up project
+  ✔ Initialize Git repo
+  ✔ Set up project
+  ✔ NPM install
+  ✔ NPM build contract
+  ✔ Set project name
+  ✔ Git init commit
 
-Copy in `src/Square.ts` and `src/index.ts` from the first tutorial - you can find these [here](https://github.com/o1-labs/docs2/tree/main/examples/zkapps/01-hello-world/src).
+  Success!
 
-That's all for setup - let's proceed to deploying to Berkeley Testnet.
+  Next steps:
+    cd 03-deploying-to-a-live-network
+    git remote add origin <your-repo-url>
+    git push -u origin main
+  ```
 
-## Deploying the smart contract
+  The `zk project` command creates the `03-deploying-to-a-live-network` directory that contains the scaffolding for your project, including tools such as the Prettier code formatting tool, the ESLint static code analysis tool, and the Jest JavaScript testing framework. 
 
-A CLI tool is provided for convenience for deploying smart contracts to networks. If you need more custom account creation for your zkApp - say deploying a zkApp to a different key than the fee payer key, programmatically parameterizing a zkApp before initializing it, or creating a Smart Contract programmatically for users as part of an application - see the server-side tutorial mentioned in the [conclusion](#conclusion).
+1. Change into the `03-deploying-to-a-live-network` directory.
 
-### zk config
+For this tutorial, you run commands from the root of the `03-deploying-to-a-live-network` directory as you work in the `src` directory on files that contain the TypeScript code for the smart contract. 
 
-`zk config` is a tool provided for managing CLI deployments. It will create a `config.json` in our project's directory, as well as a `keys` folder, containing private and public keys for our application.
+Each time you make updates, then build or deploy, the TypeScript code is compiled into JavaScript in the `build` directory.
 
-To use, run:
+### Prepare the project
 
-```sh
-$ zk config
-```
+Start by deleting the default files that come with the new project.
 
-It will ask you to specify a name (can be anything), URL to deploy to, and fee (in
-MINA) to be used when sending your deploy transaction. The URL is the Mina GraphQL API
-that will receive your deploy transaction and broadcast it to the Mina network.
-Note that this URL is significant because it also determines which network you will
-be deploying to (e.g. QANet, Testnet, Mainnet, etc).
+1. Delete the default generated files:
 
-For Berkeley Testnet, let's use the following values:
+  ```sh
+  $ rm src/Add.ts
+  $ rm src/Add.test.ts
+  $ rm src/interact.ts
+  ```
 
-- **Name**: `berkeley`
-- **URL**: `https://proxy.berkeley.minaexplorer.com/graphql`
-- **Fee**: `0.1`
+1. Now, create a new file for your smart contract:
 
-:::tip
-If your project contains multiple smart contracts (e.g. `Foo` and `Bar`) that
-you intend to deploy to the same network, we recommend following a naming
-pattern such as `berkeley-foo` and `berkeley-bar` when naming your deploy
-aliases. You can change their names at anytime within `config.json`.
-:::
+  ```sh
+  $ zk file src/Square
+  ```
 
-<br />
+1. Copy the `src/Square.ts` and `src/index.ts` files from the example files for first tutorial [01-hello-world/src](https://github.com/o1-labs/docs2/tree/main/examples/zkapps/01-hello-world/src) to your local `03-deploying-to-a-live-network/src` directory.
 
-You will see the following output:
+Now that your smart contract is in place, you are ready to deploy your smart contract to Berkeley Testnet.
 
-```sh
-$ zk config
+## Mina zkApp CLI
 
-Add a new network:
-✔ Choose a name (can be anything): · berkeley
-✔ Set URL to deploy to: · https://proxy.berkeley.minaexplorer.com/graphql
-✔ Set transaction fee to use when deploying (in MINA): · 0.1
-✔ Create key pair at keys/berkeley.json
-✔ Add network to config.json
+You already installed the Mina zkApp CLI as part of the [Prerequisites](/zkapps/tutorials#prerequisites), so you have the tools to manage deployments.
 
-Success!
+In some cases, you might need to create a custom account for your zkApp, for example, to deploy a zkApp to a different key than the fee payer key, programmatically parameterize a zkApp before you initialize it, or create a smart contract programmatically for users as part of an application. For details, see [Interacting with zkApps server-side](/zkapps/tutorials/interacting-with-zkapps-server-side).
 
-Next steps:
+## Deploy the smart contract 
 
-- If this is a testnet, request tMINA at:
-  https://faucet.minaprotocol.com/?address=<YOUR-ADDRESS>
-- To deploy, run: `zk deploy berkeley`
-```
+The `config.json` configuration file was automatically scaffolded when created your project with the `zk project` command. However, the generated file does not yet contain the deploy alias. 
 
-This command also generates keys, in `keys/berkeley.json`, that we will use in our application.
+You can have one or more deploy aliases for your project. Using naming patterns is helpful when you have more than one deploy alias. You can change the name at anytime in the `config.json` file.
 
-## Request funds from the faucet
+A deploy alias consists of:
 
-To deploy your zkApp, you will need some funds to pay for transaction fees.
+- A self-describing name. This tutorial uses `berkeley`. The deploy alias name can be anything and does not have to match the network name.
+- The Mina GraphQL API URL that defines the network that receives your deploy transaction and broadcast it to the appropriate Mina network (Testnet, Devnet, Mainnet, and so on)
+- The transaction fee (in MINA) to use when deploying
 
-To get funds on the Berkeley Testnet, use the URL that was shown from the CLI output. Visit `https://faucet.minaprotocol.com/?address=<YOUR-ADDRESS>` and click **Request**.
+The `zk config` command helps manage your deployment. The command prompts guide you to create or update a deploy alias in your project `config.json` file. 
 
-You will have to wait a few minutes for the next block to include your transaction, so you'll have tMINA before proceeding to the next step.
+1. To configure your deployment, run the `zk config` command and respond to the prompts:
 
-## Deploy your smart contract
+  ```sh
+  $ zk config
+  ```
 
-To deploy your smart contract to the network, run the following command:
+  For this tutorial on Berkeley Testnet, use:
+  
+    - name: `berkeley`
+    - Mina GraphQL API URL: `https://proxy.berkeley.minaexplorer.com/graphql`
+    - transaction fee: `0.1`
 
-```sh
-$ zk deploy berkeley
-```
+  Public and private keys to use in your application are automatically generated in `keys/berkeley.json`.
 
-When running the deploy command, the zkApp CLI will compute a verification key for your smart contract. Computing the verification key can take 1-2 minutes, so please be patient. The zkApp CLI will show you the details of the transaction such as the network name, the URL, and the smart contract that will be deployed.
+1. Request funds from the Testnet Faucet to fund your fee payer account.
 
-Finally, enter `yes` or `y` when prompted, to confirm and send the transaction.
+  Follow the prompts to request tMINA. For this tutorial, your MINA ADDRESS is populated on the Testnet Faucet. tMina arrives at your address when the next block is produced (~3 min).
 
-You will see the following output:
+1. To deploy your project:
 
-```sh
-$ zk deploy berkeley
+  ```sh
+  $ zk deploy berkeley
+  ```
 
-✔ Build project
-✔ Generate build.json
-✔ Choose smart contract
-  Only one smart contract exists in the project: Add
-  Your config.json was updated to always use this
-  smart contract when deploying to this network.
-✔ Generate verification key (takes 10-30 sec)
-✔ Build transaction
-✔ Confirm to send transaction
-  Are you sure you want to send (yes/no)? · y
-✔ Send to network
+  A verification key for your smart contract is generated (takes 10-30 seconds). 
+  
+  The deploy process is output:
 
-Success! Deploy transaction sent.
+  ```text
+  ✔ Build project
+  ✔ Generate build.json
+  ✔ Choose smart contract
+    Only one smart contract exists in the project: Add
+    Your config.json was updated to always use this
+    smart contract when deploying to this network.
+  ✔ Generate verification key (takes 10-30 sec)
+  ✔ Build transaction
+  ```
 
-Next step:
-  Your smart contract will be live (or updated)
-  as soon as the transaction is included in a block:
-  https://berkeley.minaexplorer.com/transaction/<txn-hash>
-```
+1. Review and confirm the details of the transaction: 
+  
+  ```text
+  ? Confirm to send transaction
 
-After a few minutes, the transaction will be included in the next block. Visit `https://berkeley.minaexplorer.com/transaction/<txn-hash>` to see the transaction in progresss.
+  ┌────────────────┬─────────────────────────────────────────────────┐
+  │ Deploy Alias   │ berkeley                                        │
+  ├────────────────┼─────────────────────────────────────────────────┤
+  │ Url            │ https://proxy.berkeley.minaexplorer.com/graphql │
+  ├────────────────┼─────────────────────────────────────────────────┤
+  │ Smart Contract │ Square                                          │
+  └────────────────┴─────────────────────────────────────────────────┘
+  ```
+  
+  When prompted, type `yes` to confirm and send the transaction.
 
-Once the transaction is included in a block, your smart contract is deployed!
+  ```text
+  ✔ Send to network
 
-This means, the Mina account at this public key now contains the verification key associated with this smart contract.
+  Success! Deploy transaction sent.
 
-Because we didn't modify our smart contract's `editState` permissions when writing in Tutorial 1, a transaction must contain a valid ZK proof created by the private key associated with this zkApp account, in order to be accepted by the zkApp account. Typically, you'll only allow proof authorization. More instruction on setting permissions will come in a later tutorial.
+  Next step:
+    Your smart contract will be live (or updated)
+    as soon as the transaction is included in a block:
+  ```
 
-When a user interacts with this smart contract by providing a proof, the proof is generated locally on the user's device, and included in a transaction. When the transaction is submitted to the network, Mina will check the proof, to know it is correct and matches the on-chain verification key. After it is accepted, the proof and transaction will be recursively proved, and bundled into Mina's recursive ZKP.
+1. To see the zkApp transaction, go to `https://berkeley.minaexplorer.com/transaction/<txn-hash>`, where `<txn-hash>` is the transaction hash that is output to your terminal. 
 
-When we change our code, the verification key associated with it will change, and the contract should be redeployed using the same steps as our initial deployment.
+    - The zkApp Pending Transaction shows until the transaction is included in the next block.
+    - The zkApp Transaction shows after the transaction is included in a block.
+
+## Success
+
+After the transaction is included in a block, your smart contract is deployed!
+
+The Mina account at this public key now contains the verification key associated with this smart contract.
+
+Because this tutorial used the smart contract for Tutorial 1: Hello World, the smart contract `editState` permissions require that a transaction must contain a valid zk proof that was created by the private key associated with this zkApp account. 
+
+- When a user interacts with this smart contract by providing a proof, the proof is generated locally on the user's device and included in a transaction. 
+- When the transaction is submitted to the network, the proof is checked to ensure it is correct and matches the on-chain verification key. 
+- After the transaction is accepted, the proof and transaction are recursively proved and bundled into Mina's recursive zero knowledge proof.
+
+When you change the smart contract code, the associated verification key also changes. Use the same steps to redeploy the smart contract. 
+
+For a typical smart contract, permissions are set to allow only proof authorization: the proof in zero knowledge proof. You learn more about setting permissions in a later tutorial.
 
 ## Conclusion
 
-We have finished deploying to a live network using the zkApp CLI!
+Congratulations! You have successfully deployed a smart contract to a live network.
 
-If you would like to learn how to build server-side scripts that interact with zkApps, see that tutorial [here](./interacting-with-zkapps-server-side).
-
-Checkout [Tutorial 4](zkapp-ui-with-react) to learn how to zkApp UIs with ReactJS that run in the browser with a wallet.
+Check out [Tutorial 4: Build a zkApp UI in the Browser with React](zkapp-ui-with-react) to implement a browser UI that interacts with a smart contract.

--- a/docs/zkapps/tutorials/04-zkapp-ui-with-react.mdx
+++ b/docs/zkapps/tutorials/04-zkapp-ui-with-react.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Tutorial 4: Building a zkApp UI in the Browser with React'
+title: 'Tutorial 4: Build a zkApp UI in the Browser with React'
 hide_title: true
-sidebar_label: 'Tutorial 4: Building a zkApp UI in the Browser with React'
+sidebar_label: 'Tutorial 4: Build a zkApp UI in the Browser with React'
 description: Guided steps to implement a browser UI using ReactJS that interacts with a smart contract running on the Berkeley Testnet.
 keywords:
   - smart contracts
@@ -16,7 +16,7 @@ keywords:
   - mina
 ---
 
-# Tutorial 4: Building a zkApp UI in the Browser with React
+# Tutorial 4: Build a zkApp UI in the Browser with React
 
 :::info
 

--- a/docs/zkapps/tutorials/index.mdx
+++ b/docs/zkapps/tutorials/index.mdx
@@ -23,14 +23,14 @@ To meet other developers building zkApps with SnarkyJS, participate in the [#zka
 
 ## Prerequisites
 
-Each tutorial has been tested with specific versions:
+Each tutorial has been tested with the latest versions:
 
 - [Mina zkApp CLI](https://github.com/o1-labs/zkapp-cli)
 - [SnarkyJS](https://www.npmjs.com/package/snarkyjs)
 
     SnarkyJS is automatically included when you create a project using the Mina zkApp CLI.
 
-- Other dependencies as noted
+- Other dependencies as noted.
 
 ### Install the Mina zkApp CLI
 


### PR DESCRIPTION
Preview https://docs2-git-tuto3-edits-minadocs.vercel.app/zkapps/tutorials/deploying-to-a-network
This PR includes:

- edits to tuto 1, 2, 4 for style 
- Substantive improvements to Tutorial 3: Deploy to a Live Network

To improve SEO, replace gerunds with active verbs to match search patterns "Deploy to.." instead of "Deploying to..."

Follow and adhere to tutorial standards in https://github.com/o1-labs/docs2/wiki/Tutorial-standards 