### PR TITLE
Fix tutorial 1 test runner

### DIFF
--- a/docs/zkapps/tutorials/01-hello-world.mdx
+++ b/docs/zkapps/tutorials/01-hello-world.mdx
@@ -48,9 +48,13 @@ To prevent copying line numbers and command prompts as shown in the examples, us
 
 ## Prerequisites
 
-This tutorial has been tested with [Mina zkApp CLI](https://github.com/o1-labs/zkapp-cli) version `0.7.5` and [SnarkyJS](https://www.npmjs.com/package/snarkyjs) `0.9.8`.
-
 Ensure your environment meets the [Prerequisites](/zkapps/tutorials#prerequisites) for zkApp Developer Tutorials.
+
+In particular, make sure you have the zkapp CLI installed:
+
+```sh
+$ npm install -g zkapp-cli
+```
 
 ## Create a new project
 

--- a/docs/zkapps/tutorials/01-hello-world.mdx
+++ b/docs/zkapps/tutorials/01-hello-world.mdx
@@ -50,7 +50,7 @@ To prevent copying line numbers and command prompts as shown in the examples, us
 
 Ensure your environment meets the [Prerequisites](/zkapps/tutorials#prerequisites) for zkApp Developer Tutorials.
 
-In particular, make sure you have the zkapp CLI installed:
+In particular, make sure you have the zkApp CLI installed:
 
 ```sh
 $ npm install -g zkapp-cli

--- a/docs/zkapps/tutorials/02-private-inputs-hash-functions.mdx
+++ b/docs/zkapps/tutorials/02-private-inputs-hash-functions.mdx
@@ -43,12 +43,6 @@ This tutorial has been tested with [Mina zkApp CLI](https://github.com/o1-labs/z
 
 Ensure your environment meets the [Prerequisites](/zkapps/tutorials#prerequisites) for zkApp Developer Tutorials.
 
-In particular, make sure you have the zkApp CLI installed:
-
-```sh
-$ npm install -g zkapp-cli
-```
-
 ## Create a project
 
 1. Create or change to a directory where you have write privileges.

--- a/docs/zkapps/tutorials/02-private-inputs-hash-functions.mdx
+++ b/docs/zkapps/tutorials/02-private-inputs-hash-functions.mdx
@@ -43,6 +43,12 @@ This tutorial has been tested with [Mina zkApp CLI](https://github.com/o1-labs/z
 
 Ensure your environment meets the [Prerequisites](/zkapps/tutorials#prerequisites) for zkApp Developer Tutorials.
 
+In particular, make sure you have the zkApp CLI installed:
+
+```sh
+$ npm install -g zkapp-cli
+```
+
 ## Create a project
 
 1. Create or change to a directory where you have write privileges.


### PR DESCRIPTION
Fixes tutorial 1 CI test by adding back the zkapp cli installation command which the tutorial runner needs to execute to get things started.

Also, I removed the disclaimer "this tutorial was last tested with versions ...", since the tutorial runner CI for tutorial 1 is actually always tested with the latest versions in CI