### PR TITLE
user evergreen links for social constants

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,9 @@
 export const SocialLinks = {
-  Github: 'https://github.com/MinaProtocol/mina',
+  GitHub: 'https://github.com/MinaProtocol/mina',
   Twitter: 'https://twitter.com/minaprotocol',
   WeChat: 'https://forums.minaprotocol.com/',
-  Youtube: 'https://www.youtube.com/channel/UCWzKMFfIlMzHUXKSnYot5HA',
-  Facebook: 'http://bit.ly/MinaProtocolFacebook',
-  Discord: 'https://bit.ly/MinaDiscord',
+  YouTube: 'https://www.youtube.com/c/minaprotocol',
+  Discord: 'https://discord.gg/minaprotocol',
   Telegram: 'http://bit.ly/MinaTelegram',
   Support: 'https://support.minaprotocol.com',
 };

--- a/src/theme/Footer/index.tsx
+++ b/src/theme/Footer/index.tsx
@@ -89,16 +89,13 @@ function Footer(): JSX.Element | null {
             <Link href={SocialLinks.Twitter}>
               <TwitterLogo />
             </Link>
-            <Link href={SocialLinks.Facebook}>
-              <FacebookLogo />
-            </Link>
             <Link href={SocialLinks.Telegram}>
               <TelegramLogo />
             </Link>
             <Link href={SocialLinks.WeChat}>
               <WeChatLogo />
             </Link>
-            <Link href={SocialLinks.Youtube}>
+            <Link href={SocialLinks.YouTube}>
               <YoutubeLogo />
             </Link>
           </div>
@@ -198,7 +195,7 @@ function Footer(): JSX.Element | null {
                   <Link href={SocialLinks.Telegram}>Forums</Link>
                 </li>
                 <li>
-                  <Link href={SocialLinks.Github}>Github</Link>
+                  <Link href={SocialLinks.GitHub}>Github</Link>
                 </li>
                 <li>
                   <Link href={SocialLinks.Support}>Contact Us</Link>


### PR DESCRIPTION
This PR removed the Facebook social constant since there have been no FB posts for 3 years and replaced the personal invites with evergreen link URLs