### PR TITLE
fix: glossary remove term without a definition

### DIFF
--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -1,6 +1,6 @@
 ---
 title: Glossary
-description: A zero knowledge list of terms with a focus on the Mina ecosystem. 
+description: A list of terms relating to zero knowledge and the Mina ecosystem. 
 keywords:
   - zk
   - zero knowledge

--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -1,6 +1,6 @@
 ---
 title: Glossary
-description: zkApps (zero knowledge apps) are Mina Protocol smart contracts powered by zero knowledge proofs, specifically using zk-SNARKs. Use this quickstart guide to deploy zkApps and resources for learning TypeScript.
+description: A zero knowledge list of terms with a focus on the Mina ecosystem. 
 keywords:
   - zk
   - zero knowledge
@@ -32,7 +32,7 @@ A Mina node that stores the historical chain data to a persistent data source so
 
 ### best tip
 
-The blockchain's latest block with the highest [chain strength](#chain-strength) known to the daemon.
+The blockchain's latest block with the highest [chain strength](#chain-strength) known to the mina daemon.
 
 ### block
 
@@ -87,8 +87,6 @@ An algorithm or set of rules that Mina nodes all agree upon when deciding to upd
 ### consensus node
 
 A participant in the Mina network that performs the consensus function, for example, a [block producer](#block-producer).
-
-### constraints
 
 ### cryptocurrency
 
@@ -192,7 +190,7 @@ The unit of the cryptocurrency that is exchanged by participating nodes on the M
 
 ### Mina CLI
 
-The primary way for users to interact with the Mina network. The command line tool provides standard client functionality to create accounts, send transactions, and participate in consensus and advanced client and daemon commands for power users.
+The primary way for users to interact with the Mina network. The [Mina CLI](/node-operators/mina-cli-reference) command line tool provides standard client functionality to create accounts, send transactions, and participate in consensus and advanced client and daemon commands for power users.
 
 The Mina CLI is installed when you [install Mina](/node-operators/getting-started#installation).
 


### PR DESCRIPTION
Quick fix to add a link and remove an undefined term. 
More work to follow!