### PR TITLE
Add detailed instructions for setting up archive node using Docker and Docker Compose

### DIFF
--- a/docs/node-operators/archive-node.mdx
+++ b/docs/node-operators/archive-node.mdx
@@ -106,6 +106,145 @@ To run a local archive node to run it in the foreground for testing:
   
   To connect to an archive process on another machine, specify a hostname with `localhost:3086`.
 
+## Set up the archive node using Docker
+
+To get started with installing and running the archive node using Docker, follow the steps below.
+
+1. Install Docker on your machine. For more information, see [Docker](https://docs.docker.com/get-docker/).
+
+2. Pull the archive node image from Docker Hub.
+
+   ```sh
+   docker pull minaprotocol/mina-archive:1.3.0-9b0369c-bullseye
+   ```
+
+3. Pull and install the postgres image from Docker Hub.
+
+   ```sh
+   docker pull postgres
+   ```
+
+4. Start the postgres container and expose it's networking to other containers.
+
+   ```sh
+   docker run --name postgres -p 5432:5432 -e POSTGRES_PASSWORD=postgres -d postgres
+   ```
+
+5. Create a local postgres database called `archive`.
+
+   ```sh
+   docker exec -it postgres createdb -U postgres archive
+   ```
+
+6. Load the mina archive schema into the archive database.
+
+   ```sh
+   curl -Ls https://raw.githubusercontent.com/MinaProtocol/mina/master/src/app/archive/create_schema.sql | docker exec -i postgres psql -U postgres -d archive
+   ```
+
+7. Create a local directory to store the archive node data.
+
+   ```sh
+   mkdir -p /tmp/archive
+   ```
+
+8. Start the archive node.
+
+   ```sh
+   docker run \
+   --name archive \
+   -p 3086:3086 \
+   -v /tmp/archive:/data \
+   minaprotocol/mina-archive:1.3.0-9b0369c-bullseye \
+   mina-archive run \
+   --postgres-uri postgres://postgres:postgres@postgres:5432/archive \
+   --server-port 3086
+
+   ```
+
+9. Start the mina daemon and connect it to the archive process that you started on port 3086:
+
+   ```
+   mina daemon \
+       .....
+     --archive-address 3086\
+   ```
+
+## Set up the archive node using Docker Compose
+
+Docker compose is a tool for defining and running multi-container Docker applications.
+With Compose, you use a YAML file to configure your application's services. Then, with a single command, you create and start all the services from your configuration.
+
+If you wish to run the archive node using Docker Compose, you can use the following instructions.
+
+To get started with installing and running the archive node using Docker Compose, follow the steps below.
+
+1. Install Docker on your machine. For more information, see [Docker](https://docs.docker.com/get-docker/).
+
+2. Install Docker Compose on your machine. For more information, see [Docker Compose](https://docs.docker.com/compose/install/).
+
+3. Pull the archive node image from Docker Hub.
+
+   ```sh
+   docker pull minaprotocol/mina-archive:1.3.0-9b0369c-bullseye
+   ```
+
+4. Pull and install the postgres image from Docker Hub.
+
+   ```sh
+    docker pull postgres
+   ```
+
+5. Create a local directory to store the archive node data.
+
+   ```sh
+   mkdir -p /tmp/archive
+   ```
+
+6. Create a `docker-compose.yml` file with the following contents:
+
+   ```yml
+   version: '3.8'
+   services:
+     postgres:
+       image: postgres
+       environment:
+         POSTGRES_PASSWORD: postgres
+       volumes:
+         - './postgres-data:/var/lib/postgresql/data'
+       ports:
+         - '5432:5432'
+     archive:
+       image: 'minaprotocol/mina-archive:1.3.0-9b0369c-bullseye'
+       command: >-
+         mina-archive run --postgres-uri
+         postgres://postgres:postgres@postgres:5432/archive --server-port 3086
+       volumes:
+         - '/tmp/archive:/data'
+       ports:
+         - '3086:3086'
+       depends_on:
+         - postgres
+   ```
+
+7. Start the archive node.
+
+   ```sh
+   # If you are running Docker Compose V1:
+   docker-compose up
+
+   # If you are running Docker Compose V2:
+   docker compose up
+   ```
+
+8. Start the mina daemon and connect it to the archive process that you started on port 3086:
+
+   ```
+   mina daemon \
+       .....
+     --archive-address 3086\
+   ```
+
 ## Using the Archive Node
 
 Take a look at the tables in the database.

--- a/docs/node-operators/archive-node.mdx
+++ b/docs/node-operators/archive-node.mdx
@@ -172,7 +172,7 @@ To get started with installing and running the archive node using Docker, follow
 
 ## Set up the archive node using Docker Compose
 
-Docker compose is a tool for defining and running multi-container Docker applications.
+Docker Compose is a tool for defining and running multi-container Docker applications.
 With Compose, you use a YAML file to configure your application's services. Then, with a single command, you create and start all the services from your configuration.
 
 If you wish to run the archive node using Docker Compose, you can use the following instructions.

--- a/docs/node-operators/archive-node.mdx
+++ b/docs/node-operators/archive-node.mdx
@@ -175,9 +175,7 @@ To get started with installing and running the archive node using Docker, follow
 Docker Compose is a tool for defining and running multi-container Docker applications.
 With Compose, you use a YAML file to configure your application's services. Then, with a single command, you create and start all the services from your configuration.
 
-If you wish to run the archive node using Docker Compose, you can use the following instructions.
-
-To get started with installing and running the archive node using Docker Compose, follow the steps below.
+To run the archive node using Docker Compose:
 
 1. Install Docker on your machine. For more information, see [Docker](https://docs.docker.com/get-docker/).
 


### PR DESCRIPTION
This commit adds comprehensive instructions for setting up and running the archive node using Docker and Docker Compose. This provides users with alternative methods for running the archive node, which can be more convenient and easier to manage.