### PR TITLE
Update generating-a-keypair.mdx

### DIFF
--- a/docs/node-operators/generating-a-keypair.mdx
+++ b/docs/node-operators/generating-a-keypair.mdx
@@ -124,7 +124,7 @@ Never give out your private key and make sure they are stored safely. If you los
 4. Finally, ensure the permissions are set properly for the private key file, this prevents unwanted processes from accessing it.
 
 ```
-chmod 600 ~/keys/my-wallet
+chmod 600 $(pwd)/keys/my-wallet
 ```
 
 ## Validate your private key


### PR DESCRIPTION
Path to my-wallet directory wrongly assumed to be under ~/. It was changed to $(pwd), as when mounting the directory to the container.