### PR TITLE
docs: standards, style, metadata, edits for top-level mina docs

### DIFF
--- a/docs/about-mina/consensus.mdx
+++ b/docs/about-mina/consensus.mdx
@@ -6,19 +6,20 @@ import ResponsiveVideo from '@site/src/components/common/ResponsiveVideo';
 
 # Consensus
 
-Mina Protocol uses a proof-of-stake consensus mechanism called **Ouroboros Samasika**. 
+Mina Protocol uses a proof of stake (PoS) consensus mechanism called _Ouroboros Samasika_. 
 
-Consensus is the process by which the network determines which information is retained in the blockchain. You can read about the difference between proof of stake (PoS) vs proof of work (PoW) consensus mechanisms in this blog post <a href="https://minaprotocol.com/blog/proof-of-work-vs-proof-of-stake">here</a>.
+Consensus is the process by which the network determines which information is retained in the blockchain. To learn more, see the [Proof-of-Work vs Proof-of-Stake](https://minaprotocol.com/blog/proof-of-work-vs-proof-of-stake) blog post.
 
-Learn more about how Ouroboros Samasika works in this video:
+How Ouroboros Samasika works is explained in this video:
 
 <ResponsiveVideo src="https://www.youtube.com/embed/NpjuGYcJICA" />
 
-### Decentralization properties
-Based on Cardano’s PoS Ouroboros, Ouroboros Samisika is a secure PoS protocol with some strong decentralization properties: 
+## Decentralization properties
+
+Based on Cardano's PoS Ouroboros, Ouroboros Samisika is a secure PoS protocol with strong decentralization properties: 
 
 - Can resolve long-range forks without relying on third parties to provide history
-- **No staking minimum** — You can produce blocks and receive block rewards based on your % of the MINA staked on the network. Any user with any amount of MINA can receive these rewards.
-- **No slashing** — the protocol does not need explicit slashing, since the protocol already enforces the required level of correctness.
+- **No staking minimum** — You can produce blocks and receive block rewards based on your percentage of MINA staked on the network. Any user with any amount of MINA can receive these rewards.
+- **No slashing** — Mina protocol does not need explicit slashing, since the protocol already enforces the required level of correctness.
 
-Learn about <a href="https://minaprotocol.com/blog/how-ouroboros-samasika-upholds-minas-goals-of-decentralization"> how Ouroboros Samasika upholds Mina’s goals of decentralization</a>.
+See [How Ouroboros Samasika upholds Mina's goals of decentralization](https://minaprotocol.com/blog/how-ouroboros-samasika-upholds-minas-goals-of-decentralization).

--- a/docs/about-mina/consensus.mdx
+++ b/docs/about-mina/consensus.mdx
@@ -1,5 +1,11 @@
 ---
 title: Consensus
+description: Mina Protocol uses a proof of stake (PoS) consensus mechanism called Ouroboros Samasika.
+keywords:
+  - proof of stake (PoS)
+  - Ouroboros Samasika
+  - consensus mechanism
+  - mina consensus
 ---
 
 import ResponsiveVideo from '@site/src/components/common/ResponsiveVideo';

--- a/docs/about-mina/faq.mdx
+++ b/docs/about-mina/faq.mdx
@@ -1,5 +1,14 @@
 ---
 title: Mina FAQ
+description: Frequently asked questions about Mina Protocol.
+keywords: 
+  - mina faq
+  - mina language
+  - zkapp language
+  - 22 KB
+  - kimchi proof system
+  - mina scalability
+  - mina security audits
 ---
 
 import Subhead from "@site/src/components/common/Subhead";

--- a/docs/about-mina/faq.mdx
+++ b/docs/about-mina/faq.mdx
@@ -13,13 +13,13 @@ Frequently Asked Questions about Mina Protocol
 
 ### What language is Mina written in?
 
-The Mina node is written in OCaml. But you don't need to know OCaml to write smart contracts for Mina.
+The Mina node is written in OCaml. You don't need to know OCaml to write smart contracts for Mina.
 
 ### What language are zkApp smart contracts written in?
 
 Mina's zero knowledge smart contracts (zkApps) are written in TypeScript.
 
-Learn more about [how to write a zkApp](/zkapps/how-to-write-a-zkapp).
+See [How to write a zkApp](/zkapps/how-to-write-a-zkapp).
 
 ### How large is the Mina Blockchain?
 
@@ -27,21 +27,21 @@ Learn more about [how to write a zkApp](/zkapps/how-to-write-a-zkapp).
 
 ### Given Mina is only 22 KB, where are past transactions stored?
 
-A Mina node can run with an optional flag to make it an archive node to store historic transactions. Archive nodes are useful for anyone running a service such as a block explorer. Still, this historical data is not required to verify the current consensus state of the protocol.
+A Mina node can run with an optional flag to make it an archive node to store historical transactions. Archive nodes are useful for anyone running a service, such as a block explorer. Still, this historical data is not required to verify the current consensus state of the protocol.
 
-### What zk proof system does Mina use?
+### What zero knowledge (zk) proof system does Mina use?
 
-Mina Protocol uses a custom proof system called Kimchi, which was developed by [O(1) Labs](https://o1labs.org/), and is the only blockchain offering infinite recursion.
+Mina Protocol uses a custom proof system called Kimchi,  developed by [O(1) Labs](https://o1labs.org/). Mina is the only blockchain offering infinite recursion.
 
 Check out the [Mina Book](https://o1-labs.github.io/proof-systems/plonk/overview.html) to learn more about Kimchi and the cryptography powering Mina Protocol.
 
 ### What can I do on the Mina network?
 
-Any node can send and receive transactions on the Mina network. Any node can also choose to be a node operator. See [Node Operators](/node-operators). 
+Any node can send and receive transactions on the Mina network. Any node can also be a [node operator](/node-operators).
 
 ### What consensus algorithm does Mina use?
 
-Mina's consensus mechanism is an implementation of Ouroboros Proof-of-Stake. Due to Mina's unique compressed blockchain, certain aspects of the algorithm have diverged from the Ouroboros papers. The version Mina uses is called Ouroboros Samisika. 
+Mina's consensus mechanism is an implementation of Ouroboros proof of stake. Due to Mina's unique compressed blockchain, certain aspects of the algorithm have diverged from the Ouroboros papers. The version Mina uses is called Ouroboros Samisika and achieves consensus without long-term history.
 
 #### Is there a Mina block explorer?
 

--- a/docs/about-mina/index.mdx
+++ b/docs/about-mina/index.mdx
@@ -1,41 +1,39 @@
 ---
-title: Overview
+title: Mina Overview
 ---
 
-# Overview
+# Mina Overview
 
-### What is Mina?
+## What is Mina?
 
-Mina is an L1 blockchain based on zero-knowledge proofs (“ZKP”) with smart contracts written in TypeScript. It is the first cryptocurrency protocol with a succinct blockchain (22KB).
+Mina is an L1 blockchain based on zero-knowledge proofs (ZKP) with smart contracts written in TypeScript. It is the first cryptocurrency protocol with a succinct blockchain (22KB).
 
-### Why Mina?
+## Why Mina?
 
 Mina Protocol uses zero-knowledge proofs to build a more ideal blockchain architecture.
 
-Early blockchains, like Bitcoin and Ethereum, accumulate data over time and are currently hundreds of gigabytes in size. As time goes on, their blockchains will continue to increase in size. The entire chain history is required in order to verify the current consensus state of these networks.
+Early blockchains, like Bitcoin and Ethereum, accumulate data over time and are currently hundreds of gigabytes in size. As time goes on, their blockchains will continue to increase in size. The entire chain history is required to verify the current consensus state of these networks.
 
-With Mina, the blockchain always remains a constant size–about 22KB (the size of a few tweets). It’s possible to verify the current consensus state of the protocol using this one recursive, 22KB zero-knowledge proof. This means participants can quickly sync and verify the current consensus state of the network.
+With Mina, the blockchain always remains a constant size — about 22KB (the size of a few tweets). It's possible to verify the current consensus state of the protocol using this one recursive, 22KB zero-knowledge proof. This means participants can quickly sync and verify the current consensus state of the network.
 
-Learn more about [Mina’s unique protocol architecture](about-mina/protocol-architecture).
+Learn more about Mina's unique [protocol architecture](about-mina/protocol-architecture).
 
-### What are zero-knowledge proofs?
+## What are zero-knowledge proofs?
 
-Mina’s unique characteristics are made possible using zero-knowledge proofs.
+Mina's unique characteristics are made possible using zero-knowledge proofs.
 
-Watch this [video to learn about zero-knowledge proofs](about-mina/what-are-zero-knowledge-proofs).
+Learn more in this video about [zero-knowledge proofs](about-mina/what-are-zero-knowledge-proofs).
 
-### What are zkApps?
+## What are zkApps?
 
 Mina's zero-knowledge smart contracts are referred to as zkApps. zkApps provide powerful and unique characteristics such as unlimited off-chain execution, privacy for private data inputs that are never seen by the blockchain, the ability to write smart contracts in TypeScript, and more.
 
 See [zkApps Overview](/zkapps).
 
-### How does consensus work on Mina?
+## How does consensus work on Mina?
 
-The Mina network is secured by proof-of-stake (“PoS”) consensus called Ouroboros Samisika.
+The Mina network is secured by proof of stake (PoS) consensus called Ouroboros Samisika.
 
-Based on Cardano’s Ouroboros, Ouroboros Samisika is a PoS consensus mechanism that requires far less computing power than Bitcoin’s proof-of-work (“PoW”) protocol.
+Based on Cardano's Ouroboros, Ouroboros Samisika is a PoS consensus mechanism that requires far less computing power than Bitcoin's proof of work (PoW) protocol.
 
-With this model of consensus, you don't need expensive and energy consuming mining equipment to participate in consensus. By simply holding MINA in our wallet, we can choose to either stake it ourselves if running a block producing node, or we can delegate it to another node.
-
-Read more about [Mina’s consensus mechanism](./about-mina/consensus).
+With this model of Mina's [consensus mechanism](/about-mina/consensus), you don't need expensive and energy-consuming mining equipment to participate in consensus. By simply holding MINA in your wallet, you can choose to stake it yourself by running a [block producer](/node-operators/block-producers) node or delegate your MINA to another node.

--- a/docs/about-mina/index.mdx
+++ b/docs/about-mina/index.mdx
@@ -1,5 +1,11 @@
 ---
 title: Mina Overview
+description: Mina is an L1 blockchain based on zero-knowledge proofs (ZKP) with smart contracts written in TypeScript
+keywords: 
+  - mina blockchain
+  - mina l1
+  - 22 KB constant size blockchain
+  - mina network
 ---
 
 # Mina Overview
@@ -10,7 +16,7 @@ Mina is an L1 blockchain based on zero-knowledge proofs (ZKP) with smart contrac
 
 ## Why Mina?
 
-Mina Protocol uses zero-knowledge proofs to build a more ideal blockchain architecture.
+Mina Protocol uses zero knowledge proofs to build a more ideal blockchain architecture.
 
 Early blockchains, like Bitcoin and Ethereum, accumulate data over time and are currently hundreds of gigabytes in size. As time goes on, their blockchains will continue to increase in size. The entire chain history is required to verify the current consensus state of these networks.
 

--- a/docs/about-mina/protocol-architecture.mdx
+++ b/docs/about-mina/protocol-architecture.mdx
@@ -1,6 +1,9 @@
 ---
 title: Mina Protocol Architecture
 hide_title: true
+description: Short video explaining how the Mina protocol works.
+keywords:
+  - how mina protocol works
 ---
 
 import ResponsiveVideo from '@site/src/components/common/ResponsiveVideo';

--- a/docs/about-mina/protocol-architecture.mdx
+++ b/docs/about-mina/protocol-architecture.mdx
@@ -1,5 +1,5 @@
 ---
-title: Protocol Architecture
+title: Mina Protocol Architecture
 hide_title: true
 ---
 
@@ -11,11 +11,11 @@ A new version of Mina Docs is coming soon! This page will be rewritten.
 
 :::
 
-# Protocol Architecture
+# Mina Protocol Architecture
 
 ## How Does it Work?
 
-Check out this short video explaining how the Mina protocol works in detail:
+Check out this short video explaining how the Mina protocol works:
 
 <ResponsiveVideo src="https://www.youtube-nocookie.com/embed/eWVGATxEB6M?start=100&enablejsapi=1&rel=0" />
 

--- a/docs/about-mina/what-are-zero-knowledge-proofs.mdx
+++ b/docs/about-mina/what-are-zero-knowledge-proofs.mdx
@@ -1,5 +1,8 @@
 ---
 title: What are Zero Knowledge Proofs?
+description: Short video explaining zero knowledge proofs.
+keywords:
+  - zero knowledge proofs
 ---
 
 import ResponsiveVideo from '@site/src/components/common/ResponsiveVideo';
@@ -8,6 +11,6 @@ import ResponsiveVideo from '@site/src/components/common/ResponsiveVideo';
 
 Zero knowledge proofs keep Mina's blockchain light and your personal data private.
 
-In this video, Brandon from <a href="https://o1labs.org/">O(1) Labs</a> explains what zero knowledge proofs are by comparing them to the game of "Where's Waldo?". Learn what zero-knowledge proofs are, how they work, and their importance to Mina and the greater crypto community.
+In this video, Brandon from <a href="https://o1labs.org/">O(1) Labs</a> explains what zero knowledge proofs are by comparing them to the game of "Where's Waldo?". Learn what zero knowledge proofs are, how they work, and their importance to Mina and the greater crypto community.
 
 <ResponsiveVideo src="https://www.youtube.com/embed/GvwYJDzzI-g" />

--- a/docs/about-mina/what-are-zero-knowledge-proofs.mdx
+++ b/docs/about-mina/what-are-zero-knowledge-proofs.mdx
@@ -1,13 +1,13 @@
 ---
-title: What are Zero-Knowledge Proofs?
+title: What are Zero Knowledge Proofs?
 ---
 
 import ResponsiveVideo from '@site/src/components/common/ResponsiveVideo';
 
-# What are Zero-Knowledge Proofs?
+# What are Zero Knowledge Proofs?
 
-Zero-knowledge proofs keep Mina's blockchain light and your personal data private.
+Zero knowledge proofs keep Mina's blockchain light and your personal data private.
 
-In this video, Brandon from <a href="https://o1labs.org/">O(1) Labs</a> explains what zero-knowledge proofs are by comparing them to the game of "Where's Waldo?". By the end of this video, you know what zero-knowledge proofs are, how they work, and their importance to Mina and the greater crypto community.
+In this video, Brandon from <a href="https://o1labs.org/">O(1) Labs</a> explains what zero knowledge proofs are by comparing them to the game of "Where's Waldo?". Learn what zero-knowledge proofs are, how they work, and their importance to Mina and the greater crypto community.
 
 <ResponsiveVideo src="https://www.youtube.com/embed/GvwYJDzzI-g" />


### PR DESCRIPTION
This non-technical PR applies the standards to the top-level Mina docs, adds the metadata to improve discoverability and SEO, and applies spelling that adheres to the [word list](https://github.com/o1-labs/docs2/wiki/Word-list)

proof of stake (PoS) 
proof of work (PoW)
zero knowledge (no hyphen)

If needed, we can change these spellings later, but for now, let's go with consistency.

Consistency builds trust!
