### PR TITLE
fix: add navigation to bottom of glossary

### DIFF
--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -13,8 +13,8 @@ keywords:
 
 # Glossary
 
-[A](#a) [B](#b) [C](#c) [D](#d) [E](#e) [F](#f) [I](#i) [J](#j) [K](#k) [L](#l) [M](#m) [N](#n) [O](#o) 
-[P](#p) [Q](#q) [R](#r) [S](#s) [T](#t) [U](#u) [V](#v) [Z](#z)
+[A](#a) [B](#b) [C](#c) [D](#d) [E](#e) [F](#f) G H [I](#i) J [K](#k) [L](#l) [M](#m) [N](#n) [O](#o) 
+[P](#p) Q [R](#r) [S](#s) [T](#t) [U](#u) [V](#v) W X Y [Z](#z)
 
 Are you looking for a zero knowledge or Mina term that isn't here yet? To let us know, please [create an issue](https://github.com/o1-labs/docs2/issues) or click **EDIT THIS PAGE** to submit a PR.
 
@@ -141,6 +141,8 @@ A consensus constant `k` is the point at which chain [reorganizations](#reorgani
 ### full node
 
 A Mina node that is able to verify the state of the network trustlessly. In Mina, every node is a full node since all nodes can receive and verify zk-SNARKs.
+
+## I
 
 ### internal transition
 
@@ -402,4 +404,6 @@ Zero knowledge apps (zkApps) are Mina Protocol's smart contracts powered by zero
 
 A type of zero-knowledge proof. zk-SNARK is the acronym for zero knowledge succinct non-interactive argument of knowledge. Specific properties of interest in Mina's implementation of SNARKs are succinctness and non-interactivity that allow for any node to quickly verify the state of the network.
 
-#### [Back to top](/glossary)
+[A](#a) [B](#b) [C](#c) [D](#d) [E](#e) [F](#f) G H [I](#i) J [K](#k) [L](#l) [M](#m) [N](#n) [O](#o) 
+[P](#p) Q [R](#r) [S](#s) [T](#t) [U](#u) [V](#v) W X Y [Z](#z)
+


### PR DESCRIPTION
Unambiguous terminology is always a worthy goal and essential for clear communication. Glossaries are magnets for curious readers. I'm on a quest to improve our glossary and am always on the lookout for good examples. 

Today's example glossary included navigation at the bottom of the page (brilliant, so here it is).

This PR:
- adds a missing subheading
- adds navigation to the bottom
- adds inactive navigation placeholders for letters with no terms