### PR TITLE
fix: add context to experimental topic 

### DIFF
--- a/docs/zkapps/experimental.mdx
+++ b/docs/zkapps/experimental.mdx
@@ -8,7 +8,7 @@ keywords:
 
 # Experimental features
 
-Some new features are considered experimental before they are production-ready. Experimental features are clearly marked and link back to this page.
+Some new features are considered experimental before they are production-ready. Experimental features are clearly marked and link to this page.
 
 Exposing experimental features gives you an opportunity to try our newest features sooner.
 

--- a/docs/zkapps/experimental.mdx
+++ b/docs/zkapps/experimental.mdx
@@ -8,7 +8,7 @@ keywords:
 
 # Experimental features
 
-Some new features are considered experimental before they are production-ready.
+Some new features are considered experimental before they are production-ready. Experimental features are clearly marked and link back to this page.
 
 Exposing experimental features gives you an opportunity to try our newest features sooner.
 
@@ -26,4 +26,4 @@ Experimental features are in active development and your feedback is especially 
 
 - The feature may have bugs
 - The feature may be changed, deprecated, or removed
-- Any documentation for the feature explicitly notes the feature is experimental
+- All documentation for the feature explicitly notes the feature is experimental

--- a/sidebars.js
+++ b/sidebars.js
@@ -330,7 +330,6 @@ module.exports = {
         },
         'zkapps/roadmap',
         'zkapps/faq',
-        'zkapps/experimental',    
         'zkapps/zkapps-for-ethereum-developers',
       ],
     },


### PR DESCRIPTION
Add sentence: Experimental features are clearly marked and link to this page.

@MartinMinkov  can you help me learn how to publish this page without an entry in the sidebar.js file? 