### PR TITLE
Update minadocs to reflect 1.4.0 release and OS support

### DIFF
--- a/docs/node-operators/archive-node.mdx
+++ b/docs/node-operators/archive-node.mdx
@@ -47,13 +47,13 @@ Running an archive node requires some knowledge of managing a PostgreSQL databas
    - Ubuntu/Debian:
 
      ```
-     sudo apt-get install mina-archive=1.3.0-9b0369c
+     sudo apt-get install mina-archive=1.4.0-c980ba8
      ```
 
    - Docker:
 
      ```
-     minaprotocol/mina-archive:1.3.0-9b0369c-bullseye
+     minaprotocol/mina-archive:1.4.0-c980ba8-bullseye
      ```
 
 ## Set up the archive node
@@ -155,7 +155,7 @@ To get started with installing and running the archive node using Docker, follow
    --name archive \
    -p 3086:3086 \
    -v /tmp/archive:/data \
-   minaprotocol/mina-archive:1.3.0-9b0369c-bullseye \
+   minaprotocol/mina-archive:1.4.0-c980ba8-bullseye \
    mina-archive run \
    --postgres-uri postgres://postgres:postgres@postgres:5432/archive \
    --server-port 3086
@@ -213,7 +213,7 @@ To run the archive node using Docker Compose:
        ports:
          - '5432:5432'
      archive:
-       image: 'minaprotocol/mina-archive:1.3.0-9b0369c-bullseye'
+       image: 'minaprotocol/mina-archive:1.4.0-c980ba8-bullseye'
        command: >-
          mina-archive run --postgres-uri
          postgres://postgres:postgres@postgres:5432/archive --server-port 3086

--- a/docs/node-operators/connecting-to-the-network.mdx
+++ b/docs/node-operators/connecting-to-the-network.mdx
@@ -38,32 +38,9 @@ Steps to install mina, connect to the Mina Mainnet network, and test connectivit
 
 The first step to connecting to Mainnet is to install the latest daemon version. 
 
-Follow the steps for your operating system.
-
 ### Ubuntu 20.04 and Debian 10, 11, 12
 
-Install the latest **Stable** [Mina Release 1.4.0](https://github.com/MinaProtocol/mina/releases/tag/1.4.0) or visit the [GitHub Releases Page](https://github.com/MinaProtocol/mina/releases) to install pre-release (Beta) builds.
-
-To set up the new `stable` package repository and install the latest version:
-
-```sh
-echo "deb [trusted=yes] http://packages.o1test.net $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/mina.list
-sudo apt-get install --yes apt-transport-https
-sudo apt-get update
-sudo apt-get install --yes curl unzip mina-mainnet=1.4.0-c980ba8
-```
-
-To verify the daemon is correctly installed:
-
-```sh
-mina version
-```
-
-The expected output is:
-
-```text
-Commit c980ba87c3417f40a7081225dfe7478c5ee70fd7 on branch master
-```
+To install the latest [Mainnet **Stable** Release 1.4.0](https://github.com/MinaProtocol/mina/releases/tag/1.4.0), use the [Installation](/node-operators/getting-started#installation) steps for your environment.
 
 ## Start a standalone mina node
 
@@ -73,13 +50,13 @@ Auto-restart flows are in place to ensure your nodes perform optimally.
 
 1. Start a standalone mina node to make sure everything works.
 
-   To start a Mina node instance and connect to the live network:
+   To start a mina node instance and connect to the live network:
 
    ```sh
    mina daemon --peer-list-url https://storage.googleapis.com/seed-lists/mainnet_seeds.txt
    ```
 
-   The `--peer-list` argument specifies the the source file of seed peer addresses for the initial peer to connect to on the network. Mina is a [peer-to-peer](/glossary#peer-to-peer) protocol, so there is no dependence on a single centralized server.
+   The `--peer-list` argument specifies the source file of seed peer addresses for the initial peer to connect to on the network. Mina is a [peer-to-peer](/glossary#peer-to-peer) protocol, so there is no dependence on a single centralized server.
 
    If you have a key with MINA stake and want to produce blocks:
 
@@ -118,7 +95,7 @@ To produce blocks or otherwise customize the configuration for the mina daemon:
 
    Replace `<BLOCK_PRODUCER_KEY_PATH>` with the full path to your block producer private key. For example, `/home/ubuntu/keys/my-wallet`.
 
-   If you do not want to produce blocks then you can keep `~/.mina-env` empty for now.
+   If you do not want to produce blocks, then you can keep `~/.mina-env` empty for now.
 
 1. To change how mina is configured, specify flags to the mina daemon process with space-separated arguments between the quotes in `EXTRA_FLAGS=""`.
 
@@ -129,7 +106,7 @@ To produce blocks or otherwise customize the configuration for the mina daemon:
    - Mainnet package [https://storage.googleapis.com/seed-lists/mainnet_seeds.txt](https://storage.googleapis.com/seed-lists/mainnet_seeds.txt)
      - Change with `--peer-list-url`
 
-1. After your `.mina-env` file is ready, start a Mina node instance and connect to the live network:
+1. After your `.mina-env` file is ready, start a mina node instance and connect to the live network:
 
    ```sh
    systemctl --user daemon-reload
@@ -168,7 +145,7 @@ Look at logs that show the last 1000 lines, and follow from there:
 journalctl --user -u mina -n 1000 -f
 ```
 
-In some cases, you might need run the following command to view the logs:
+In some cases, you might need to run the following command to view the logs:
 
 ```sh
 journalctl --user-unit mina -n 1000 -f
@@ -176,7 +153,7 @@ journalctl --user-unit mina -n 1000 -f
 
 ### Docker
 
-When running your daemon using Docker, first ensure that your private key has the correct permissions.
+When running your daemon using Docker, ensure your private key has the correct permissions.
 
 ```sh
 cd ~
@@ -197,7 +174,7 @@ PEER_LIST_URL=https://storage.googleapis.com/seed-lists/mainnet_seeds.txt
 
 Replace `<BLOCK_PRODUCER_KEY_PATH>` with the full path to your block producer private key. For example, `/home/ubuntu/keys/my-wallet`.
 
-If you do not want to produce blocks, then provide only the `PEER_LIST_URL`.
+If you do not want to produce blocks, provide only the `PEER_LIST_URL`.
 
 Now, run the image with your `~/.mina-config` and `~/.mina-env` files mounted into the container:
 
@@ -234,7 +211,7 @@ Monitor connectivity to the network:
 docker exec -it mina mina client status
 ```
 
-At least 10 peers are expected. Watch the block height and the max observed block height climb.
+At least 10 peers are expected. Watch the block height and the maximum observed block height climb.
 
 :::tip
 
@@ -246,13 +223,13 @@ If you encounter `[Warn] Shutdown before Mina instance was created, not saving a
 
 Monitor the mina client status in a different terminal window.
 
-Now that a node is started and running the Mina daemon, run:
+Now that a node is started and running the mina daemon, run:
 
 ```sh
 mina client status
 ```
 
-When first starting up a node, it can take up to a minute before `mina client status` connects to the daemon. If you see `Error: daemon not running. See mina daemon`, just a wait a bit and try again.
+When first starting up a node, it can take up to a minute before `mina client status` connects to the daemon. If you see `Error: daemon not running. See mina daemon`, just wait a bit and try again.
 
 The expected response includes these fields:
 
@@ -263,7 +240,7 @@ The expected response includes these fields:
 
 - `Sync Status: Bootstrap` means that the node is bootstrapping and needs to sync with the rest of the network. Be patient here as this step might take some time for the node to get all the data it needs.
 
-- After a while, the node connects to more peers and then moves into `Sync Status: Catchup` which gathers the most recent blocks and state while catching up to the the highest block.
+- After a while, the node connects to more peers and then moves into `Sync Status: Catchup`, which gathers the most recent blocks and state while catching up to the the highest block.
 
 - When sync status reaches `Synced` and the node is connected to 1 or more peers, the node is successfully connected to the network. A corresponding daemon log shows the sync status: `[Info] Mina daemon is now synced`.
 
@@ -271,6 +248,6 @@ The expected response includes these fields:
 
 ## Step up your game
 
-Now that you have a fully synced node, learn about some of the more advanced features of the daemon such as [Sending a payment](sending-a-payment) and [Staking & Delegating](staking-and-snarking). 
+Now that you have a fully synced node, learn about some of the more advanced features of the daemon, such as [Sending a payment](sending-a-payment) and [Staking & Delegating](staking-and-snarking). 
 
 To earn MINA tokens, check out the [Mina Foundation Delegation Program](foundation-delegation-program).

--- a/docs/node-operators/getting-started.mdx
+++ b/docs/node-operators/getting-started.mdx
@@ -49,7 +49,7 @@ O(1) Labs has tested running nodes on several cloud providers. We recommend the 
 - Azure [Standard_F8s_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-compute#fsv2-series-1)
 - Digital Ocean [c-8-16gib](https://cloud.digitalocean.com/droplets/new?size=c-8-16gib)
 
-Check out the [Connecting to the Mina Testnet (Google Cloud)](https://youtu.be/M9lE2lgyVEo) video for steps to configure your Mina node on Google Cloud.
+Check out the [Connecting to the Mina Testnet (Google Cloud)](https://youtu.be/M9lE2lgyVEo) video for steps to configure your mina node on Google Cloud.
 
 ## Installation
 
@@ -79,11 +79,11 @@ The expected output is `Commit c980ba87c3417f40a7081225dfe7478c5ee70fd7 on branc
 
 Windows is not natively supported. Instead, use the [Docker instructions](./#docker). 
 
-If you are interested in receiving a grant to develop Mina for Windows, send an email to grants@o1labs.org or reach out in the [Mina Protocol Discord server](https://discord.gg/minaprotocol).
+If you are interested in receiving a grant to develop Mina for Windows, email grants@o1labs.org or reach out in the [Mina Protocol Discord server](https://discord.gg/minaprotocol).
 
 ### macOS
 
-macOS is used by developers and is not officially supporting any pre-built packages at this time.
+macOS is used by developers and is not officially supporting any pre-built packages.
 
 Instead, use the Docker instructions or build from source.
 
@@ -103,7 +103,7 @@ Other operating systems haven't been tested thoroughly and might have issues. Yo
 
 If you are running a firewall, you must allow traffic on TCP port 8302.
 
-If the `-external-ip YOUR_IP` flag is not provided, the daemon uses HTTPS (443) and HTTP (80) to determine its own IP address.
+Unless the `-external-ip YOUR_IP` flag is provided, the daemon uses HTTPS (443) and HTTP (80) to determine its own IP address.
 
 Enable port forwarding on your router to allow inbound traffic to the following ports through your **external** IP address:
 
@@ -112,4 +112,4 @@ Enable port forwarding on your router to allow inbound traffic to the following 
 
 ## Next
 
-Now that you've installed Mina and configured your network, you are ready to move on to the next step: [generating a keypair](generating-a-keypair).
+Now that you've installed mina and configured your network, you can move on to the next step: [generating a keypair](generating-a-keypair).

--- a/docs/node-operators/getting-started.mdx
+++ b/docs/node-operators/getting-started.mdx
@@ -14,7 +14,7 @@ A new version of Mina Docs is coming soon! This page will be rewritten.
 # Getting Started
 
 <Subhead>
-Welcome to Mina! This section walks you through the process of setting up a Mina node. After we will show you how to generate a keypair for use with the network. Finally, we'll show you how to connect to the network and begin producing blocks.
+Welcome to Mina! This section walks you through the process of setting up a Mina node, provides instructions on how to generate a keypair for use with the network, connect to the network, and begin producing blocks.
 </Subhead>
 
 :::info
@@ -25,40 +25,43 @@ This documentation is for the **Mainnet** release.
 
 ## Requirements
 
-**Software**: macOS, Linux (currently supports Debian 10, 11, 12 and Ubuntu 20.04 LTS), or any host with Docker. We only support AMD64 CPU architecture at this time.
+**Software**: Supported environments include macOS, Linux (Debian 10, 11, 12 and Ubuntu 20.04 LTS), and any host machine with Docker. 
 
-:::note
+**Processor**: Only AMD64 CPU architecture is supported.
 
-Windows is not officially supported at this time. However, it may be possible to use the [Docker instructions](./#docker). If you are interested in receiving a grant to develop Mina for Windows, please email grants@o1labs.org or reach out in the [Mina Protocol Discord server](https://discord.gg/minaprotocol).
+**Hardware**: Sending and receiving MINA does not require any special hardware. 
 
-:::
+Running a block producer on the Mina network requires at least:
 
-**Hardware**: Sending and receiving mina does not require any special hardware, but running a block producer on the Mina network currently requires:
+- 8-core processor
+- 16 GB of RAM
 
-- at least a 8-core processor
-- at least 16GB of RAM
-
-Note that if you plan on running a snark worker node at the same time as a block producer, you may need more RAM. GPUs aren't currently required, but may be required for node operators when the protocol is upgraded.
+More RAM is required to run a SNARK worker node at the same time as a block producer.
 
 **Network**: At least 1 Mbps connection
 
 **VM Instances**:
-O(1) Labs has tested running nodes on several cloud providers, and recommends the following instances for basic node operator needs. Keep in mind that custom requirements as well as different cost constraints may require a different instance type.
 
-- AWS - [c5.2xlarge](https://www.ec2instances.info/?filter=c5.2xl&region=us-west-2&cost_duration=daily&selected=c5.2xlarge)
-- GCP - [c2-standard-8](https://cloud.google.com/compute/docs/machine-types)
-- Azure - [Standard_F8s_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-compute#fsv2-series-1)
-- Digital Ocean - [c-8-16gib](https://cloud.digitalocean.com/droplets/new?size=c-8-16gib)
+O(1) Labs has tested running nodes on several cloud providers. We recommend the following instances for basic node operator needs. Custom requirements and different cost constraints might require a different instance type.
 
-Check out our [guide](https://youtu.be/M9lE2lgyVEo) for how to configure your Mina node on Google Cloud.
+- AWS [c5.2xlarge](https://www.ec2instances.info/?filter=c5.2xl&region=us-west-2&cost_duration=daily&selected=c5.2xlarge)
+- GCP [c2-standard-8](https://cloud.google.com/compute/docs/machine-types)
+- Azure [Standard_F8s_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-compute#fsv2-series-1)
+- Digital Ocean [c-8-16gib](https://cloud.digitalocean.com/droplets/new?size=c-8-16gib)
+
+Check out the [Connecting to the Mina Testnet (Google Cloud)](https://youtu.be/M9lE2lgyVEo) video for steps to configure your Mina node on Google Cloud.
 
 ## Installation
 
-### Ubuntu / Debian
+To install the latest [Mainnet **Stable** Release 1.4.0](https://github.com/MinaProtocol/mina/releases/tag/1.4.0), use the installation steps for your environment.
 
-Follow along below to install the latest **Stable** [Mina Release 1.4.0](https://github.com/MinaProtocol/mina/releases/tag/1.4.0) or visit the [Mina Releases Page](https://github.com/MinaProtocol/mina/releases) on GitHub to discover and install pre-release (Beta) builds.
+The binary download is around 1 GB, so the installation might take a few minutes.
 
-You can set up the new debian `stable` repository and install the latest version as follows:
+To discover and install pre-release (Beta) builds, see the [Mina Releases](https://github.com/MinaProtocol/mina/releases) page on GitHub.
+
+### Ubuntu and Debian
+
+To set up the new Debian `stable` repository and install the latest binary version:
 
 ```
 echo "deb [trusted=yes] http://packages.o1test.net $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/mina.list
@@ -66,13 +69,17 @@ sudo apt-get update
 sudo apt-get install -y curl unzip mina-mainnet=1.4.0-c980ba8
 ```
 
-Check that the daemon installed correctly by running `mina version`. The expected output is `Commit c980ba87c3417f40a7081225dfe7478c5ee70fd7 on branch master`.
+To verify the mina daemon installation, run:
+
+- `mina version`
+
+The expected output is `Commit c980ba87c3417f40a7081225dfe7478c5ee70fd7 on branch master`.
 
 ### Windows
 
-Windows is not yet natively supported. If you are interested in receiving a grant to develop Mina for Windows, please email grants@o1labs.org or reach out in the [Mina Protocol Discord server](https://discord.gg/minaprotocol).
+Windows is not natively supported. Instead, use the [Docker instructions](./#docker). 
 
-Instead, use the Docker instructions.
+If you are interested in receiving a grant to develop Mina for Windows, send an email to grants@o1labs.org or reach out in the [Mina Protocol Discord server](https://discord.gg/minaprotocol).
 
 ### macOS
 
@@ -82,20 +89,26 @@ Instead, use the Docker instructions or build from source.
 
 ### Docker
 
-Docker is cross-platform tool that allows you to run a virtual machine that will execute any needed software. Follow the official installation instructions for your platform. See [Get Docker](https://docs.docker.com/get-docker/). After Docker is installed, proceed to the Mina Docker instructions on [Connect to the Network](connecting-to-the-network).
+Docker is a cross-platform tool. You can download and install Docker on multiple platforms. 
+
+Use the Docker installation instructions for your platform on [Get Docker](https://docs.docker.com/get-docker/). After Docker is installed, follow the [Connect to the Mina Network](/node-operators/connecting-to-the-network#docker) instructions.
 
 ### Build from source
 
-If you're running another Linux distro or some version of macOS, you can [try building Mina from source code](https://github.com/MinaProtocol/mina/blob/master/README-dev.md#building-mina). Please note that other operating systems haven't been tested thoroughly, and might have issues. Feel free to share any logs and get troubleshooting help in the [Mina Protocol Discord server](https://discord.gg/minaprotocol).
+On Linux or macOS operating systems, you can experiment with [Building Mina](https://github.com/MinaProtocol/mina/blob/master/README-dev.md#building-mina) from source code.
 
-## Set up port forwarding and any firewalls
+Other operating systems haven't been tested thoroughly and might have issues. You can share logs and get troubleshooting help in the [Mina Protocol Discord server](https://discord.gg/minaprotocol).
 
-If you are running a firewall, you must allow traffic on TCP port 8302. Additionally, unless the `-external-ip YOUR_IP` flag is provided, the daemon  uses HTTPS (443) and HTTP (80) to try and determine its own IP address.
+## Set up port forwarding and firewalls
 
-You might need to configure your router's port forwarding to allow inbound traffic to the following ports through your **external** IP address.
+If you are running a firewall, you must allow traffic on TCP port 8302.
 
-- `TCP` port `8302`
-- _Optionally_ to use the GraphQL service, expose `TCP` port `3085`
+Unless the `-external-ip YOUR_IP` flag is provided, the daemon uses HTTPS (443) and HTTP (80) to determine its own IP address.
+
+Enable port forwarding on your router to allow inbound traffic to the following ports through your **external** IP address:
+
+- TCP port `8302`
+- To use the GraphQL service, expose TCP port `3085`
 
 ## Next
 

--- a/docs/node-operators/getting-started.mdx
+++ b/docs/node-operators/getting-started.mdx
@@ -25,7 +25,7 @@ This documentation is for the **Mainnet** release.
 
 ## Requirements
 
-**Software**: macOS, Linux (currently supports Debian 9 and Ubuntu 18.04 LTS), or any host with Docker
+**Software**: macOS, Linux (currently supports Debian 10, 11, 12 and Ubuntu 20.04 LTS), or any host with Docker. We only support AMD64 CPU architecture at this time.
 
 :::note
 
@@ -56,17 +56,17 @@ Check out our [guide](https://youtu.be/M9lE2lgyVEo) for how to configure your Mi
 
 ### Ubuntu / Debian
 
-Follow along below to install the latest **Stable** [Mina Release 1.3.1.2](https://github.com/MinaProtocol/mina/releases/tag/1.3.1.2) or visit the [Mina Releases Page](https://github.com/MinaProtocol/mina/releases) on GitHub to discover and install pre-release (Beta) builds.
+Follow along below to install the latest **Stable** [Mina Release 1.4.0](https://github.com/MinaProtocol/mina/releases/tag/1.4.0) or visit the [Mina Releases Page](https://github.com/MinaProtocol/mina/releases) on GitHub to discover and install pre-release (Beta) builds.
 
 You can set up the new debian `stable` repository and install the latest version as follows:
 
 ```
 echo "deb [trusted=yes] http://packages.o1test.net $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/mina.list
 sudo apt-get update
-sudo apt-get install -y curl unzip mina-mainnet=1.3.1.2-25388a0
+sudo apt-get install -y curl unzip mina-mainnet=1.4.0-c980ba8
 ```
 
-Check that the daemon installed correctly by running `mina version`. The expected output is `Commit 25388a0fed9695e8e9d04f75f50c2bae1c9c80db on branch master`.
+Check that the daemon installed correctly by running `mina version`. The expected output is `Commit c980ba87c3417f40a7081225dfe7478c5ee70fd7 on branch master`.
 
 ### Windows
 

--- a/docs/node-operators/getting-started.mdx
+++ b/docs/node-operators/getting-started.mdx
@@ -103,7 +103,7 @@ Other operating systems haven't been tested thoroughly and might have issues. Yo
 
 If you are running a firewall, you must allow traffic on TCP port 8302.
 
-Unless the `-external-ip YOUR_IP` flag is provided, the daemon uses HTTPS (443) and HTTP (80) to determine its own IP address.
+If the `-external-ip YOUR_IP` flag is not provided, the daemon uses HTTPS (443) and HTTP (80) to determine its own IP address.
 
 Enable port forwarding on your router to allow inbound traffic to the following ports through your **external** IP address:
 


### PR DESCRIPTION
This PR is to add changes to our documentation to reflect our latest 1.4.0 Stable release version as well as editing our supported operating systems (and adding a caveat re: CPU support).

For the visually curious reviewers, here are the docs preview links

- Archive Node https://docs2-git-amcie-update-to-140-minadocs.vercel.app/node-operators/archive-node 
- Connect to Devnet https://docs2-git-amcie-update-to-140-minadocs.vercel.app/node-operators/connecting-to-devnet 
- Getting Started https://docs2-git-amcie-update-to-140-minadocs.vercel.app/node-operators/getting-started 

