### PR TITLE
fix: update docs to use experimental callout

### DIFF
--- a/docs/exchange-operators/faq.mdx
+++ b/docs/exchange-operators/faq.mdx
@@ -60,10 +60,8 @@ You can view the fees for pending transactions and adjust your fees accordingly:
 
 :::tip
 
-<p>
-  While Mina and its SDKs do support the memo field when sending a transaction, the recommended best practice is <u>do NOT require a memo for deposits</u> to
-  prevent this issue for your exchange.
-</p>
+While Mina and its SDKs do support the memo field when sending a transaction, the recommended best practice is <u>do NOT require a memo for deposits</u>.
+
 :::
 
 To associate the deposit with the user's account, some exchanges require their users to include a unique memo field when sending MINA deposits to the exchange's address.
@@ -106,10 +104,7 @@ fi
 
 :::tip
 
-<p>
-  Be sure your Mina daemon is monitored by something such as systemd, so it can
-  auto-restart.
-</p>
+Be sure your Mina daemon is monitored by something such as systemd, so it can auto-restart.
 
 :::
 

--- a/docs/zkapps/experimental.mdx
+++ b/docs/zkapps/experimental.mdx
@@ -8,7 +8,13 @@ keywords:
 
 # Experimental features
 
-Some new features are considered experimental before they are production-ready. Experimental features are clearly marked and link to this page.
+Some new features are considered experimental before they are production-ready. 
+
+:::experimental
+
+Experimental features are clearly marked and link to this page.
+
+:::
 
 Exposing experimental features gives you an opportunity to try our newest features sooner.
 

--- a/docs/zkapps/o1js/recursion.mdx
+++ b/docs/zkapps/o1js/recursion.mdx
@@ -22,7 +22,7 @@ zkApp programmability is not yet available on the Mina Mainnet. You can get star
 
 :::experimental
 
-The use of the ZkProgram API with recursion is experimental. This API may change. 
+The use of the ZkProgram API with recursion is experimental. This API may change. To learn more, see [Experimental Features](/zkapps/experimental).
 
 :::
 

--- a/docs/zkapps/o1js/recursion.mdx
+++ b/docs/zkapps/o1js/recursion.mdx
@@ -20,7 +20,11 @@ zkApp programmability is not yet available on the Mina Mainnet. You can get star
 
 :::
 
-[Experimental](/zkapps/experimental). This API may change.
+:::experimental
+
+The use of the ZkProgram API with recursion is experimental. This API may change. 
+
+:::
 
 Specifically, ZkProgram methods could be refactored to explicitly return values rather than requiring them to be passed as further inputs.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -330,7 +330,6 @@ module.exports = {
         },
         'zkapps/roadmap',
         'zkapps/faq',
-        'zkapps/experimental',    
         'zkapps/zkapps-for-ethereum-developers',
       ],
     },


### PR DESCRIPTION
Now that https://github.com/o1-labs/docs2/pull/581 is merged, this PR updates the docs to use the new callout and removes the experimental doc from the sidebars.js file so the topic doesn't show in the TOC