### PR TITLE
docs fix: o1js reference redirect

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -188,6 +188,10 @@ module.exports = {
             from: '/exchange-operators/exchange-faq',
             to: '/exchange-operators/faq',
           },
+          {
+            from: '/zkapps//zkapps/o1js-reference',
+            to: '/exchange-operators/faq',
+          },
         ],
       },
     ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -189,8 +189,8 @@ module.exports = {
             to: '/exchange-operators/faq',
           },
           {
-            from: '/zkapps//zkapps/o1js-reference',
-            to: '/exchange-operators/faq',
+            from: '/zkapps//zkapps/snarkyjs-reference',
+            to: '/zkapps/o1js-reference',
           },
         ],
       },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -189,7 +189,7 @@ module.exports = {
             to: '/exchange-operators/faq',
           },
           {
-            from: '/zkapps//zkapps/snarkyjs-reference',
+            from: '/zkapps/snarkyjs-reference',
             to: '/zkapps/o1js-reference',
           },
         ],


### PR DESCRIPTION
A stale link in a community doc went to https://docs.minaprotocol.com/zkapps/SnarkyJS-reference which makes me think other people might also rely on that link

This PR submits a redirect to https://docs.minaprotocol.com/zkapps/o1js-reference 

I followed guidance in https://github.com/o1-labs/docs2/wiki/Redirects-on-the-docs-website 

