### PR TITLE
docs fix: merge conflicts

### DIFF
--- a/docs/node-operators/scan-state.mdx
+++ b/docs/node-operators/scan-state.mdx
@@ -8,15 +8,9 @@ description: A data structure that allows decoupling the production of transacti
 
 The scan state is a data structure that allows decoupling the production of transaction SNARKs from block producers to SNARK workers.
 
-<<<<<<< HEAD
 Block producers do not have to produce transaction SNARKs, so the block production time can remain constant regardless of the transaction throughput. Additionally, the scan state data structure allows the transaction SNARK proof generation to be parallelized and completed by multiple competing [SNARK workers](/node-operators/snark-workers).
 
 The scan state is comprised of a forest of full [binary trees](https://en.wikipedia.org/wiki/Binary_tree), where each node in the tree is a job to be completed by a SNARK worker. The scan state periodically returns a single proof from the top of a tree that attests to the correctness of all transactions at the base of the tree.
-=======
-As the block producers no longer have to produce these transaction SNARKs, the block production time may remain constant regardless of the transaction throughput. Additionally, the scan state data structure allows the transaction SNARK proof generation to be parallelized and completed by multiple competing [SNARK workers](/node-operators/snark-workers).
-
-The scan state is comprised of a forest of [full-binary trees](https://en.wikipedia.org/wiki/Binary_tree) where each node in the tree is a job to be completed by a SNARK worker. The scan state periodically returns a single proof from the top of a tree that attests to the correctness of all transactions at the base of the tree.
->>>>>>> main
 
 The block producers include the emitted ledger proof in the blockchain SNARK they generate that proves both the chain's current state is valid and attests to the validity of all transactions included in the SNARKed ledger.
 
@@ -205,11 +199,7 @@ While multiple SNARK workers can complete the same work, only the lowest fee is 
 
 :::
 
-<<<<<<< HEAD
-When a block producer includes completed proofs into a block to offset any transactions they add, they can purchase the corresponding work from the SNARK pool. For example, continuing the previous example, consider the next block (12). If the block producer wants to add three transactions, comprised of a coinbase, a user payment, and a fee transfer to the SNARK worker, they need to purchase three completed SNARK works. This corresponds to the 6 `B9`, `B10`s, `M9`, and `M10` (from the seventh tree) proofs, as each SNARK work includes two _workIds_.
-=======
 When a block producer includes completed proofs into a block to offset any transactions they add, they may purchase the corresponding work from the SNARK pool. For example, continuing the example above consider the next block (12). If the block producer wants to add three transactions, comprising a coinbase, a user payment, and a fee transfer to the SNARK worker, they need to purchase three completed SNARK work. This corresponds to the 6 `B9`, `B10`s, `M9`, and `M10` (from the seventh tree) proofs, as each SNARK work includes two _workIds_.
->>>>>>> main
 
 During the time the block is generated, the SNARK pool may include completed work in addition to the best bids for the required jobs (0.025, 0.165, 0.1 and 0.5) respectively, in the example).
 
@@ -225,10 +215,6 @@ In the case where there is no completed SNARK work available to purchase in the 
 
 :::tip
 
-<<<<<<< HEAD
-The current SNARK pool is visible via [GraphQL](/node-developers/graphql-api) or the Mina CLI by using the `mina advanced snark-pool` command.
-=======
 The current SNARK pool is visible via [GraphQL](/node-developers/graphql-api) or the CLI via the `mina advanced snark-pool` command.
->>>>>>> main
 
 :::

--- a/docs/node-operators/snark-workers.mdx
+++ b/docs/node-operators/snark-workers.mdx
@@ -7,15 +7,9 @@ hide_title: true
 
 While most protocols have just one primary group of node operators (often called miners, validators, or block producers), Mina has a second group — the **SNARK worker**.
 
-<<<<<<< HEAD
 SNARK workers are integral to the Mina network's health because these nodes are responsible for snarking, or producing SNARK proofs, of transactions in the network. By producing these proofs, snark workers help maintain the succinctness of the Mina blockchain.
 
 Read on to learn why SNARK workers are needed, how the economic incentives align, and operational details of performing SNARK work. Feel free to click through to any of the sections that are most relevant to your needs.
-=======
-SNARK workers are integral to the Mina network's health because these nodes are responsible for snarking, or producing SNARK proofs, of transactions in the network. By producing these proofs, SNARK workers help maintain the succinctness of the Mina blockchain.
-
-In this document, we'll briefly cover why SNARK workers are needed, how the economic incentives align, and provide operational details of performing SNARK work. Feel free to click through to any of the sections above that are most relevant to your needs.
->>>>>>> main
 
 Note: The theory of zk-SNARKs is not covered. Deep knowledge of SNARKs is not required to read this section, but it is helpful to understand in general how SNARKs work and what they are useful for. To learn more, check out this
  [What are zk-SNARKs?](https://minaprotocol.com/blog/what-are-zk-snarks) primer first.

--- a/docs/node-operators/staking-and-snarking.mdx
+++ b/docs/node-operators/staking-and-snarking.mdx
@@ -152,11 +152,7 @@ args={["-run-snark-worker $MINA_PUBLIC_KEY", "-snark-worker-fee <fee>"]}
 
 As a SNARK-worker, you get to share some of the block rewards for each block that include your compressed transactions. The block producer is responsible for gathering compressed transactions before including them into a block and is incentivized by the protocol to reward SNARK-workers.
 
-<<<<<<< HEAD
-SNARK workers can be fairly compute intensive, so if you need to limit their CPU usage, you can specify the number of threads snark workers use with the `-snark-worker-parallelism` flag. This can be especially useful if you're trying to run a block producer and snark worker on the same machine and having issues producing blocks in time.
-=======
 SNARK-workers can be fairly compute intensive. If you need to limit their CPU usage, specify the number of threads that SNARK-workers use with the `-snark-worker-parallelism` flag. This can be especially useful if you're trying to run a block producer and SNARK-worker on the same machine and having issues producing blocks in time.
->>>>>>> main
 
 The roles and responsibilities of a Mina node operator offer you incentives to participate in block production through staking or delegation. Mina is a permissionless peer-to-peer network, so everything is managed and run in a decentralized manner by nodes all over the world. 
 

--- a/docs/node-operators/troubleshooting.mdx
+++ b/docs/node-operators/troubleshooting.mdx
@@ -342,11 +342,7 @@ Run `mina client set-snark-worker` to disable the SNARK worker. To enable again,
 
 ### Can I run a SNARK worker and block producer on the same machine?
 
-<<<<<<< HEAD
 Yes, you can, but you should stop the snark worker during block production so as not to compete for resources and miss producing a block. SNARK workers also consume more resources in general. See the [snark stopper script](https://github.com/c29r3/mina-snark-stopper) to help in automating this.
-=======
-Yes, you can, but you should stop the SNARK worker during block production so as not to compete for resources and miss producing a block. SNARK workers also consume more resources in general. See the [SNARK stopper script](https://github.com/c29r3/mina-snark-stopper) to help in automating this.
->>>>>>> main
 
 ## Logging
 


### PR DESCRIPTION
I learned a lot about using the merge conflict editor in VSC, but not enough! 
This PR fixes errors I introduced with the latest long-lived PR with too many topics.