### PR TITLE
link GitHub logo to the docs repo

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -346,7 +346,7 @@ module.exports = {
           {
             type: 'html',
             position: 'right',
-            value: `<a href="https://github.com/MinaProtocol/mina"><img class="navbar-icon" src="/svg/socials/github_24x24.svg"/></a>`,
+            value: `<a href="https://github.com/o1-labs/docs2/"><img class="navbar-icon" src="/svg/socials/github_24x24.svg"/></a>`,
           },
           {
             type: 'html',


### PR DESCRIPTION
This PR changes the link on the GitHub repo
closes #638 

Although there is not evidence of high click count on the logo, the pattern for repo links is to send the user to the source of the page where the GitHub logo lives... in this case, the docs2 repo