### PR TITLE
Add itn authentication to snark coordinator

### DIFF
--- a/docs/test-world-2/launching-a-node.mdx
+++ b/docs/test-world-2/launching-a-node.mdx
@@ -154,6 +154,7 @@ You must configure the SNARK coordinators with the following flags:
 --file-log-level Debug
 --config-directory <path>
 --external-ip  <external server IP>
+--itn-keys  f1F38+W3zLcc45fGZcAf9gsZ7o9Rh3ckqZQw6yOJiS4=,6GmWmMYv5oPwQd2xr6YArmU1YXYCAxQAxKH7aYnBdrk=,ZJDkF9EZlhcAU1jyvP3m9GbkhfYa0yPV+UdAqSamr1Q=,NW2Vis7S5G1B9g2l9cKh3shy9qkI1lvhid38763vZDU=,Cg/8l+JleVH8yNwXkoLawbfLHD93Do4KbttyBS7m9hQ=
 --itn-graphql-port 3089
 --uptime-submitter-key  <uptime-keyfile path>
 --uptime-url https://block-producers-uptime-itn.minaprotocol.tools/v1/submit


### PR DESCRIPTION
Snark coordinator crashes without this with `"Could not create GraphQL server, authentication is required, but no authentication keys were provided"`