### PR TITLE
docs: Scan State edit grooming while fixing a typo

### DIFF
--- a/docs/mina-protocol/scan-state.mdx
+++ b/docs/mina-protocol/scan-state.mdx
@@ -1,7 +1,7 @@
 ---
 title: Scan State
 hide_title: true
-description: The scan state is a data structure that allows decoupling the production of transaction SNARKs from block producers to snark workers. 
+description: A data structure that allows decoupling the production of transaction SNARKs from block producers to snark workers. 
 keywords:
   - data structure
   - blockchian
@@ -14,60 +14,63 @@ keywords:
 
 The scan state is a data structure that allows decoupling the production of transaction SNARKs from block producers to SNARK workers.
 
-Block producers do not have to produce transaction SNARKs, so the block production time can remain constant regardless of the transaction throughput. Additionally, the scan state data structure allows the transaction SNARK proof generation to be parallelized and completed by multiple competing [SNARK workers](/node-operators/snark-workers).
+[Block producers](/mina-protocol/block-producers) do not have to produce transaction SNARKs, so the block production time can remain constant regardless of the transaction throughput. The scan state data structure allows the transaction SNARK proof generation to be parallelized and completed by multiple competing [SNARK workers](/node-operators/snark-workers).
 
 The scan state is comprised of a forest of full [binary trees](https://en.wikipedia.org/wiki/Binary_tree), where each node in the tree is a job to be completed by a SNARK worker. The scan state periodically returns a single proof from the top of a tree that attests to the correctness of all transactions at the base of the tree.
 
 The block producers include the emitted ledger proof in the blockchain SNARK they generate that proves both the chain's current state is valid and attests to the validity of all transactions included in the SNARKed ledger.
 
-As a result, block times can remain constant regardless of the transaction throughput, with the scan state capable of adjusting to match a desired transaction throughput.
+As a result, block times can remain constant regardless of the transaction throughput. The scan state is capable of adjusting to match a desired transaction throughput.
 
 :::tip
 
-In a steady-state, when all slots are filled, and all the required proofs are completed, a ledger proof would be emitted every block.
+In a steady state, when all slots are filled and all the required proofs are completed, a ledger proof is emitted every block.
 
 :::
 
 ### Including transactions
 
-When constructing a block, a [block producer](/mina-protocol/block-producers) may include transactions up to the maximum defined by the [scan state constants](#scan-state-constants). By including transactions, they can pick up any available transaction fees and pay themselves a coinbase reward. Each transaction they add are transformed to new base jobs and added to the scan state.
+When constructing a block, a [block producer](/mina-protocol/block-producers) can include transactions up to the maximum defined by the [scan state constants](#scan-state-constants). Block producers can pick up any available transaction fees and pay themselves a coinbase reward by including transactions. Each transaction they add is transformed into new base jobs and added to the scan state.
 
-For every transaction added, a block producer must include an equivalent amount of completed SNARK work that corresponds to a sequence of jobs that already exist in the scan state. These completed jobs, when added to scan state, create new merge jobs except when it is for the root node, in which case the proof is simply returned as a result.
+For every transaction added, a block producer must include an equivalent amount of completed SNARK work corresponding to a sequence of jobs already existing in the scan state. When added to the scan state, these completed jobs create new merge jobs, except for the root node, in which case the proof is returned as a result.
 
-The block producer, rather than completing the work themselves, may purchase the completed work from any SNARK workers from bids available in the SNARK pool.
+The block producer, rather than completing the work themselves, can purchase the completed work from any SNARK workers from bids available in the SNARK pool (snarketplace).
 
 ### Scan state constants
 
 The following constants dictate the structure and behavior of the scan state:
 
-- transaction_capacity_log_2
-- work_delay
+- `transaction_capacity_log_2`
+- `work_delay`
 
-The transaction_capacity_log_2 constant defines the maximum number of transactions that can be included in a block:
+The `transaction_capacity_log_2` constant defines the maximum number of transactions that can be included in a block:
 
 ```
 max_no_of_transactions = 2^{transaction_capacity_log_2}
 ```
 
-The work delay ensures there is enough time for the SNARK work to be completed by the SNARK workers. If there are no completed proofs available, the block producer cannot include any transactions. Using the work delay, the maximum number of trees that may exist in the scan state is defined by:
+The work delay ensures there is enough time for the SNARK work to be completed by the SNARK workers. The block producer cannot include any transactions if no completed proofs are available. With the work delay, the maximum number of trees that can exist in the scan state is defined by:
 
 ```
 max_number_of_trees = (transaction_capacity_log_2 + 1) * (work_delay + 1) + 1
 ```
 
-The maximum number of proofs that may be included per block is defined by:
+The maximum number of proofs that can be included per block is defined by:
 
 ```
 max_number_of_proofs = 2^{transaction\_capacity_log_2 + 1} - 1
 ```
 
-These scan state constraints ensure that only a single proof can be emitted per block and that the merge node that is to be updated after adding proofs corresponding to its children is always empty.
+These scan state constraints ensure that:
 
-While the maximum number of transactions may be fixed, this may adjust dynamically such that it adjusts to the transaction throughput. As such, the scan state can handle an unlimited transaction throughput, albeit at the cost of increasing (logarithmically) the transaction proof latency.
+- Only a single proof can be emitted per block
+- The merge node to be updated after adding proofs corresponding to its children is always empty.
+
+While the maximum number of transactions can be fixed, this number can dynamically adjust to the transaction throughput. As such, the scan state can handle an unlimited transaction throughput, albeit at the cost of increasing (logarithmically) the transaction proof latency.
 
 ### Example
 
-Consider a scan state with `max_no_of_transactions = 4`, and `work_delay = 1`. Accordingly, this means there can be a maximum amount of work to complete equal to 7 and a maximum number of 7 trees. At **genesis**, the scan state is empty.
+Consider a scan state with `max_no_of_transactions = 4`, and `work_delay = 1`. Accordingly, this means there can be a maximum amount of work to complete equal to 7 and a maximum of 7 trees. At **genesis**, the scan state is empty.
 
 <img
   alt="Block 0"
@@ -115,7 +118,7 @@ Consider a scan state with `max_no_of_transactions = 4`, and `work_delay = 1`. A
 
 :::tip
 
-Any pending work (displayed in orange) is work for the SNARK workers to complete. The SNARK workers submit completed work to the SNARK pool. Multiple SNARK workers may complete the work, but only the lowest fee remains in the SNARK pool that may be purchased by the block producers.
+Any pending work (displayed in orange) is work for the SNARK workers to complete. The SNARK workers submit completed work to the SNARK pool. Multiple SNARK workers can complete the work, but only the lowest fee remains in the SNARK pool that can be purchased by the block producers.
 
 :::
 
@@ -135,7 +138,7 @@ Any pending work (displayed in orange) is work for the SNARK workers to complete
   width="100%"
 />
 
-**Block 7**: In the seventh block, a further four transactions (`B7`) are added by the block producer filling the base of the seventh tree. Seven trees are the maximum number of trees according to the specified scan state constants. The maximum number of proofs (7) are included (`B5` and `M5`). These included proofs create three new merge jobs (`M7`), and additionally, the top `M5` proof is emitted from the scan state.
+**Block 7**: In the seventh block, the block producer adds a further four transactions (`B7`), filling the base of the seventh tree. Seven trees are the maximum number of trees according to the specified scan state constants. The maximum number of proofs (7) are included (`B5` and `M5`). These included proofs create three new merge jobs (`M7`);additionally, the top `M5` proof is emitted from the scan state.
 
 <img
   alt="Block 7"
@@ -161,11 +164,11 @@ The proof that is emitted from the first tree is the ledger proof corresponding 
 
 :::tip
 
-SNARK work is bundled into a work package typically containing two _workIds_, with the exception of the final root proof of a tree. Prorated work for a transaction is two proofs, so this ensures the equality of transactions included and SNARK work to be purchased.
+SNARK work is bundled into a work package typically containing two _workIds_, except for the final root proof of a tree. Prorated work for a transaction is two proofs, ensuring the equality of transactions included and SNARK work to be purchased.
 
 :::
 
-**Block 9**: In the ninth block, the block producer adds three transactions (`B9`). Three proofs (`M6`) are required for the slots to be occupied in the currently unfilled tree. Four proofs were added in the previous block, and therefore only three more needs to be done (given the maximum work is 7). The `M6` proof from tree two is returned as the ledger proof. The third `B9` transaction goes into the now empty tree, and two `B7` proofs are added.
+**Block 9**: The block producer adds three transactions (`B9`) in the ninth block. Three proofs (`M6`) are required to occupy the slots in the currently unfilled tree. Four proofs were added in the previous block, so only three more proofs need to be done (given the maximum work is 7). The `M6` proof from tree two is returned as the ledger proof. The third `B9` transaction goes into the now empty tree, and two `B7` proofs are added.
 
 <img
   alt="Block 9"
@@ -191,13 +194,13 @@ SNARK work is bundled into a work package typically containing two _workIds_, wi
 
 :::tip
 
-View the contents of the scan state using the `mina advanced snark-job-list` command.
+To view the contents of the scan state, run the `mina advanced snark-job-list` command.
 
 :::
 
 ### Integration with the SNARK Pool
 
-Newly added jobs to the scan state are pending jobs for SNARK workers to complete. SNARK workers complete the required transaction SNARKs, submitting bids for their completed work. When a node receives and validates the completed work, they will add to their local SNARK pool if it is valid and the lowest fee for the required work. The work will also be gossiped to other peers in the network.
+Newly added jobs to the scan state are pending jobs for SNARK workers to complete. SNARK workers complete the required transaction SNARKs, submitting bids for their completed work. When a node receives and validates the completed work, SNARK workers add the completed work to the local SNARK pool if it is valid and has the lowest fee for the required work. The work is also gossiped to other peers in the network.
 
 :::tip
 
@@ -205,9 +208,9 @@ While multiple SNARK workers can complete the same work, only the lowest fee is 
 
 :::
 
-When a block producer includes completed proofs into a block to offset any transactions they add, they may purchase the corresponding work from the SNARK pool. For example, continuing the example above consider the next block (12). If the block producer wants to add three transactions, comprising a coinbase, a user payment, and a fee transfer to the SNARK worker, they need to purchase three completed SNARK work. This corresponds to the 6 `B9`, `B10`s, `M9`, and `M10` (from the seventh tree) proofs, as each SNARK work includes two _workIds_.
+When a block producer includes completed proofs into a block to offset any transactions they add, they may purchase the corresponding work from the SNARK pool. Continuing the previous example, consider the next block (12). If the block producer wants to add three transactions, comprising a coinbase, a user payment, and a fee transfer to the SNARK worker, the block producer must purchase three completed SNARK works. This corresponds to the six `B9`, `B10`s, `M9`, and `M10` (from the seventh tree) proofs, as each SNARK work includes two _workIds_.
 
-During the time the block is generated, the SNARK pool may include completed work in addition to the best bids for the required jobs (0.025, 0.165, 0.1 and 0.5) respectively, in the example).
+During the time the block is generated, the SNARK pool can include completed work and the best bids for the required jobs (0.025, 0.165, 0.1, and 0.5) respectively, in the example.
 
 <img
   alt="Submitted work"
@@ -215,12 +218,17 @@ During the time the block is generated, the SNARK pool may include completed wor
   width="100%"
 />
 
-A block producer will consider the price of available work before selecting transactions. The first transaction a block producer will add will be the coinbase transaction for which there is the coinbase reward. If transaction fees do not cover the SNARK work fees required for them to be included, they would not be added. A block producer will never purchase work if it is not economical to do so.
+A block producer considers the price of available work before selecting transactions.
 
-In the case where there is no completed SNARK work available to purchase in the order required, then the corresponding transactions will not be included in a block. This may result in an empty block, but also for the case where no transactions can be added (including a coinbase transaction), there will be no reward for the block producer.
+- The first transaction a block producer adds is the coinbase transaction for which there is the coinbase reward. 
+- If transaction fees do not cover the SNARK work fees required for them to be included, the transaction is not added. 
 
-:::tip
+A block producer never purchases work if it is not economical.
 
-The current SNARK pool is visible via [GraphQL](/node-developers/graphql-api) or the CLI via the `mina advanced snark-pool` command.
+If completed SNARK work is not available to purchase in the order required, then the corresponding transactions are not included in a block. This situation can result in an empty block, but also, for the case where no transactions can be added (including a coinbase transaction), there is no reward for the block producer.
 
-:::
+To view the current SNARK pool, use:
+
+- [GraphQL API](/node-developers/graphql-api)
+- Mina CLI `mina advanced snark-pool` command
+


### PR DESCRIPTION
This PR improves the ... um... circuitous language to clarify the scan state content.
Preview of the doc https://docs2-git-scan-state-minadocs.vercel.app/mina-protocol/scan-state 
I did some edit grooming while fixing simple errors

Applied standards and styles, per the [Docs Style Guide](https://github.com/o1-labs/docs2/wiki/Docs-Style-Guide), esp:
- present tense
- identifying the subject in complex sentences (replacing "they" and "it")
- serial commas

and so on. Questions? Please ask