### PR TITLE
HF docs: verify permissions doc

### DIFF
--- a/docs/zkapps/o1js/permissions.mdx
+++ b/docs/zkapps/o1js/permissions.mdx
@@ -30,7 +30,7 @@ Permissions live on-chain, which means they are a part of the account representa
 
 ## Types of Permissions
 
-There are 11 different types of permissions that you can access and adjust to guard a zkApp account:
+There are 13 different types of permissions that you can access and adjust to guard a zkApp account:
 
 - `editState`: The permission describing how the zkApp account's eight on-chain state fields are allowed to be manipulated.
 

--- a/docs/zkapps/o1js/permissions.mdx
+++ b/docs/zkapps/o1js/permissions.mdx
@@ -24,26 +24,27 @@ zkApp programmability is not yet available on the Mina Mainnet. You can get star
 # Permissions
 
 Permissions are an integral part of zkApp development because they determine who has the authority to interact and make changes to a specific part of a smart contract.
+
 Naturally, every smart contract must have proper permissions to prevent attacks or security holes.
 Permissions live on-chain, which means they are a part of the account representation on the network. Permissions are checked every time an account update tries to interact with an account.
 
 ## Types of Permissions
 
-There are 11 different types of permissions that a developer can access and adjust to guard a zkApp account:
+There are 11 different types of permissions that you can access and adjust to guard a zkApp account:
 
-- `editState`: The permission describing how the zkApp account's eight on-chain state fields are allowed to be manipulated. This permission describes how the on-chate state fields can be manipulated.
+- `editState`: The permission describing how the zkApp account's eight on-chain state fields are allowed to be manipulated.
 
-- `send`: The permission corresponding to the ability to send transactions from this account. This permission determines whether someone can send a transaction, for example, transfer MINA from this particular account.
+- `send`: The permission corresponding to the ability to send transactions from this account. For example, this permission determines whether someone can send a transaction to transfer MINA from this particular account.
 
 - `receive`: Similar to `send`, the `receive` permission determines whether a particular account can receive transactions, for example, depositing MINA.
 
-- `setDelegate`: The permission corresponding to the ability to set the delegate field of the account. The delegate field is the address of another account to whom this account is delegating its MINA for staking.
+- `setDelegate`: The permission corresponding to the ability to set the delegate field of the account. The delegate field is the address of another account that this account is delegating its MINA for staking.
 
 - `setPermissions`: The permission corresponding to the ability to change the permissions of the account. As the name suggests, this type of permission describes how already set permissions can be changed.
 
 - `setVerificationKey`: The permission corresponding to the ability to change the verification key of the account. Every smart contract has a verification key stored on-chain. The verification key is used to verify off-chain proofs. This permission essentially describes if the verification key can be changed; you can also think of it as the "upgradeability" of smart contracts.
 
-- `setZkappUri`: The permission corresponding to the ability to change the zkapp uri field of the account. The `zkappUri` field can be used to store metadata about the smart contract, for example, link to the source code.
+- `setZkappUri`: The permission corresponding to the ability to change the `zkappUri` field of the account that stores metadata about the smart contract, for example, link to the source code.
 
 - `editActionsState`: The permission that corresponds to the ability to change the actions state of the associated account. Every smart contract can dispatch actions that are committed on-chain. This type of permission describes who can change the actions state.
 
@@ -53,7 +54,7 @@ There are 11 different types of permissions that a developer can access and adju
 
 - `setVotingFor`: The permission corresponding to the ability to set the chain hash for this account. The `votingFor` field is an on-chain mechanism to set the chain hash of the hard fork this account is voting for.
 
-- `access`: This permission is more restrictive than all the other permissions combined! It corresponds to the ability to include any account update for this account in a transaction, even no-op account updates. Usually, the access permission is set to require no authorization. However, for [token manager contracts](custom-tokens), `access` requires at least proof authorization so that token interactions are approved by calling one of the token manager's methods.
+- `access`: This permission is more restrictive than all the other permissions combined! It corresponds to the ability to include any account update for this account in a transaction, even no-op account updates. Usually, the access permission is set to require no authorization. However, for token manager contracts [(custom tokens)](custom-tokens), `access` requires at least proof authorization so that token interactions are approved by calling one of the token manager's methods.
 
 - `setTiming`: The permission corresponding to the ability to control the vesting schedule of time-locked accounts.
 
@@ -101,7 +102,7 @@ This example account update is authorized by a signature:
 }
 ```
 
-As you can see, this example account update has an authorization with a `signature` provided. You can also see it's trying to update the app state of the smart contract.
+This example account update has an authorization with a `signature` provided. You can also see it's trying to update the app state of the smart contract.
 
 However, imagine if a smart contract had the the permission `editState` set to the authorization `none`.
 When authorization is `none`, everyone can freely change the state of the smart contract as they please! Obviously, this is not a safe practice. To allow state changes only when a valid proof accompanies the account update that wants to access the state, set your authorization to `proof` so that the transaction is authorized by a proof that is checked against the verification key of the account. Using a `proof` authorization ensures that state is changed only if the user generated a valid proof by executing a smart contract method correctly.
@@ -128,15 +129,13 @@ Smart contracts, when first deployed, always start with this default set of perm
 
 `setTokenSymbol`: `signature`
 
-## Example
-
 To better understand how to leverage permissions to make your smart contract more secure, look at these examples.
 
-### Sending MINA from smart contracts
+## Example: UnsecureContract
 
 Some smart contracts manage state and token, such as the native MINA token. To prevent malicious actors from withdrawing all funds, use permissions to secure them.
 
-Consider the following `UnsecureContract` smart contract. [A similar example](https://github.com/o1-labs/o1js/blob/main/src/examples/zkapps/simple_zkapp_payment.ts) is also provided in the `examples` folder in the `o1js` codebase repo:
+Consider the following `UnsecureContract` smart contract. A similar [simple_zkapp_payment.ts](https://github.com/o1-labs/o1js/blob/main/src/examples/zkapps/simple_zkapp_payment.ts) contract is also provided in the `examples` folder:
 
 ```ts
 class UnsecureContract extends SmartContract {
@@ -154,9 +153,11 @@ class UnsecureContract extends SmartContract {
 }
 ```
 
-This `UnsecureContract` has just one method: `withdraw()` for withdrawing funds from the smart contract account. We will use that method later.
+This `UnsecureContract` has only the `withdraw()` method for withdrawing funds from the smart contract account. 
 
-But first, notice that the permissions specified in the `init()` method have set the `send` permission to `Permissions.none()`. Because `none` means you don't have to provide _any_ form of authorization, a malicious actor can easily drain all funds from the smart contract! Take a look at the following malicious transaction that abuses this permission:
+But first, notice that the permissions specified in the `init()` method have set the `send` permission to `Permissions.none()`. Because `none` means you don't have to provide _any_ form of authorization, a malicious actor can easily drain all funds from the smart contract. 
+
+Take a look at the following malicious transaction that abuses this permission:
 
 ```ts
 tx = await Mina.transaction(account1Address, () => {
@@ -166,8 +167,9 @@ tx = await Mina.transaction(account1Address, () => {
 await tx.sign([account1Key]).send();
 ```
 
-This transaction creates a new account update for our smart contract address. Right after that, the new account update sends 1 MINA to the address of the fee payer (`account1Address`).
-At the end of the transaction block, the transaction is signed only with the private key of the fee payer -- not the private key of the smart contract!
+This transaction creates a new account update for the smart contract address. Right after that, the new account update sends 1 MINA to the address of the fee payer (`account1Address`).
+At the end of the transaction block, the transaction is signed only with the private key of the fee payer -- not the private key of the smart contract.
+
 Because the permissions for sending funds away from a smart contract are set to `none`, this transaction succeeds and drains 1 MINA from the smart contract.
 
 Now, change the `send` permission to `signature` instead:
@@ -179,7 +181,7 @@ Now, change the `send` permission to `signature` instead:
 
 If you try to run the same transaction as before, the manual account update fails with `Update_not_permitted_balance`. This check prevents withdrawing funds from the smart contract, since the authorization does not fit the permission for `send` that now requires a valid signature.
 
-You can slightly modify the withdraw-transaction to include a valid signature by adding `.requireSignature()` on the withdrawal account update and providing the private key of the smart contract account to `tx.send([zkappKey]) `
+You can slightly modify the withdraw transaction to include a valid signature by adding `.requireSignature()` on the withdrawal account update and providing the private key of the smart contract account to `tx.send([zkappKey])`:
 
 ```ts
 tx = await Mina.transaction(account1Address, () => {
@@ -190,11 +192,13 @@ tx = await Mina.transaction(account1Address, () => {
 await tx.sign([account1Key, zkappKey]).send();
 ```
 
-Now that you have provided a valid signature, the transaction succeeds!
+Now that you have provided a valid signature, the transaction succeeds.
 
-However, this way of authorizing a transaction is not what you expect from a smart contract. If you set a permission to `signature`, only the owner of the zkApp's private key (`zkappKey`) is able to perform the interaction. However, the point of a smart contract is that anyone can interact, by trustlessly executing the smart contract code. For enabling a trustless execution, we have `Permissions.proof()`.
+However, this way of authorizing a transaction is not what you expect from a smart contract. If you set a permission to `signature`, only the owner of the zkApp's private key (`zkappKey`) is able to perform the interaction. However, the point of a smart contract is to let anyone interact by trustlessly executing the smart contract code. 
 
-Now, try to make `UnsecureContract` a proper smart contract by setting the `send` permission to `proof`:
+For enabling a trustless execution, use `Permissions.proof()`.
+
+Now, to make `UnsecureContract` a proper smart contract, set the `send` permission to `proof`:
 
 ```diff
 -      send: Permissions.signature(),
@@ -216,9 +220,11 @@ Alternatively, you can just delete the entire `init()` method, since a `send` pe
 
 If you try running one of the two transactions from before, which created account updates manually, you'll find that they both fail with `Update_not_permitted_balance`.
 
-Setting the `send` permission to `proof` means that, to send MINA from this account, you need to execute one of the contract's `@method`s.
+Setting the `send` permission to `proof` means that, to send MINA from this account, you need to execute one of the contract's `@method`.
 
-In fact, our contract already has a `@method` which you can use: `withdraw()`. You create a withdrawal transaction containing a valid proof like this:
+The contract already has an `@method` that you can use: `withdraw()`. 
+
+To create a withdrawal transaction that contains a valid proof:
 
 ```ts
 tx = await Mina.transaction(account1Address, () => {
@@ -229,9 +235,13 @@ await tx.prove();
 await tx.sign([account1Key, zkappKey]).send();
 ```
 
-As opposed to the other examples, you don't explicitly create an `AccountUpdate`. Instead, you instantiate `UnsecureContract` and call its `withdraw()` method. Each method call is automatically associated with an account update, for which it creates a valid proof. You can access and modify this account update by using `this` inside the method; in our example, you use `this.send(...)` to send MINA. So, by calling the method and doing `tx.prove()`, you satisfy the `proof` authorization requirement for sending MINA.
+In contrast to the other examples, you don't explicitly create an `AccountUpdate`. Instead, you instantiate `UnsecureContract` and call its `withdraw()` method. Each method call is automatically associated with an account update, for which it creates a valid proof. You can access and modify this account update by using `this` inside the method. 
 
-You might have noticed that the contract is still not very secure: Anyone can call the `withdraw()` method to drain any amount of MINA from the contract. That's why it's called `UnsecureContract`. In a real contract, you would add some conditions to the `withdraw()` code, that restrict which users that can successfully call the method.
+In this example, use `this.send(...)` to send MINA. By calling the method and doing `tx.prove()`, you satisfy the `proof` authorization requirement for sending MINA.
+
+You might have noticed that the contract is still not very secure: Anyone can call the `withdraw()` method to drain any amount of MINA from the contract. That's why the example is called `UnsecureContract`. 
+
+In a real contract, you would add some conditions to the `withdraw()` code to restrict which users can successfully call the method.
 
 <!-- TODO: commented until we add the signature page -->
 <!-- To learn about signatures in zkApps, see [Signatures in a smart contract](./signatures-in-zkapps) for a continuation of this example that adds user authorization to the smart contract code. -->
@@ -239,11 +249,13 @@ You might have noticed that the contract is still not very secure: Anyone can ca
 ### Upgradeability of smart contracts
 
 Another important part of smart contract development is upgradeability.
-By using permissions, you can make a smart contract upgradeable or not upgradeable at all.
-On Mina, when you deploy a smart contract you generate a verification key from the contract source code. The verification key and the smart contract are stored on-chain and used to verify proofs that belong to that smart contract.
-Remember the permission called `setVerificationKey`? You can modify the authorization for this permission to set the upgradability of the smart contract.
 
-#### Example: Impossible to upgrade
+By using permissions, you can make a smart contract upgradeable or not upgradeable.
+On Mina, when you deploy a smart contract you generate a verification key from the contract source code. The verification key and the smart contract are stored on-chain and used to verify proofs that belong to that smart contract.
+
+Remember the permission called `setVerificationKey`? Modify the authorization for this permission to set the upgradability of the smart contract.
+
+## Example: Impossible to upgrade
 
 This simple example ensures that the smart contract is not upgradeable. After a verification key is deployed, it cannot be changed.
 
@@ -283,10 +295,11 @@ Using the `LocalBlockchain`, you get the following (expected) error:
 
 For the sake of security, it is important to note that you must also set the `setPermissions` permission to `impossible` to make the smart contract truly impossible to upgrade. This permission prevents a zkApp developer from changing the permission `setVerificationKey` to, for example, `signature` - which allows them to manipulate the verification key again.
 
-#### Example: Upgradeable with a proof
+## Example: Upgradeable with a proof
 
 There are situations where you might want the smart contract to be upgradeable.
-Modify the method `updateVerificationKey` to do some checks before you can update the verification key (as the result of a vote or other conditions).
+Modify the method `updateVerificationKey` to do some checks before you can update the verification key. For example, as the result of a vote or other conditions.
+
 For now, just check that you can provide an `x` that is greater than or equal to 5. If this check succeeds, then update the verification key.
 
 ```ts
@@ -307,7 +320,7 @@ this.account.permissions.set({
 });
 ```
 
-Now when you invoke the `updateVerificationKey` method, the transaction generates a valid smart contract execution proof to succeed and upgrade the verification key to a new one!
+Now when you invoke the `updateVerificationKey` method, the transaction generates a valid smart contract execution proof to succeed and upgrade the verification key to a new one.
 
 ```ts
 console.log('try upgrading vk');
@@ -321,4 +334,5 @@ await tx.sign([feePayerKey, zkappKey]).send();
 ## Where to learn more
 
 Integration tests exercise the behavior of different permissions, including upgradeability.
-If you want to take a look, check out the [voting integration test](https://github.com/o1-labs/o1js/blob/main/src/examples/zkapps/voting/test.ts#L50) as well as the [DEX integration test](https://github.com/o1-labs/o1js/blob/main/src/examples/zkapps/dex/upgradability.ts) examples.
+
+Check out the [voting integration test](https://github.com/o1-labs/o1js/blob/main/src/examples/zkapps/voting/test.ts#L50) and the [DEX integration test](https://github.com/o1-labs/o1js/blob/main/src/examples/zkapps/dex/upgradability.ts) examples.


### PR DESCRIPTION
This PR verifies the content for HF for the zkApps > o1js > Permissions doc

Closes https://github.com/o1-labs/docs2/issues/479

Please review in entirety.

It's difficult to see what is not here, but please lmk what changes we might need

Preview doc https://docs2-git-permissions-verify-minadocs.vercel.app/zkapps/o1js/permissions