### PR TITLE
Fixed broken link syntax

### DIFF
--- a/docs/zkapps/o1js/actions-and-reducer.mdx
+++ b/docs/zkapps/o1js/actions-and-reducer.mdx
@@ -120,4 +120,4 @@ Right now, `getActions` is available for [testing with `LocalBlockchain`](/zkapp
 
 One of the most important use cases for actions is to enable concurrent state updates. This enablement is also why actions were originally added to the protocol.
 
-You can see a full code example in [reducer.ts]](https://github.com/o1-labs/o1js/blob/main/src/examples/zkapps/reducer/reducer.ts) that demonstrates this pattern. Leveraging `Reducer.reduce()`, it takes only about 30 lines of code to build a zkApp that handles concurrent state updates.
+You can see a full code example in [reducer.ts](https://github.com/o1-labs/o1js/blob/main/src/examples/zkapps/reducer/reducer.ts) that demonstrates this pattern. Leveraging `Reducer.reduce()`, it takes only about 30 lines of code to build a zkApp that handles concurrent state updates.


### PR DESCRIPTION
Found a link that wasn't displaying correctly on the actions and reducer page. Fixed it