### PR TITLE
quick fix: create, but not modify, the deploy alias 

### DIFF
--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -136,7 +136,7 @@ Because staking MINA requires nodes to be online, some nodes delegate their MINA
 
 ### deploy alias
 
-Created and updated with the Mina zkApp CLI, a [deploy alias](/zkapps/tutorials/deploying-to-a-network#deploy-alias) in your project `config.json` file contains the details to manage deployments.
+Created with the zkApp CLI, a [deploy alias](/zkapps/tutorials/deploying-to-a-network#deploy-alias) in your project `config.json` file contains the details to manage deployments.
 
 ### Devnet
 

--- a/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
+++ b/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
@@ -120,7 +120,7 @@ The `config.json` configuration file was automatically scaffolded when you creat
 
 ### Deploy alias
 
-The `zk config` command prompts guide you to create or update a deploy alias in your project `config.json` file. 
+The `zk config` command prompts guide you to create a deploy alias in your project `config.json` file. 
 
 You can have one or more deploy aliases for your project.  
 


### PR DESCRIPTION
wishful thinking as detailed in this feature request https://app.zenhub.com/workspaces/zkapps-product-eng-6130fedb3b0fc600123d8796/issues/gh/o1-labs/zkapp-cli/508

I misunderstood that `zk config` only created the deploy alias but didn't allow updates. This PR fixes the doc error 