### PR TITLE
Fix "zkapps - developers - creating zkapps" page ordering in a sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -41,9 +41,9 @@ module.exports = {
           label: 'Creating zkApps',
           items: [
             'zkapps/how-to-write-a-zkapp',
-            'zkapps/how-to-write-a-zkapp-ui',
             'zkapps/how-to-test-a-zkapp',
             'zkapps/how-to-deploy-a-zkapp',
+            'zkapps/how-to-write-a-zkapp-ui',
           ],
         },
         {


### PR DESCRIPTION
<img width="236" alt="image" src="https://github.com/o1-labs/docs2/assets/9920174/3f73d853-8bc4-41b9-9243-0836bf837da5">

This PR moves sidebar item "How to write zkApp UI" to the bottom, according to the Creating zkApps articles' logical order (see current ordering on the screenshot above)