### PR TITLE
Fix zkapps broken / irrelevant links

### DIFF
--- a/docs/zkapps/tutorials/01-hello-world.mdx
+++ b/docs/zkapps/tutorials/01-hello-world.mdx
@@ -279,7 +279,7 @@ Notice that `get()` and `set()` methods are used for retrieving and setting on-c
 
 - Similarly, using `set()` changes the transaction to indicate that changes to this particular on-chain state are updated only when the transaction is received by the Mina network if it contains a valid authorization (usually, a valid authorization is a proof).
 
-The logic also uses the `.mul()` method for multiplication of the values stored in `Field` types. You can view all available methods in the [o1js Reference](/zkapps/o1js-reference) documentation. 
+The logic also uses the `.mul()` method for multiplication of the values stored in `Field` types. You can view all available methods in the [Field](/zkapps/o1js-reference/classes/Field) in the o1js Reference documentation. 
 
 You remember that functions in your smart contract must operate on o1js compatible data types: `Field` types and other types built on top of `Field` types. Because a smart contract is really a zero-knowledge circuit, functions from random NPM packages work inside a smart contract only if the functions the contract provides operate on o1js-compatible data types.
 

--- a/docs/zkapps/tutorials/01-hello-world.mdx
+++ b/docs/zkapps/tutorials/01-hello-world.mdx
@@ -279,7 +279,7 @@ Notice that `get()` and `set()` methods are used for retrieving and setting on-c
 
 - Similarly, using `set()` changes the transaction to indicate that changes to this particular on-chain state are updated only when the transaction is received by the Mina network if it contains a valid authorization (usually, a valid authorization is a proof).
 
-The logic also uses the `.mul()` method for multiplication of the values stored in `Field` types. You can view all available methods in the [Field](/zkapps/o1js-reference/classes/Field) in the o1js Reference documentation. 
+The logic also uses the `.mul()` method for multiplication of the values stored in `Field` types. You can view all available [methods](/zkapps/o1js-reference/classes/Field#methods) in the o1js Reference documentation. 
 
 You remember that functions in your smart contract must operate on o1js compatible data types: `Field` types and other types built on top of `Field` types. Because a smart contract is really a zero-knowledge circuit, functions from random NPM packages work inside a smart contract only if the functions the contract provides operate on o1js-compatible data types.
 

--- a/docs/zkapps/tutorials/06-offchain-storage.mdx
+++ b/docs/zkapps/tutorials/06-offchain-storage.mdx
@@ -84,10 +84,10 @@ Suggested improvements:
 
 ## Implement a Project Using Off-Chain Storage
 
-The sample code for this project is provided at [examples/zkapps/06-offchain-storage/contracts](https://github.com/o1-labs/docs2/tree/main/examples/zkapps/06-offchain-storage/contracts) with a focus on:
+The sample code for this project is provided at [examples/zkapps/06-offchain-storage/contracts](https://github.com/o1-labs/docs2/tree/main/examples/zkapps/06-offchain-storage/offchain-storage-zkapp/contracts) with a focus on:
 
-- [src/main.ts](https://github.com/o1-labs/docs2/tree/main/examples/zkapps/06-offchain-storage/contracts/src/main.ts)
-- [src/NumberTreeContract.ts](https://github.com/o1-labs/docs2/tree/main/examples/zkapps/06-offchain-storage/contracts/src/NumberTreeContract.ts) 
+- [src/main.ts](https://github.com/o1-labs/docs2/blob/main/examples/zkapps/06-offchain-storage/offchain-storage-zkapp/contracts/src/main.ts)
+- [src/NumberTreeContract.ts](https://github.com/o1-labs/docs2/blob/main/examples/zkapps/06-offchain-storage/offchain-storage-zkapp/contracts/src/NumberTreeContract.ts) 
 
 This project implements a Merkle tree where:
 

--- a/docs/zkapps/tutorials/09-recursion.mdx
+++ b/docs/zkapps/tutorials/09-recursion.mdx
@@ -315,4 +315,4 @@ You learned about:
 
 Recursive zero knowledge proofs can help you build powerful zkApps.
 
-Check out [Tutorial 10: Account Updates](zkapps/tutorials/account-updates) to learn about account updates, the underlying structure of zkApps, and how they enable permissions, preconditions, and composability.
+Check out [Tutorial 10: Account Updates](/zkapps/tutorials/account-updates) to learn about account updates, the underlying structure of zkApps, and how they enable permissions, preconditions, and composability.

--- a/docs/zkapps/tutorials/10-account-updates.mdx
+++ b/docs/zkapps/tutorials/10-account-updates.mdx
@@ -335,7 +335,7 @@ Now there are two AccountUpdates:
   - The parent corresponds to the `add()` method call
   - The child corresponds to the `this.incrementCalls()` call that the parent makes.
 
-One update is the child because it was called from the parent, which also implies that the parent has the child included as part of its proof. To learn more about parent/child account updates, see [Payment to zkApp example](/zkapps/o1js/interact-with-mina#signing-transactions-and-explicit-account-updates).
+One update is the child because it was called from the parent, which also implies that the parent has the child included as part of its proof. To learn more about parent/child account updates, see [Signing transactions and explicit account updates](/zkapps/o1js/interact-with-mina#signing-transactions-and-explicit-account-updates) in the Payment to zkApp example.
 
 As a reminder, this update corresponds to code:
 

--- a/docs/zkapps/tutorials/10-account-updates.mdx
+++ b/docs/zkapps/tutorials/10-account-updates.mdx
@@ -335,7 +335,7 @@ Now there are two AccountUpdates:
   - The parent corresponds to the `add()` method call
   - The child corresponds to the `this.incrementCalls()` call that the parent makes.
 
-One update is the child because it was called from the parent, which also implies that the parent has the child included as part of its proof. To learn more about parent/child account updates, see [Payment to zkApp example](/zkapps/o1js/interact-with-mina#payment-to-zkapp-example).
+One update is the child because it was called from the parent, which also implies that the parent has the child included as part of its proof. To learn more about parent/child account updates, see [Payment to zkApp example](/zkapps/o1js/interact-with-mina#signing-transactions-and-explicit-account-updates).
 
 As a reminder, this update corresponds to code:
 


### PR DESCRIPTION
This one fixes following issues related to broken links in Tutorials 1, 6, 9 and 10

- [Here](https://docs.minaprotocol.com/zkapps/tutorials/hello-world#smart-contract-class) the link to o1js Reference sends me to 01js reference home page. Its better to link the Field page instead
- Broken links to [src/main.ts](https://github.com/o1-labs/docs2/tree/main/examples/zkapps/06-offchain-storage/contracts/src/main.ts) and [src/NumberTreeContract.ts](https://github.com/o1-labs/docs2/tree/main/examples/zkapps/06-offchain-storage/contracts/src/NumberTreeContract.ts) in [Tutorial 6](https://docs.minaprotocol.com/zkapps/tutorials/offchain-storage#implement-a-project-using-off-chain-storage)
- [Tutorial 9](https://docs.minaprotocol.com/zkapps/tutorials/recursion): the last link is broken
- [Payment to zkApp](https://docs.minaprotocol.com/zkapps/tutorials/account-updates#two-accountupdates) anchor is referenced but no longer exists, should be changed to [this one](https://docs.minaprotocol.com/zkapps/o1js/interact-with-mina#signing-transactions-and-explicit-account-updates)