### PR TITLE
Remove unneeded 'Install dependencies' section in Tutorial 4

### DIFF
--- a/docs/zkapps/tutorials/04-zkapp-ui-with-react.mdx
+++ b/docs/zkapps/tutorials/04-zkapp-ui-with-react.mdx
@@ -142,27 +142,6 @@ For this tutorial, you run commands from the root of the `04-zkapp-browser-ui/ui
 
 Each time you make updates, then build or deploy, the TypeScript code is compiled into JavaScript in the `build` directory.
 
-### Install the dependencies
-
-When you ran the `zk project` command, your UI was created in the project directory: `/04-zkapp-browser-ui/ui` with two sub-directories:
-
-  - `contracts`: The smart contract code 
-  - `ui`: Where you write your UI code
-
-Install the dependencies in each sub-directory.
-
-1. In the `/04-zkapp-browser-ui/ui` directory, run:
-
-  ```sh
-  $ npm install
-  ```
-
-1. In the `/04-zkapp-browser-ui/contracts` directory:
-
-  ```sh
-  $ npm install
-  ```
-
 ## Create a repository
 
 To interact with a deployed zkApp UI on GitHub pages, you must create a GitHub repository.

--- a/docs/zkapps/tutorials/04-zkapp-ui-with-react.mdx
+++ b/docs/zkapps/tutorials/04-zkapp-ui-with-react.mdx
@@ -142,6 +142,15 @@ For this tutorial, you run commands from the root of the `04-zkapp-browser-ui/ui
 
 Each time you make updates, then build or deploy, the TypeScript code is compiled into JavaScript in the `build` directory.
 
+### Install the dependencies
+
+When you ran the zk project command, your UI was created in the project directory: `/04-zkapp-browser-ui/ui`. The project has two sub-directories:
+
+`contracts`: The smart contract code
+`ui`: Where you write your UI code
+
+The dependencies in each sub-directory are installed automatically by the zkApp-cli.
+
 ## Create a repository
 
 To interact with a deployed zkApp UI on GitHub pages, you must create a GitHub repository.

--- a/docs/zkapps/tutorials/04-zkapp-ui-with-react.mdx
+++ b/docs/zkapps/tutorials/04-zkapp-ui-with-react.mdx
@@ -146,8 +146,8 @@ Each time you make updates, then build or deploy, the TypeScript code is compile
 
 When you ran the zk project command, your UI was created in the project directory: `/04-zkapp-browser-ui/ui`. The project has two sub-directories:
 
-`contracts`: The smart contract code
-`ui`: Where you write your UI code
+- `contracts`: The smart contract code
+- `ui`: Where you write your UI code
 
 The dependencies in each sub-directory are installed automatically by the zkApp-cli.
 


### PR DESCRIPTION
[Here](https://docs.minaprotocol.com/zkapps/tutorials/zkapp-ui-with-react#install-the-dependencies) “npm install” have been already done when “zk project <project name>” was called. We may want to omit the whole section