### PR TITLE
remove irrelevant video from Tutorial 5

### DIFF
--- a/docs/zkapps/tutorials/05-common-types-and-functions.mdx
+++ b/docs/zkapps/tutorials/05-common-types-and-functions.mdx
@@ -509,7 +509,3 @@ You use [MerkleMaps](/zkapps/o1js-reference/classes/MerkleMap) to implement many
 Congratulations! You have finished reviewing more common types and functions in o1js. With this, you should now be capable of writing many advanced smart contracts and zkApps.
 
 To use more data from your zkApp, check out [Tutorial 6](offchain-storage) to learn how to use off-chain storage.
-
-## Other Resources
-
-<ResponsiveVideo src="https://www.youtube.com/embed/nxM7VmJqoU4" />


### PR DESCRIPTION
Tutorial 5 is about common datatypes, but referencing videotutorial about Local blockchain. 