### PR TITLE
fix typo in Tutorial 11

### DIFF
--- a/docs/zkapps/tutorials/11-advanced-account-updates.mdx
+++ b/docs/zkapps/tutorials/11-advanced-account-updates.mdx
@@ -142,7 +142,7 @@ The `fundNewAccount` call is included as the deployer account. In this case, it 
   }
 ```
 
-Which calls the `transferAway` method on `tokenHolder`:
+Which calls the `transferAway()` method on `tokenHolder`:
 
 ```typescript
   @method transferAway(amount: UInt64) {

--- a/docs/zkapps/tutorials/11-advanced-account-updates.mdx
+++ b/docs/zkapps/tutorials/11-advanced-account-updates.mdx
@@ -142,7 +142,7 @@ The `fundNewAccount` call is included as the deployer account. In this case, it 
   }
 ```
 
-Which calls the `transferAway` contract on `tokenHolder`:
+Which calls the `transferAway` method on `tokenHolder`:
 
 ```typescript
   @method transferAway(amount: UInt64) {


### PR DESCRIPTION
Typo in “[Which calls the transferAway contract](https://docs.minaprotocol.com/zkapps/tutorials/advanced-account-updates)”, should be “method”