### PR TITLE
fix typo

### DIFF
--- a/docs/zkapps/tutorials/anonymous-message-board.mdx
+++ b/docs/zkapps/tutorials/anonymous-message-board.mdx
@@ -93,7 +93,7 @@ This command creates a directory containing a new project template, fully set up
 
 ### Scaffolding
 
-Now that your project is set up, you can open it in your IDE or `cd zk-message` if you work from the command line.
+Now that your project is set up, you can open it in your IDE or `cd message-board` if you work from the command line.
 
 There should be an example smart contract in `./src` called `Add.ts` and tests for it in `Add.test.ts`. These are just example code, and you can delete them if they bother you.
 


### PR DESCRIPTION
The project name is message-board, however the edited sentence says `cd zk-message`