### PR TITLE
Removed line 10 from 'Interact with a smart contract' code snippet

### DIFF
--- a/docs/zkapps/tutorials/01-hello-world.mdx
+++ b/docs/zkapps/tutorials/01-hello-world.mdx
@@ -309,7 +309,6 @@ For this tutorial, the `import` statement brings in items from `o1js` that you u
 7   PrivateKey,
 8   AccountUpdate,
 9 } from 'o1js';
-10
 ```
 
 These import items are:


### PR DESCRIPTION
Line 10 in the first code snippet in the section 'Interact with a smart contract' is blank, so the number 10 is included when you use the copy button