### PR TITLE
feat(o1js-reference): update api reference docs

### DIFF
--- a/docs/zkapps/o1js-reference/README.md
+++ b/docs/zkapps/o1js-reference/README.md
@@ -2,6 +2,22 @@ o1js / [Modules](modules.md)
 
 # o1js &nbsp; [![npm version](https://img.shields.io/npm/v/o1js.svg?style=flat)](https://www.npmjs.com/package/o1js) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/o1-labs/o1js/blob/main/CONTRIBUTING.md)
 
+ℹ️ **o1js** is an evolution of [SnarkyJS](https://www.npmjs.com/package/snarkyjs) which saw:
+49 updated versions over 2 years of development with 43,141 downloads
+
+This name change reflects the evolution of our vision for the premiere toolkit used by developers to build zero knowledge-enabled applications, while paying homage to our technology's recursive proof generation capabilities.
+
+Your favorite functionality stays the same and transitioning to o1js is a quick and easy process:
+
+- To update zkApp-cli, run the following command:
+  `npm i -g zkapp-cli@latest`
+- To remove the now-deprecated SnarkyJs package and install o1js, run the following command:
+  `npm remove snarkyjs && npm install o1js`
+- For existing zkApps, make sure to update your imports from `snarkyjs` to `o1js`
+- No need to redeploy, you are good to go!
+
+## o1js
+
 o1js helps developers build apps powered by zero-knowledge (zk) cryptography.
 
 The easiest way to write zk programs is using o1js.
@@ -32,6 +48,7 @@ See the [Contributing guidelines](https://github.com/o1-labs/o1js/blob/main/CONT
 
 High-quality community packages from open source developers are available for your project.
 
-- **snarkyjs-elgamal** A partially homomorphic encryption library for o1js based on Elgamal encryption: [GitHub](https://github.com/Trivo25/snarkyjs-elgamal) and [npm](https://www.npmjs.com/package/snarkyjs-elgamal)
+- **o1js-elgamal** A partially homomorphic encryption library for o1js based on Elgamal encryption: [GitHub](https://github.com/Trivo25/o1js-elgamal) and [npm](https://www.npmjs.com/package/o1js-elgamal)
+- **o1js-pack** A library for o1js that allows a zkApp developer to pack extra data into a single Field. [GitHub](https://github.com/45930/o1js-pack) and [npm](https://www.npmjs.com/package/o1js-pack)
 
 To include your package, see [Creating high-quality community packages](https://github.com/o1-labs/o1js/blob/main/CONTRIBUTING.md#creating-high-quality-community-packages).

--- a/docs/zkapps/o1js-reference/classes/AccountUpdate.md
+++ b/docs/zkapps/o1js-reference/classes/AccountUpdate.md
@@ -100,7 +100,7 @@ be authorized by either a [Signature](Signature.md) or [Proof](Proof.md).
 
 #### Defined in
 
-[lib/account_update.ts:689](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L689)
+[lib/account_update.ts:686](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L686)
 
 ## Properties
 
@@ -110,7 +110,7 @@ be authorized by either a [Signature](Signature.md) or [Proof](Proof.md).
 
 #### Defined in
 
-[lib/account_update.ts:670](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L670)
+[lib/account_update.ts:667](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L667)
 
 ___
 
@@ -131,7 +131,7 @@ Types.AccountUpdate.authorization
 
 #### Defined in
 
-[lib/account_update.ts:667](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L667)
+[lib/account_update.ts:664](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L664)
 
 ___
 
@@ -145,7 +145,7 @@ Types.AccountUpdate.body
 
 #### Defined in
 
-[lib/account_update.ts:666](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L666)
+[lib/account_update.ts:663](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L663)
 
 ___
 
@@ -162,7 +162,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:673](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L673)
+[lib/account_update.ts:670](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L670)
 
 ___
 
@@ -172,7 +172,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:672](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L672)
+[lib/account_update.ts:669](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L669)
 
 ___
 
@@ -182,7 +182,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:660](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L660)
+[lib/account_update.ts:657](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L657)
 
 ___
 
@@ -192,7 +192,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:685](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L685)
+[lib/account_update.ts:682](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L682)
 
 ___
 
@@ -205,7 +205,7 @@ was created. Can be modified by applications to add richer information.
 
 #### Defined in
 
-[lib/account_update.ts:665](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L665)
+[lib/account_update.ts:662](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L662)
 
 ___
 
@@ -215,7 +215,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:668](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L668)
+[lib/account_update.ts:665](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L665)
 
 ___
 
@@ -225,7 +225,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:671](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L671)
+[lib/account_update.ts:668](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L668)
 
 ___
 
@@ -235,7 +235,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:683](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L683)
+[lib/account_update.ts:680](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L680)
 
 ___
 
@@ -265,7 +265,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:687](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L687)
+[lib/account_update.ts:684](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L684)
 
 ___
 
@@ -308,7 +308,7 @@ StaticChildren(AnyChildren, StaticChildren(1))
 
 #### Defined in
 
-[lib/account_update.ts:1398](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1398)
+[lib/account_update.ts:1395](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1395)
 
 ___
 
@@ -332,7 +332,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1283](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1283)
+[lib/account_update.ts:1280](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1280)
 
 ___
 
@@ -342,7 +342,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1019](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1019)
+[lib/account_update.ts:1016](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1016)
 
 ___
 
@@ -360,7 +360,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1262](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1262)
+[lib/account_update.ts:1259](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1259)
 
 ___
 
@@ -384,7 +384,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1263](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1263)
+[lib/account_update.ts:1260](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1260)
 
 ___
 
@@ -408,7 +408,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1282](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1282)
+[lib/account_update.ts:1279](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1279)
 
 ## Accessors
 
@@ -427,7 +427,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:880](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L880)
+[lib/account_update.ts:877](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L877)
 
 ___
 
@@ -441,7 +441,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:963](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L963)
+[lib/account_update.ts:960](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L960)
 
 ___
 
@@ -455,7 +455,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:820](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L820)
+[lib/account_update.ts:817](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L817)
 
 ___
 
@@ -477,7 +477,7 @@ use `this.account.tokenSymbol`
 
 #### Defined in
 
-[lib/account_update.ts:827](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L827)
+[lib/account_update.ts:824](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L824)
 
 ___
 
@@ -540,7 +540,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:895](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L895)
+[lib/account_update.ts:892](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L892)
 
 ___
 
@@ -570,7 +570,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1412](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1412)
+[lib/account_update.ts:1409](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1409)
 
 ## Methods
 
@@ -594,7 +594,7 @@ approves it.
 
 #### Defined in
 
-[lib/account_update.ts:872](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L872)
+[lib/account_update.ts:869](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L869)
 
 ___
 
@@ -608,7 +608,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1079](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1079)
+[lib/account_update.ts:1076](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1076)
 
 ___
 
@@ -622,7 +622,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1108](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1108)
+[lib/account_update.ts:1105](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1105)
 
 ___
 
@@ -650,7 +650,7 @@ be (can be) authorized by a signature.
 
 #### Defined in
 
-[lib/account_update.ts:982](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L982)
+[lib/account_update.ts:979](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L979)
 
 ___
 
@@ -672,7 +672,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:837](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L837)
+[lib/account_update.ts:834](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L834)
 
 ___
 
@@ -696,7 +696,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:988](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L988)
+[lib/account_update.ts:985](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L985)
 
 ___
 
@@ -710,7 +710,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1068](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1068)
+[lib/account_update.ts:1065](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1065)
 
 ___
 
@@ -727,7 +727,7 @@ default [AccountUpdate](AccountUpdate.md).
 
 #### Defined in
 
-[lib/account_update.ts:1447](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1447)
+[lib/account_update.ts:1441](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1441)
 
 ___
 
@@ -741,7 +741,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1096](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1096)
+[lib/account_update.ts:1093](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1093)
 
 ___
 
@@ -764,7 +764,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:726](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L726)
+[lib/account_update.ts:723](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L723)
 
 ___
 
@@ -794,7 +794,7 @@ Constrain a property to lie between lower and upper bounds.
 
 #### Defined in
 
-[lib/account_update.ts:923](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L923)
+[lib/account_update.ts:920](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L920)
 
 ___
 
@@ -823,7 +823,7 @@ Fix a property to a certain value.
 
 #### Defined in
 
-[lib/account_update.ts:950](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L950)
+[lib/account_update.ts:947](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L947)
 
 ___
 
@@ -846,7 +846,7 @@ Attach account update to the current transaction
 
 #### Defined in
 
-[lib/account_update.ts:1152](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1152)
+[lib/account_update.ts:1149](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1149)
 
 ___
 
@@ -868,7 +868,7 @@ Clones the [AccountUpdate](AccountUpdate.md).
 
 #### Defined in
 
-[lib/account_update.ts:707](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L707)
+[lib/account_update.ts:704](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L704)
 
 ___
 
@@ -895,7 +895,7 @@ becomes part of the proof.
 
 #### Defined in
 
-[lib/account_update.ts:1133](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1133)
+[lib/account_update.ts:1130](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1130)
 
 ___
 
@@ -930,7 +930,7 @@ be (can be) authorized by a signature.
 
 #### Defined in
 
-[lib/account_update.ts:1199](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1199)
+[lib/account_update.ts:1196](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1196)
 
 ▸ `Static` **createSigned**(`signer`, `tokenId?`): [`AccountUpdate`](AccountUpdate.md)
 
@@ -951,7 +951,7 @@ in favor of calling this function with a `PublicKey` as `signer`
 
 #### Defined in
 
-[lib/account_update.ts:1203](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1203)
+[lib/account_update.ts:1200](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1200)
 
 ___
 
@@ -972,7 +972,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1102](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1102)
+[lib/account_update.ts:1099](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1099)
 
 ___
 
@@ -993,7 +993,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1112](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1112)
+[lib/account_update.ts:1109](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1109)
 
 ___
 
@@ -1007,7 +1007,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1105](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1105)
+[lib/account_update.ts:1102](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1102)
 
 ___
 
@@ -1021,7 +1021,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1121](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1121)
+[lib/account_update.ts:1118](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1118)
 
 ___
 
@@ -1042,7 +1042,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1284](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1284)
+[lib/account_update.ts:1281](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1281)
 
 ___
 
@@ -1062,7 +1062,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1074](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1074)
+[lib/account_update.ts:1071](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1071)
 
 ___
 
@@ -1091,7 +1091,7 @@ they [AccountUpdate](AccountUpdate.md) for the account which pays the fee
 
 #### Defined in
 
-[lib/account_update.ts:1231](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1231)
+[lib/account_update.ts:1228](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1228)
 
 ▸ `Static` **fundNewAccount**(`feePayer`, `options?`): [`AccountUpdate`](AccountUpdate.md)
 
@@ -1117,7 +1117,7 @@ feePayerUpdate.send({ to: receiverAddress, amount: initialBalance });
 
 #### Defined in
 
-[lib/account_update.ts:1243](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1243)
+[lib/account_update.ts:1240](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1240)
 
 ___
 
@@ -1137,7 +1137,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1015](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1015)
+[lib/account_update.ts:1012](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1012)
 
 ___
 
@@ -1162,7 +1162,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1024](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1024)
+[lib/account_update.ts:1021](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1021)
 
 ___
 
@@ -1187,7 +1187,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1032](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1032)
+[lib/account_update.ts:1029](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1029)
 
 ___
 
@@ -1214,7 +1214,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:899](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L899)
+[lib/account_update.ts:896](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L896)
 
 ___
 
@@ -1235,7 +1235,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1006](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1006)
+[lib/account_update.ts:1003](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1003)
 
 ___
 
@@ -1255,7 +1255,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1264](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1264)
+[lib/account_update.ts:1261](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1261)
 
 ___
 
@@ -1275,7 +1275,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1071](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1071)
+[lib/account_update.ts:1068](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1068)
 
 ___
 
@@ -1297,7 +1297,7 @@ Disattach an account update from where it's currently located in the transaction
 
 #### Defined in
 
-[lib/account_update.ts:1172](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1172)
+[lib/account_update.ts:1169](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1169)
 
 ___
 
@@ -1331,7 +1331,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1292](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1292)
+[lib/account_update.ts:1289](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1289)
 
 ___
 
@@ -1354,7 +1354,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1308](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1308)
+[lib/account_update.ts:1305](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1305)
 
 ___
 
@@ -1392,4 +1392,4 @@ accountUpdate's children, which also get witnessed
 
 #### Defined in
 
-[lib/account_update.ts:1353](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1353)
+[lib/account_update.ts:1350](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1350)

--- a/docs/zkapps/o1js-reference/classes/Bool.md
+++ b/docs/zkapps/o1js-reference/classes/Bool.md
@@ -74,7 +74,7 @@ Use [[assertEquals]] to enforce the value of a Bool.
 
 #### Defined in
 
-[lib/bool.ts:36](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L36)
+[lib/bool.ts:36](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L36)
 
 ## Properties
 
@@ -84,7 +84,7 @@ Use [[assertEquals]] to enforce the value of a Bool.
 
 #### Defined in
 
-[lib/bool.ts:34](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L34)
+[lib/bool.ts:34](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L34)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[lib/bool.ts:325](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L325)
+[lib/bool.ts:325](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L325)
 
 ## Methods
 
@@ -123,7 +123,7 @@ this [Bool](Bool.md) and `y` are also true.
 
 #### Defined in
 
-[lib/bool.ts:74](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L74)
+[lib/bool.ts:74](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L74)
 
 ___
 
@@ -146,7 +146,7 @@ Proves that this [Bool](Bool.md) is equal to `y`.
 
 #### Defined in
 
-[lib/bool.ts:97](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L97)
+[lib/bool.ts:97](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L97)
 
 ___
 
@@ -168,7 +168,7 @@ Proves that this [Bool](Bool.md) is `false`.
 
 #### Defined in
 
-[lib/bool.ts:128](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L128)
+[lib/bool.ts:128](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L128)
 
 ___
 
@@ -190,7 +190,7 @@ Proves that this [Bool](Bool.md) is `true`.
 
 #### Defined in
 
-[lib/bool.ts:114](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L114)
+[lib/bool.ts:114](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L114)
 
 ___
 
@@ -212,7 +212,7 @@ Returns true if this [Bool](Bool.md) is equal to `y`.
 
 #### Defined in
 
-[lib/bool.ts:143](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L143)
+[lib/bool.ts:143](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L143)
 
 ___
 
@@ -226,7 +226,7 @@ this is Object
 
 #### Defined in
 
-[lib/bool.ts:48](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L48)
+[lib/bool.ts:48](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L48)
 
 ___
 
@@ -242,7 +242,7 @@ a new [Bool](Bool.md) that is the negation of this [Bool](Bool.md).
 
 #### Defined in
 
-[lib/bool.ts:62](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L62)
+[lib/bool.ts:62](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L62)
 
 ___
 
@@ -265,7 +265,7 @@ this [Bool](Bool.md) or `y` is true.
 
 #### Defined in
 
-[lib/bool.ts:86](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L86)
+[lib/bool.ts:86](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L86)
 
 ___
 
@@ -281,7 +281,7 @@ Returns the size of this type.
 
 #### Defined in
 
-[lib/bool.ts:153](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L153)
+[lib/bool.ts:153](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L153)
 
 ___
 
@@ -298,7 +298,7 @@ This can only be called on non-witness values.
 
 #### Defined in
 
-[lib/bool.ts:184](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L184)
+[lib/bool.ts:184](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L184)
 
 ___
 
@@ -314,7 +314,7 @@ Converts a [Bool](Bool.md) to a [Field](Field.md). `false` becomes 0 and `true` 
 
 #### Defined in
 
-[lib/bool.ts:55](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L55)
+[lib/bool.ts:55](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L55)
 
 ___
 
@@ -330,7 +330,7 @@ Serializes this [Bool](Bool.md) into [Field](Field.md) elements.
 
 #### Defined in
 
-[lib/bool.ts:160](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L160)
+[lib/bool.ts:160](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L160)
 
 ___
 
@@ -347,7 +347,7 @@ This operation does _not_ affect the circuit and can't be used to prove anything
 
 #### Defined in
 
-[lib/bool.ts:176](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L176)
+[lib/bool.ts:176](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L176)
 
 ___
 
@@ -364,7 +364,7 @@ This operation does _not_ affect the circuit and can't be used to prove anything
 
 #### Defined in
 
-[lib/bool.ts:168](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L168)
+[lib/bool.ts:168](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L168)
 
 ___
 
@@ -384,7 +384,7 @@ x is Bool
 
 #### Defined in
 
-[lib/bool.ts:344](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L344)
+[lib/bool.ts:344](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L344)
 
 ___
 
@@ -404,7 +404,7 @@ ___
 
 #### Defined in
 
-[lib/bool.ts:348](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L348)
+[lib/bool.ts:348](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L348)
 
 ___
 
@@ -427,7 +427,7 @@ Boolean AND operation.
 
 #### Defined in
 
-[lib/bool.ts:213](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L213)
+[lib/bool.ts:213](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L213)
 
 ___
 
@@ -450,7 +450,7 @@ Asserts if both [Bool](Bool.md) are equal.
 
 #### Defined in
 
-[lib/bool.ts:233](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L233)
+[lib/bool.ts:233](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L233)
 
 ___
 
@@ -470,7 +470,7 @@ ___
 
 #### Defined in
 
-[lib/bool.ts:321](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L321)
+[lib/bool.ts:321](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L321)
 
 ___
 
@@ -493,7 +493,7 @@ Checks two [Bool](Bool.md) for equality.
 
 #### Defined in
 
-[lib/bool.ts:244](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L244)
+[lib/bool.ts:244](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L244)
 
 ___
 
@@ -513,7 +513,7 @@ ___
 
 #### Defined in
 
-[lib/bool.ts:306](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L306)
+[lib/bool.ts:306](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L306)
 
 ___
 
@@ -535,7 +535,7 @@ Creates a data structure from an array of serialized [Field](Field.md) elements.
 
 #### Defined in
 
-[lib/bool.ts:268](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L268)
+[lib/bool.ts:268](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L268)
 
 ___
 
@@ -558,7 +558,7 @@ This operation does _not_ affect the circuit and can't be used to prove anything
 
 #### Defined in
 
-[lib/bool.ts:287](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L287)
+[lib/bool.ts:287](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L287)
 
 ___
 
@@ -580,7 +580,7 @@ Boolean negation.
 
 #### Defined in
 
-[lib/bool.ts:203](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L203)
+[lib/bool.ts:203](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L203)
 
 ___
 
@@ -603,7 +603,7 @@ Boolean OR operation.
 
 #### Defined in
 
-[lib/bool.ts:223](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L223)
+[lib/bool.ts:223](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L223)
 
 ___
 
@@ -630,7 +630,7 @@ ___
 
 #### Defined in
 
-[lib/bool.ts:310](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L310)
+[lib/bool.ts:310](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L310)
 
 ___
 
@@ -644,7 +644,7 @@ ___
 
 #### Defined in
 
-[lib/bool.ts:317](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L317)
+[lib/bool.ts:317](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L317)
 
 ___
 
@@ -660,7 +660,7 @@ Returns the size of this type.
 
 #### Defined in
 
-[lib/bool.ts:294](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L294)
+[lib/bool.ts:294](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L294)
 
 ___
 
@@ -682,7 +682,7 @@ Static method to serialize a [Bool](Bool.md) into its auxiliary data.
 
 #### Defined in
 
-[lib/bool.ts:261](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L261)
+[lib/bool.ts:261](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L261)
 
 ___
 
@@ -702,7 +702,7 @@ ___
 
 #### Defined in
 
-[lib/bool.ts:302](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L302)
+[lib/bool.ts:302](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L302)
 
 ___
 
@@ -722,7 +722,7 @@ ___
 
 #### Defined in
 
-[lib/bool.ts:196](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L196)
+[lib/bool.ts:196](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L196)
 
 ___
 
@@ -744,7 +744,7 @@ Static method to serialize a [Bool](Bool.md) into an array of [Field](Field.md) 
 
 #### Defined in
 
-[lib/bool.ts:254](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L254)
+[lib/bool.ts:254](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L254)
 
 ___
 
@@ -768,7 +768,7 @@ ___
 
 #### Defined in
 
-[lib/bool.ts:298](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L298)
+[lib/bool.ts:298](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L298)
 
 ___
 
@@ -791,4 +791,4 @@ This operation does _not_ affect the circuit and can't be used to prove anything
 
 #### Defined in
 
-[lib/bool.ts:279](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L279)
+[lib/bool.ts:279](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L279)

--- a/docs/zkapps/o1js-reference/classes/Character.md
+++ b/docs/zkapps/o1js-reference/classes/Character.md
@@ -63,7 +63,7 @@
 
 #### Defined in
 
-[lib/circuit_value.ts:72](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L72)
+[lib/circuit_value.ts:72](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L72)
 
 ## Properties
 
@@ -73,7 +73,7 @@
 
 #### Defined in
 
-[lib/string.ts:11](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/string.ts#L11)
+[lib/string.ts:11](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/string.ts#L11)
 
 ## Methods
 
@@ -97,7 +97,7 @@
 
 #### Defined in
 
-[lib/circuit_value.ts:160](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L160)
+[lib/circuit_value.ts:160](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L160)
 
 ___
 
@@ -121,7 +121,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:156](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L156)
+[lib/circuit_value.ts:156](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L156)
 
 ___
 
@@ -139,7 +139,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:164](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L164)
+[lib/circuit_value.ts:164](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L164)
 
 ___
 
@@ -153,7 +153,7 @@ ___
 
 #### Defined in
 
-[lib/string.ts:13](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/string.ts#L13)
+[lib/string.ts:13](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/string.ts#L13)
 
 ___
 
@@ -171,7 +171,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L152)
+[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L152)
 
 ___
 
@@ -185,7 +185,7 @@ ___
 
 #### Defined in
 
-[lib/string.ts:17](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/string.ts#L17)
+[lib/string.ts:17](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/string.ts#L17)
 
 ___
 
@@ -203,7 +203,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L144)
+[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L144)
 
 ___
 
@@ -221,7 +221,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L148)
+[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L148)
 
 ___
 
@@ -235,7 +235,7 @@ ___
 
 #### Defined in
 
-[lib/string.ts:21](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/string.ts#L21)
+[lib/string.ts:21](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/string.ts#L21)
 
 ___
 
@@ -259,7 +259,7 @@ ___
 
 #### Defined in
 
-[lib/string.ts:33](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/string.ts#L33)
+[lib/string.ts:33](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/string.ts#L33)
 
 ___
 
@@ -290,7 +290,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L168)
+[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L168)
 
 ___
 
@@ -321,7 +321,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:226](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L226)
+[lib/circuit_value.ts:226](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L226)
 
 ___
 
@@ -352,7 +352,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L89)
+[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L89)
 
 ___
 
@@ -372,7 +372,7 @@ ___
 
 #### Defined in
 
-[lib/string.ts:26](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/string.ts#L26)
+[lib/string.ts:26](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/string.ts#L26)
 
 ___
 
@@ -390,7 +390,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L96)
+[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L96)
 
 ___
 
@@ -408,7 +408,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L118)
+[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L118)
 
 ___
 
@@ -439,7 +439,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L207)
+[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L207)
 
 ___
 
@@ -470,7 +470,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L101)
+[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L101)
 
 ___
 
@@ -501,7 +501,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:122](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L122)
+[lib/circuit_value.ts:122](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L122)
 
 ___
 
@@ -532,4 +532,4 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:215](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L215)
+[lib/circuit_value.ts:215](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L215)

--- a/docs/zkapps/o1js-reference/classes/Circuit.md
+++ b/docs/zkapps/o1js-reference/classes/Circuit.md
@@ -45,7 +45,7 @@
 
 #### Defined in
 
-[lib/circuit.ts:14](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L14)
+[lib/circuit.ts:14](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L14)
 
 ___
 
@@ -80,7 +80,7 @@ use [Array](../modules.md#array)
 
 #### Defined in
 
-[lib/circuit.ts:110](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L110)
+[lib/circuit.ts:110](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L110)
 
 ___
 
@@ -108,7 +108,7 @@ use [asProver](../modules.md#asprover)
 
 #### Defined in
 
-[lib/circuit.ts:94](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L94)
+[lib/circuit.ts:94](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L94)
 
 ___
 
@@ -167,7 +167,7 @@ use [assertEqual](../modules.md#assertequal)
 
 #### Defined in
 
-[lib/circuit.ts:114](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L114)
+[lib/circuit.ts:114](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L114)
 
 ___
 
@@ -209,7 +209,7 @@ use [constraintSystem](../modules.md#constraintsystem)
 
 #### Defined in
 
-[lib/circuit.ts:106](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L106)
+[lib/circuit.ts:106](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L106)
 
 ___
 
@@ -268,7 +268,7 @@ use [equal](../modules.md#equal)
 
 #### Defined in
 
-[lib/circuit.ts:118](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L118)
+[lib/circuit.ts:118](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L118)
 
 ___
 
@@ -329,7 +329,7 @@ use [if](../modules.md#if)
 
 #### Defined in
 
-[lib/circuit.ts:122](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L122)
+[lib/circuit.ts:122](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L122)
 
 ___
 
@@ -351,7 +351,7 @@ use [inCheckedComputation](../modules.md#incheckedcomputation)
 
 #### Defined in
 
-[lib/circuit.ts:134](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L134)
+[lib/circuit.ts:134](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L134)
 
 ___
 
@@ -373,7 +373,7 @@ use [inProver](../modules.md#inprover)
 
 #### Defined in
 
-[lib/circuit.ts:130](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L130)
+[lib/circuit.ts:130](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L130)
 
 ___
 
@@ -401,7 +401,7 @@ use [log](../modules.md#log)
 
 #### Defined in
 
-[lib/circuit.ts:138](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L138)
+[lib/circuit.ts:138](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L138)
 
 ___
 
@@ -429,7 +429,7 @@ use [runAndCheck](../modules.md#runandcheck)
 
 #### Defined in
 
-[lib/circuit.ts:98](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L98)
+[lib/circuit.ts:98](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L98)
 
 ___
 
@@ -457,7 +457,7 @@ use [runUnchecked](../modules.md#rununchecked)
 
 #### Defined in
 
-[lib/circuit.ts:102](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L102)
+[lib/circuit.ts:102](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L102)
 
 ___
 
@@ -494,7 +494,7 @@ use [switch](../modules.md#switch)
 
 #### Defined in
 
-[lib/circuit.ts:126](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L126)
+[lib/circuit.ts:126](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L126)
 
 ___
 
@@ -530,7 +530,7 @@ use [witness](../modules.md#witness)
 
 #### Defined in
 
-[lib/circuit.ts:90](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L90)
+[lib/circuit.ts:90](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L90)
 
 ## Methods
 
@@ -552,7 +552,7 @@ const keypair = await MyCircuit.generateKeypair();
 
 #### Defined in
 
-[lib/circuit.ts:23](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L23)
+[lib/circuit.ts:23](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L23)
 
 ___
 
@@ -583,7 +583,7 @@ const proof = await MyCircuit.prove(privateInput, publicInput, keypair);
 
 #### Defined in
 
-[lib/circuit.ts:42](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L42)
+[lib/circuit.ts:42](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L42)
 
 ___
 
@@ -615,4 +615,4 @@ const isValid = await MyCircuit.verify(publicInput, keypair.vk, proof);
 
 #### Defined in
 
-[lib/circuit.ts:68](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L68)
+[lib/circuit.ts:68](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L68)

--- a/docs/zkapps/o1js-reference/classes/CircuitString.md
+++ b/docs/zkapps/o1js-reference/classes/CircuitString.md
@@ -70,7 +70,7 @@
 
 #### Defined in
 
-[lib/string.ts:45](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/string.ts#L45)
+[lib/string.ts:45](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/string.ts#L45)
 
 ## Properties
 
@@ -80,7 +80,7 @@
 
 #### Defined in
 
-[lib/string.ts:40](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/string.ts#L40)
+[lib/string.ts:40](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/string.ts#L40)
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 #### Defined in
 
-[lib/string.ts:39](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/string.ts#L39)
+[lib/string.ts:39](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/string.ts#L39)
 
 ## Methods
 
@@ -113,7 +113,7 @@ within the `maxLength` of this string (the other string can have a different max
 
 #### Defined in
 
-[lib/string.ts:88](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/string.ts#L88)
+[lib/string.ts:88](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/string.ts#L88)
 
 ___
 
@@ -137,7 +137,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:160](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L160)
+[lib/circuit_value.ts:160](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L160)
 
 ___
 
@@ -156,7 +156,7 @@ ___
 
 #### Defined in
 
-[lib/string.ts:58](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/string.ts#L58)
+[lib/string.ts:58](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/string.ts#L58)
 
 ___
 
@@ -180,7 +180,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:156](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L156)
+[lib/circuit_value.ts:156](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L156)
 
 ___
 
@@ -196,7 +196,7 @@ returns true if `str` is found in this `CircuitString`
 
 #### Defined in
 
-[lib/string.ts:124](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/string.ts#L124)
+[lib/string.ts:124](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/string.ts#L124)
 
 ___
 
@@ -214,7 +214,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:164](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L164)
+[lib/circuit_value.ts:164](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L164)
 
 ___
 
@@ -228,7 +228,7 @@ ___
 
 #### Defined in
 
-[lib/string.ts:80](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/string.ts#L80)
+[lib/string.ts:80](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/string.ts#L80)
 
 ___
 
@@ -242,7 +242,7 @@ ___
 
 #### Defined in
 
-[lib/string.ts:77](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/string.ts#L77)
+[lib/string.ts:77](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/string.ts#L77)
 
 ___
 
@@ -256,7 +256,7 @@ ___
 
 #### Defined in
 
-[lib/string.ts:53](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/string.ts#L53)
+[lib/string.ts:53](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/string.ts#L53)
 
 ___
 
@@ -277,7 +277,7 @@ ___
 
 #### Defined in
 
-[lib/string.ts:128](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/string.ts#L128)
+[lib/string.ts:128](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/string.ts#L128)
 
 ___
 
@@ -295,7 +295,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L152)
+[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L152)
 
 ___
 
@@ -313,7 +313,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L144)
+[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L144)
 
 ___
 
@@ -331,7 +331,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L148)
+[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L148)
 
 ___
 
@@ -345,7 +345,7 @@ ___
 
 #### Defined in
 
-[lib/string.ts:132](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/string.ts#L132)
+[lib/string.ts:132](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/string.ts#L132)
 
 ___
 
@@ -376,7 +376,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:193](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L193)
+[lib/circuit_value.ts:193](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L193)
 
 ___
 
@@ -396,7 +396,7 @@ ___
 
 #### Defined in
 
-[lib/string.ts:49](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/string.ts#L49)
+[lib/string.ts:49](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/string.ts#L49)
 
 ___
 
@@ -427,7 +427,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L168)
+[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L168)
 
 ___
 
@@ -458,7 +458,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:226](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L226)
+[lib/circuit_value.ts:226](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L226)
 
 ___
 
@@ -489,7 +489,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L89)
+[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L89)
 
 ___
 
@@ -509,7 +509,7 @@ ___
 
 #### Defined in
 
-[lib/string.ts:139](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/string.ts#L139)
+[lib/string.ts:139](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/string.ts#L139)
 
 ___
 
@@ -527,7 +527,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L96)
+[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L96)
 
 ___
 
@@ -545,7 +545,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L118)
+[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L118)
 
 ___
 
@@ -576,7 +576,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L207)
+[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L207)
 
 ___
 
@@ -607,7 +607,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L101)
+[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L101)
 
 ___
 
@@ -638,7 +638,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:122](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L122)
+[lib/circuit_value.ts:122](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L122)
 
 ___
 
@@ -669,4 +669,4 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:215](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L215)
+[lib/circuit_value.ts:215](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L215)

--- a/docs/zkapps/o1js-reference/classes/CircuitValue.md
+++ b/docs/zkapps/o1js-reference/classes/CircuitValue.md
@@ -69,7 +69,7 @@
 
 #### Defined in
 
-[lib/circuit_value.ts:72](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L72)
+[lib/circuit_value.ts:72](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L72)
 
 ## Methods
 
@@ -89,7 +89,7 @@
 
 #### Defined in
 
-[lib/circuit_value.ts:160](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L160)
+[lib/circuit_value.ts:160](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L160)
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:156](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L156)
+[lib/circuit_value.ts:156](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L156)
 
 ___
 
@@ -123,7 +123,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:164](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L164)
+[lib/circuit_value.ts:164](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L164)
 
 ___
 
@@ -137,7 +137,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L152)
+[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L152)
 
 ___
 
@@ -151,7 +151,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L144)
+[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L144)
 
 ___
 
@@ -165,7 +165,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L148)
+[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L148)
 
 ___
 
@@ -192,7 +192,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:193](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L193)
+[lib/circuit_value.ts:193](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L193)
 
 ___
 
@@ -219,7 +219,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L168)
+[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L168)
 
 ___
 
@@ -246,7 +246,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:226](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L226)
+[lib/circuit_value.ts:226](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L226)
 
 ___
 
@@ -273,7 +273,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L89)
+[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L89)
 
 ___
 
@@ -287,7 +287,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L96)
+[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L96)
 
 ___
 
@@ -301,7 +301,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L118)
+[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L118)
 
 ___
 
@@ -328,7 +328,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L207)
+[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L207)
 
 ___
 
@@ -355,7 +355,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L101)
+[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L101)
 
 ___
 
@@ -382,7 +382,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:122](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L122)
+[lib/circuit_value.ts:122](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L122)
 
 ___
 
@@ -409,4 +409,4 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:215](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L215)
+[lib/circuit_value.ts:215](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L215)

--- a/docs/zkapps/o1js-reference/classes/Field.md
+++ b/docs/zkapps/o1js-reference/classes/Field.md
@@ -97,6 +97,7 @@ the value to convert to a [Field](Field.md)
 - [fromJSON](Field.md#fromjson)
 - [random](Field.md#random)
 - [readBytes](Field.md#readbytes)
+- [sizeInBits](Field.md#sizeinbits)
 - [sizeInBytes](Field.md#sizeinbytes)
 - [sizeInFields](Field.md#sizeinfields)
 - [toAuxiliary](Field.md#toauxiliary-1)
@@ -117,11 +118,11 @@ Coerce anything "field-like" (bigint, number, string, and [Field](Field.md)) to 
 
 | Name | Type |
 | :------ | :------ |
-| `x` | `string` \| `number` \| `bigint` \| `Uint8Array` \| [`FieldVar`](../modules.md#fieldvar-1) \| [`Field`](Field.md) |
+| `x` | `string` \| `number` \| `bigint` \| [`FieldVar`](../modules.md#fieldvar-1) \| [`FieldConst`](../modules.md#fieldconst-1) \| [`Field`](Field.md) |
 
 #### Defined in
 
-[lib/field.ts:143](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L143)
+[lib/field.ts:141](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L141)
 
 ## Properties
 
@@ -131,7 +132,7 @@ Coerce anything "field-like" (bigint, number, string, and [Field](Field.md)) to 
 
 #### Defined in
 
-[lib/field.ts:132](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L132)
+[lib/field.ts:130](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L130)
 
 ___
 
@@ -144,7 +145,7 @@ Order of the [Field](Field.md) is 2894802230932904885589274625217197696336305648
 
 #### Defined in
 
-[lib/field.ts:138](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L138)
+[lib/field.ts:136](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L136)
 
 ## Methods
 
@@ -169,7 +170,7 @@ Order of the [Field](Field.md) is 2894802230932904885589274625217197696336305648
 
 #### Defined in
 
-[lib/field.ts:656](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L656)
+[lib/field.ts:651](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L651)
 
 ___
 
@@ -189,7 +190,7 @@ ___
 
 #### Defined in
 
-[lib/field.ts:203](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L203)
+[lib/field.ts:202](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L202)
 
 ___
 
@@ -237,7 +238,7 @@ A [Field](Field.md) element equivalent to the modular addition of the two value.
 
 #### Defined in
 
-[lib/field.ts:311](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L311)
+[lib/field.ts:310](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L310)
 
 ___
 
@@ -262,7 +263,7 @@ Calling this function is equivalent to `Bool.or(Field(...).equals(1), Field(...)
 
 #### Defined in
 
-[lib/field.ts:920](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L920)
+[lib/field.ts:910](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L910)
 
 ___
 
@@ -289,7 +290,7 @@ See [equals](Field.md#equals) for more details.
 
 #### Defined in
 
-[lib/field.ts:269](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L269)
+[lib/field.ts:268](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L268)
 
 ___
 
@@ -319,7 +320,7 @@ The method will throw if one of the inputs exceeds 253 bits.
 
 #### Defined in
 
-[lib/field.ts:861](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L861)
+[lib/field.ts:851](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L851)
 
 ___
 
@@ -349,7 +350,7 @@ The method will throw if one of the inputs exceeds 253 bits.
 
 #### Defined in
 
-[lib/field.ts:878](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L878)
+[lib/field.ts:868](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L868)
 
 ___
 
@@ -379,7 +380,7 @@ The method will throw if one of the inputs exceeds 253 bits.
 
 #### Defined in
 
-[lib/field.ts:805](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L805)
+[lib/field.ts:795](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L795)
 
 ___
 
@@ -409,7 +410,7 @@ The method will throw if one of the inputs exceeds 253 bits.
 
 #### Defined in
 
-[lib/field.ts:833](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L833)
+[lib/field.ts:823](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L823)
 
 ___
 
@@ -440,7 +441,7 @@ x.assertNotEquals(0, "expect x to be non-zero");
 
 #### Defined in
 
-[lib/field.ts:895](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L895)
+[lib/field.ts:885](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L885)
 
 ___
 
@@ -491,7 +492,7 @@ A [Field](Field.md) element equivalent to the modular division of the two value.
 
 #### Defined in
 
-[lib/field.ts:524](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L524)
+[lib/field.ts:523](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L523)
 
 ___
 
@@ -522,7 +523,7 @@ A [Bool](Bool.md) representing if this [Field](Field.md) is equal another "field
 
 #### Defined in
 
-[lib/field.ts:636](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L636)
+[lib/field.ts:636](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L636)
 
 ___
 
@@ -564,7 +565,7 @@ A [Bool](Bool.md) representing if this [Field](Field.md) is greater than another
 
 #### Defined in
 
-[lib/field.ts:759](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L759)
+[lib/field.ts:751](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L751)
 
 ___
 
@@ -606,7 +607,7 @@ A [Bool](Bool.md) representing if this [Field](Field.md) is greater than or equa
 
 #### Defined in
 
-[lib/field.ts:787](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L787)
+[lib/field.ts:778](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L778)
 
 ___
 
@@ -637,7 +638,7 @@ A [Field](Field.md) element that is equivalent to one divided by this element.
 
 #### Defined in
 
-[lib/field.ts:476](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L476)
+[lib/field.ts:475](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L475)
 
 ___
 
@@ -670,7 +671,7 @@ A `boolean` showing if this [Field](Field.md) is a constant or not.
 
 #### Defined in
 
-[lib/field.ts:199](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L199)
+[lib/field.ts:198](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L198)
 
 ___
 
@@ -698,7 +699,7 @@ b.isEven().assertTrue(); // does not throw, as expected!
 
 #### Defined in
 
-[lib/field.ts:393](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L393)
+[lib/field.ts:392](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L392)
 
 ___
 
@@ -716,7 +717,7 @@ use `x.equals(0)` which is equivalent
 
 #### Defined in
 
-[lib/field.ts:596](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L596)
+[lib/field.ts:596](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L596)
 
 ___
 
@@ -758,7 +759,7 @@ A [Bool](Bool.md) representing if this [Field](Field.md) is less than another "f
 
 #### Defined in
 
-[lib/field.ts:699](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L699)
+[lib/field.ts:691](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L691)
 
 ___
 
@@ -800,7 +801,7 @@ A [Bool](Bool.md) representing if this [Field](Field.md) is less than or equal a
 
 #### Defined in
 
-[lib/field.ts:729](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L729)
+[lib/field.ts:721](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L721)
 
 ___
 
@@ -833,7 +834,7 @@ A [Field](Field.md) element equivalent to the modular difference of the two valu
 
 #### Defined in
 
-[lib/field.ts:437](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L437)
+[lib/field.ts:436](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L436)
 
 ___
 
@@ -867,7 +868,7 @@ A [Field](Field.md) element that is equivalent to the element multiplied by -1.
 
 #### Defined in
 
-[lib/field.ts:339](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L339)
+[lib/field.ts:338](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L338)
 
 ___
 
@@ -896,7 +897,7 @@ A [Field](Field.md) element that is equal to the `length` of this [Field](Field.
 
 #### Defined in
 
-[lib/field.ts:1012](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1012)
+[lib/field.ts:1002](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1002)
 
 ___
 
@@ -920,7 +921,7 @@ A [Field](Field.md) element that is equal to the result of AST that was previous
 
 #### Defined in
 
-[lib/field.ts:1040](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1040)
+[lib/field.ts:1030](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1030)
 
 ___
 
@@ -951,7 +952,7 @@ A [Field](Field.md) element equivalent to the square root of the [Field](Field.m
 
 #### Defined in
 
-[lib/field.ts:574](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L574)
+[lib/field.ts:574](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L574)
 
 ___
 
@@ -980,7 +981,7 @@ A [Field](Field.md) element equivalent to the multiplication of the [Field](Fiel
 
 #### Defined in
 
-[lib/field.ts:544](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L544)
+[lib/field.ts:544](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L544)
 
 ___
 
@@ -1026,7 +1027,7 @@ A [Field](Field.md) element equivalent to the modular difference of the two valu
 
 #### Defined in
 
-[lib/field.ts:375](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L375)
+[lib/field.ts:374](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L374)
 
 ___
 
@@ -1044,7 +1045,7 @@ As the primitive [Field](Field.md) type has no auxiliary data associated with it
 
 #### Defined in
 
-[lib/field.ts:1148](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1148)
+[lib/field.ts:1136](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1136)
 
 ___
 
@@ -1071,7 +1072,7 @@ A bigint equivalent to the bigint representation of the Field.
 
 #### Defined in
 
-[lib/field.ts:237](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L237)
+[lib/field.ts:236](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L236)
 
 ___
 
@@ -1101,7 +1102,7 @@ An array of [Bool](Bool.md) element representing little endian binary representa
 
 #### Defined in
 
-[lib/field.ts:957](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L957)
+[lib/field.ts:947](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L947)
 
 ___
 
@@ -1128,7 +1129,7 @@ A constant [Field](Field.md) element equivalent to this [Field](Field.md) elemen
 
 #### Defined in
 
-[lib/field.ts:220](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L220)
+[lib/field.ts:219](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L219)
 
 ___
 
@@ -1148,7 +1149,7 @@ A [Field](Field.md) array of length 1 created from this [Field](Field.md).
 
 #### Defined in
 
-[lib/field.ts:1139](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1139)
+[lib/field.ts:1127](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1127)
 
 ___
 
@@ -1175,7 +1176,7 @@ A string equivalent to the JSON representation of the [Field](Field.md).
 
 #### Defined in
 
-[lib/field.ts:1167](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1167)
+[lib/field.ts:1155](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1155)
 
 ___
 
@@ -1202,7 +1203,7 @@ A string equivalent to the string representation of the Field.
 
 #### Defined in
 
-[lib/field.ts:255](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L255)
+[lib/field.ts:254](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L254)
 
 ___
 
@@ -1223,7 +1224,7 @@ ___
 
 #### Defined in
 
-[lib/field.ts:935](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L935)
+[lib/field.ts:925](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L925)
 
 ___
 
@@ -1235,7 +1236,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `x` | `string` \| `number` \| `bigint` \| `Uint8Array` \| [`FieldVar`](../modules.md#fieldvar-1) \| [`Field`](Field.md) |
+| `x` | `string` \| `number` \| `bigint` \| [`FieldVar`](../modules.md#fieldvar-1) \| [`FieldConst`](../modules.md#fieldconst-1) \| [`Field`](Field.md) |
 
 #### Returns
 
@@ -1243,13 +1244,13 @@ x is Field
 
 #### Defined in
 
-[lib/field.ts:163](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L163)
+[lib/field.ts:162](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L162)
 
 ___
 
 ### #toConst
 
-▸ `Static` `Private` **#toConst**(`x`): `Uint8Array`
+▸ `Static` `Private` **#toConst**(`x`): [`FieldConst`](../modules.md#fieldconst-1)
 
 #### Parameters
 
@@ -1259,11 +1260,11 @@ ___
 
 #### Returns
 
-`Uint8Array`
+[`FieldConst`](../modules.md#fieldconst-1)
 
 #### Defined in
 
-[lib/field.ts:168](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L168)
+[lib/field.ts:167](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L167)
 
 ___
 
@@ -1283,7 +1284,7 @@ ___
 
 #### Defined in
 
-[lib/field.ts:172](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L172)
+[lib/field.ts:171](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L171)
 
 ___
 
@@ -1301,7 +1302,7 @@ As any field element can be a [Field](Field.md), this function does not create a
 
 #### Defined in
 
-[lib/field.ts:1130](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1130)
+[lib/field.ts:1118](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1118)
 
 ___
 
@@ -1321,7 +1322,7 @@ ___
 
 #### Defined in
 
-[lib/field.ts:176](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L176)
+[lib/field.ts:175](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L175)
 
 ___
 
@@ -1349,7 +1350,7 @@ A [Field](Field.md) element matching the [little endian binary representation](h
 
 #### Defined in
 
-[lib/field.ts:983](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L983)
+[lib/field.ts:973](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L973)
 
 ___
 
@@ -1376,7 +1377,7 @@ A new [Field](Field.md) element created using the [little-endian](https://en.wik
 
 #### Defined in
 
-[lib/field.ts:1254](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1254)
+[lib/field.ts:1242](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1242)
 
 ___
 
@@ -1404,7 +1405,7 @@ The first [Field](Field.md) element of the given array.
 
 #### Defined in
 
-[lib/field.ts:1119](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1119)
+[lib/field.ts:1107](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1107)
 
 ___
 
@@ -1430,7 +1431,7 @@ A [Field](Field.md) coerced from the given JSON string.
 
 #### Defined in
 
-[lib/field.ts:1199](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1199)
+[lib/field.ts:1187](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1187)
 
 ___
 
@@ -1454,7 +1455,7 @@ A random [Field](Field.md) element.
 
 #### Defined in
 
-[lib/field.ts:1058](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1058)
+[lib/field.ts:1046](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1046)
 
 ___
 
@@ -1485,7 +1486,27 @@ Part of the `Binable` interface.
 
 #### Defined in
 
-[lib/field.ts:1237](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1237)
+[lib/field.ts:1225](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1225)
+
+___
+
+### sizeInBits
+
+▸ `Static` **sizeInBits**(): `number`
+
+**Warning**: This function is mainly for internal use. Normally it is not intended to be used by a zkApp developer.
+
+As all [Field](Field.md) elements have 255 bits, this function returns 255.
+
+#### Returns
+
+`number`
+
+The size of a [Field](Field.md) element in bits - 255.
+
+#### Defined in
+
+[lib/field.ts:1264](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1264)
 
 ___
 
@@ -1495,17 +1516,17 @@ ___
 
 **Warning**: This function is mainly for internal use. Normally it is not intended to be used by a zkApp developer.
 
-As all [Field](Field.md) elements have 31 bits, this function returns 31.
+As all [Field](Field.md) elements have 32 bytes, this function returns 32.
 
 #### Returns
 
 `number`
 
-The size of a [Field](Field.md) element - 31.
+The size of a [Field](Field.md) element - 32.
 
 #### Defined in
 
-[lib/field.ts:1265](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1265)
+[lib/field.ts:1253](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1253)
 
 ___
 
@@ -1532,7 +1553,7 @@ A number representing the size of the [Field](Field.md) type in terms of [Field]
 
 #### Defined in
 
-[lib/field.ts:1104](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1104)
+[lib/field.ts:1092](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1092)
 
 ___
 
@@ -1550,7 +1571,7 @@ As the primitive [Field](Field.md) type has no auxiliary data associated with it
 
 #### Defined in
 
-[lib/field.ts:1087](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1087)
+[lib/field.ts:1075](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1075)
 
 ___
 
@@ -1575,7 +1596,7 @@ An array of digits equal to the [little-endian](https://en.wikipedia.org/wiki/En
 
 #### Defined in
 
-[lib/field.ts:1228](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1228)
+[lib/field.ts:1216](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1216)
 
 ___
 
@@ -1602,7 +1623,7 @@ A [Field](Field.md) array of length 1 created from this [Field](Field.md).
 
 #### Defined in
 
-[lib/field.ts:1076](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1076)
+[lib/field.ts:1064](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1064)
 
 ___
 
@@ -1632,7 +1653,7 @@ An object where the `fields` key is a [Field](Field.md) array of length 1 create
 
 #### Defined in
 
-[lib/field.ts:1213](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1213)
+[lib/field.ts:1201](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1201)
 
 ___
 
@@ -1665,4 +1686,4 @@ A string equivalent to the JSON representation of the given [Field](Field.md).
 
 #### Defined in
 
-[lib/field.ts:1186](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1186)
+[lib/field.ts:1174](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1174)

--- a/docs/zkapps/o1js-reference/classes/Group.md
+++ b/docs/zkapps/o1js-reference/classes/Group.md
@@ -69,7 +69,7 @@ Coerces anything group-like to a [Group](Group.md).
 
 #### Defined in
 
-[lib/group.ts:47](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L47)
+[lib/group.ts:44](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L44)
 
 ## Properties
 
@@ -79,7 +79,7 @@ Coerces anything group-like to a [Group](Group.md).
 
 #### Defined in
 
-[lib/group.ts:15](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L15)
+[lib/group.ts:15](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L15)
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 #### Defined in
 
-[lib/group.ts:16](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L16)
+[lib/group.ts:16](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L16)
 
 ## Accessors
 
@@ -105,7 +105,7 @@ The generator `g` of the Group.
 
 #### Defined in
 
-[lib/group.ts:21](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L21)
+[lib/group.ts:21](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L21)
 
 ___
 
@@ -130,7 +130,7 @@ g.add(zero).assertEquals(g);
 
 #### Defined in
 
-[lib/group.ts:37](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L37)
+[lib/group.ts:37](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L37)
 
 ## Methods
 
@@ -144,7 +144,7 @@ g.add(zero).assertEquals(g);
 
 #### Defined in
 
-[lib/group.ts:99](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L99)
+[lib/group.ts:96](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L96)
 
 ___
 
@@ -164,7 +164,7 @@ ___
 
 #### Defined in
 
-[lib/group.ts:103](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L103)
+[lib/group.ts:100](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L100)
 
 ___
 
@@ -178,7 +178,7 @@ ___
 
 #### Defined in
 
-[lib/group.ts:95](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L95)
+[lib/group.ts:92](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L92)
 
 ___
 
@@ -205,7 +205,7 @@ let g2 = g1.add(g1)
 
 #### Defined in
 
-[lib/group.ts:127](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L127)
+[lib/group.ts:124](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L124)
 
 ___
 
@@ -233,7 +233,7 @@ g1.assertEquals(g2);
 
 #### Defined in
 
-[lib/group.ts:261](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L261)
+[lib/group.ts:246](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L246)
 
 ___
 
@@ -260,7 +260,7 @@ g1.equals(g1); // Bool(true)
 
 #### Defined in
 
-[lib/group.ts:277](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L277)
+[lib/group.ts:262](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L262)
 
 ___
 
@@ -276,7 +276,7 @@ Checks if this element is the `zero` element `{x: 0, y: 0}`.
 
 #### Defined in
 
-[lib/group.ts:114](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L114)
+[lib/group.ts:111](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L111)
 
 ___
 
@@ -292,7 +292,7 @@ Negates this [Group](Group.md). Under the hood, it simply negates the `y` coordi
 
 #### Defined in
 
-[lib/group.ts:225](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L225)
+[lib/group.ts:210](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L210)
 
 ___
 
@@ -319,7 +319,7 @@ let 5g = g.scale(s);
 
 #### Defined in
 
-[lib/group.ts:239](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L239)
+[lib/group.ts:224](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L224)
 
 ___
 
@@ -341,7 +341,7 @@ Subtracts another [Group](Group.md) element from this one.
 
 #### Defined in
 
-[lib/group.ts:218](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L218)
+[lib/group.ts:203](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L203)
 
 ___
 
@@ -359,7 +359,7 @@ Returns an array containing this [Group](Group.md) element as an array of [Field
 
 #### Defined in
 
-[lib/group.ts:304](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L304)
+[lib/group.ts:289](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L289)
 
 ___
 
@@ -382,7 +382,7 @@ This operation does NOT affect the circuit and can't be used to prove anything a
 
 #### Defined in
 
-[lib/group.ts:289](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L289)
+[lib/group.ts:274](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L274)
 
 ___
 
@@ -405,7 +405,7 @@ ___
 
 #### Defined in
 
-[lib/group.ts:79](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L79)
+[lib/group.ts:76](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L76)
 
 ___
 
@@ -428,7 +428,7 @@ ___
 
 #### Defined in
 
-[lib/group.ts:91](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L91)
+[lib/group.ts:88](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L88)
 
 ___
 
@@ -455,7 +455,7 @@ Adds a [Group](Group.md) element to another one.
 
 #### Defined in
 
-[lib/group.ts:323](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L323)
+[lib/group.ts:308](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L308)
 
 ___
 
@@ -487,7 +487,7 @@ Group.assertEquals(g1, g2);
 
 #### Defined in
 
-[lib/group.ts:373](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L373)
+[lib/group.ts:358](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L358)
 
 ___
 
@@ -509,7 +509,7 @@ Checks that a [Group](Group.md) element is constraint properly by checking that 
 
 #### Defined in
 
-[lib/group.ts:454](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L454)
+[lib/group.ts:439](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L439)
 
 ___
 
@@ -541,7 +541,7 @@ Group.equal(g1, g2); // Bool(true)
 
 #### Defined in
 
-[lib/group.ts:387](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L387)
+[lib/group.ts:372](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L372)
 
 ___
 
@@ -564,7 +564,7 @@ Coerces two x and y coordinates into a [Group](Group.md) element.
 
 #### Defined in
 
-[lib/group.ts:311](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L311)
+[lib/group.ts:296](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L296)
 
 ___
 
@@ -588,7 +588,7 @@ Deserializes a [Group](Group.md) element from a list of field elements.
 
 #### Defined in
 
-[lib/group.ts:414](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L414)
+[lib/group.ts:399](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L399)
 
 ___
 
@@ -614,7 +614,7 @@ This operation does NOT affect the circuit and can't be used to prove anything a
 
 #### Defined in
 
-[lib/group.ts:441](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L441)
+[lib/group.ts:426](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L426)
 
 ___
 
@@ -644,7 +644,7 @@ let gNeg = Group.neg(g);
 
 #### Defined in
 
-[lib/group.ts:345](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L345)
+[lib/group.ts:330](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L330)
 
 ___
 
@@ -676,7 +676,7 @@ let 5g = Group.scale(g, s);
 
 #### Defined in
 
-[lib/group.ts:359](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L359)
+[lib/group.ts:344](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L344)
 
 ___
 
@@ -694,7 +694,7 @@ Returns 2.
 
 #### Defined in
 
-[lib/group.ts:423](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L423)
+[lib/group.ts:408](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L408)
 
 ___
 
@@ -721,7 +721,7 @@ Subtracts a [Group](Group.md) element from another one.
 
 #### Defined in
 
-[lib/group.ts:332](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L332)
+[lib/group.ts:317](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L317)
 
 ___
 
@@ -745,7 +745,7 @@ Returns an empty array.
 
 #### Defined in
 
-[lib/group.ts:405](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L405)
+[lib/group.ts:390](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L390)
 
 ___
 
@@ -769,7 +769,7 @@ Returns an array containing a [Group](Group.md) element as an array of [Field](F
 
 #### Defined in
 
-[lib/group.ts:396](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L396)
+[lib/group.ts:381](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L381)
 
 ___
 
@@ -798,4 +798,4 @@ This operation does NOT affect the circuit and can't be used to prove anything a
 
 #### Defined in
 
-[lib/group.ts:432](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/group.ts#L432)
+[lib/group.ts:417](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/group.ts#L417)

--- a/docs/zkapps/o1js-reference/classes/Int64.md
+++ b/docs/zkapps/o1js-reference/classes/Int64.md
@@ -82,7 +82,7 @@ A 64 bit signed integer with values ranging from -18,446,744,073,709,551,615 to 
 
 #### Defined in
 
-[lib/int.ts:785](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L785)
+[lib/int.ts:788](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L788)
 
 ## Properties
 
@@ -96,7 +96,7 @@ BalanceChange.magnitude
 
 #### Defined in
 
-[lib/int.ts:762](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L762)
+[lib/int.ts:765](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L765)
 
 ___
 
@@ -110,7 +110,7 @@ BalanceChange.sgn
 
 #### Defined in
 
-[lib/int.ts:763](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L763)
+[lib/int.ts:766](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L766)
 
 ## Accessors
 
@@ -126,7 +126,7 @@ Static method to create a [Int64](Int64.md) with value `-1`.
 
 #### Defined in
 
-[lib/int.ts:860](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L860)
+[lib/int.ts:863](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L863)
 
 ___
 
@@ -142,7 +142,7 @@ Static method to create a [Int64](Int64.md) with value `1`.
 
 #### Defined in
 
-[lib/int.ts:854](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L854)
+[lib/int.ts:857](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L857)
 
 ___
 
@@ -158,7 +158,7 @@ Static method to create a [Int64](Int64.md) with value `0`.
 
 #### Defined in
 
-[lib/int.ts:848](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L848)
+[lib/int.ts:851](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L851)
 
 ## Methods
 
@@ -180,7 +180,7 @@ Addition with overflow checking.
 
 #### Defined in
 
-[lib/int.ts:894](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L894)
+[lib/int.ts:897](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L897)
 
 ___
 
@@ -207,7 +207,7 @@ Asserts that two values are equal.
 
 #### Defined in
 
-[lib/int.ts:948](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L948)
+[lib/int.ts:951](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L951)
 
 ___
 
@@ -232,7 +232,7 @@ Integer division.
 
 #### Defined in
 
-[lib/int.ts:919](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L919)
+[lib/int.ts:922](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L922)
 
 ___
 
@@ -258,7 +258,7 @@ Checks if two values are equal.
 
 #### Defined in
 
-[lib/int.ts:941](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L941)
+[lib/int.ts:944](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L944)
 
 ___
 
@@ -276,7 +276,7 @@ ___
 
 #### Defined in
 
-[lib/int.ts:837](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L837)
+[lib/int.ts:840](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L840)
 
 ___
 
@@ -292,7 +292,7 @@ Checks if the value is postive.
 
 #### Defined in
 
-[lib/int.ts:958](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L958)
+[lib/int.ts:961](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L961)
 
 ___
 
@@ -317,7 +317,7 @@ Integer remainder.
 
 #### Defined in
 
-[lib/int.ts:931](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L931)
+[lib/int.ts:934](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L934)
 
 ___
 
@@ -339,7 +339,7 @@ Multiplication with overflow checking.
 
 #### Defined in
 
-[lib/int.ts:908](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L908)
+[lib/int.ts:911](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L911)
 
 ___
 
@@ -357,7 +357,7 @@ Negates the value.
 
 #### Defined in
 
-[lib/int.ts:887](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L887)
+[lib/int.ts:890](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L890)
 
 ___
 
@@ -379,7 +379,7 @@ Subtraction with underflow checking.
 
 #### Defined in
 
-[lib/int.ts:901](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L901)
+[lib/int.ts:904](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L904)
 
 ___
 
@@ -397,7 +397,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L152)
+[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L152)
 
 ___
 
@@ -413,7 +413,7 @@ Returns the [Field](../modules.md#field-1) value.
 
 #### Defined in
 
-[lib/int.ts:867](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L867)
+[lib/int.ts:870](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L870)
 
 ___
 
@@ -431,7 +431,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L144)
+[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L144)
 
 ___
 
@@ -449,7 +449,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L148)
+[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L148)
 
 ___
 
@@ -465,7 +465,7 @@ Turns the [Int64](Int64.md) into a string.
 
 #### Defined in
 
-[lib/int.ts:832](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L832)
+[lib/int.ts:835](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L835)
 
 ___
 
@@ -496,7 +496,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:193](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L193)
+[lib/circuit_value.ts:193](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L193)
 
 ___
 
@@ -520,7 +520,7 @@ Check the range if the argument is a constant.
 
 #### Defined in
 
-[lib/int.ts:822](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L822)
+[lib/int.ts:825](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L825)
 
 ___
 
@@ -542,7 +542,7 @@ Static method to create a [Int64](Int64.md) from a [Field](../modules.md#field-1
 
 #### Defined in
 
-[lib/int.ts:873](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L873)
+[lib/int.ts:876](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L876)
 
 ___
 
@@ -566,7 +566,7 @@ Does check if the [Field](../modules.md#field-1) is within range.
 
 #### Defined in
 
-[lib/int.ts:794](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L794)
+[lib/int.ts:797](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L797)
 
 ___
 
@@ -597,7 +597,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L168)
+[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L168)
 
 ___
 
@@ -628,7 +628,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:226](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L226)
+[lib/circuit_value.ts:226](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L226)
 
 ___
 
@@ -659,7 +659,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L89)
+[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L89)
 
 ___
 
@@ -683,7 +683,7 @@ Creates a new [Int64](Int64.md) from a [Field](../modules.md#field-1).
 
 #### Defined in
 
-[lib/int.ts:812](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L812)
+[lib/int.ts:815](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L815)
 
 ___
 
@@ -701,7 +701,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L96)
+[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L96)
 
 ___
 
@@ -719,7 +719,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L118)
+[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L118)
 
 ___
 
@@ -750,7 +750,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L207)
+[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L207)
 
 ___
 
@@ -781,7 +781,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L101)
+[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L101)
 
 ___
 
@@ -812,7 +812,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:122](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L122)
+[lib/circuit_value.ts:122](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L122)
 
 ___
 
@@ -843,4 +843,4 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:215](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L215)
+[lib/circuit_value.ts:215](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L215)

--- a/docs/zkapps/o1js-reference/classes/Keypair.md
+++ b/docs/zkapps/o1js-reference/classes/Keypair.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[lib/circuit.ts:144](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L144)
+[lib/circuit.ts:144](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L144)
 
 ## Properties
 
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[lib/circuit.ts:142](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L142)
+[lib/circuit.ts:142](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L142)
 
 ## Methods
 
@@ -65,7 +65,7 @@ const json = MyProvable.witnessFromKeypair(keypair);
 
 #### Defined in
 
-[lib/circuit.ts:163](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L163)
+[lib/circuit.ts:163](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L163)
 
 ___
 
@@ -79,4 +79,4 @@ ___
 
 #### Defined in
 
-[lib/circuit.ts:148](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L148)
+[lib/circuit.ts:148](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L148)

--- a/docs/zkapps/o1js-reference/classes/Ledger.md
+++ b/docs/zkapps/o1js-reference/classes/Ledger.md
@@ -44,7 +44,7 @@ Adds an account and its balance to the ledger.
 
 #### Defined in
 
-[snarky.d.ts:395](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L395)
+[snarky.d.ts:475](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L475)
 
 ___
 
@@ -68,7 +68,7 @@ Applies a JSON transaction to the ledger.
 
 #### Defined in
 
-[snarky.d.ts:400](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L400)
+[snarky.d.ts:480](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L480)
 
 ___
 
@@ -83,7 +83,7 @@ Returns an account.
 | Name | Type |
 | :------ | :------ |
 | `publicKey` | [`MlPublicKey`](../modules.md#mlpublickey) |
-| `tokenId` | `Uint8Array` |
+| `tokenId` | [`FieldConst`](../modules.md#fieldconst-1) |
 
 #### Returns
 
@@ -91,7 +91,7 @@ Returns an account.
 
 #### Defined in
 
-[snarky.d.ts:409](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L409)
+[snarky.d.ts:489](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L489)
 
 ___
 
@@ -107,4 +107,4 @@ Creates a fresh ledger.
 
 #### Defined in
 
-[snarky.d.ts:390](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L390)
+[snarky.d.ts:470](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L470)

--- a/docs/zkapps/o1js-reference/classes/MerkleMap.md
+++ b/docs/zkapps/o1js-reference/classes/MerkleMap.md
@@ -30,7 +30,7 @@ Creates a new, empty Merkle Map.
 
 #### Defined in
 
-[lib/merkle_map.ts:19](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_map.ts#L19)
+[lib/merkle_map.ts:19](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_map.ts#L19)
 
 ## Properties
 
@@ -40,7 +40,7 @@ Creates a new, empty Merkle Map.
 
 #### Defined in
 
-[lib/merkle_map.ts:11](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_map.ts#L11)
+[lib/merkle_map.ts:11](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_map.ts#L11)
 
 ## Methods
 
@@ -60,7 +60,7 @@ Creates a new, empty Merkle Map.
 
 #### Defined in
 
-[lib/merkle_map.ts:34](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_map.ts#L34)
+[lib/merkle_map.ts:34](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_map.ts#L34)
 
 ___
 
@@ -84,7 +84,7 @@ The value stored at the key.
 
 #### Defined in
 
-[lib/merkle_map.ts:70](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_map.ts#L70)
+[lib/merkle_map.ts:70](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_map.ts#L70)
 
 ___
 
@@ -102,7 +102,7 @@ The root of the Merkle Map.
 
 #### Defined in
 
-[lib/merkle_map.ts:81](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_map.ts#L81)
+[lib/merkle_map.ts:81](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_map.ts#L81)
 
 ___
 
@@ -126,7 +126,7 @@ A MerkleMapWitness, which can be used to assert changes to the MerkleMap, and th
 
 #### Defined in
 
-[lib/merkle_map.ts:90](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_map.ts#L90)
+[lib/merkle_map.ts:90](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_map.ts#L90)
 
 ___
 
@@ -149,4 +149,4 @@ Sets a key of the merkle map to a given value.
 
 #### Defined in
 
-[lib/merkle_map.ts:58](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_map.ts#L58)
+[lib/merkle_map.ts:58](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_map.ts#L58)

--- a/docs/zkapps/o1js-reference/classes/MerkleMapWitness.md
+++ b/docs/zkapps/o1js-reference/classes/MerkleMapWitness.md
@@ -62,7 +62,7 @@
 
 #### Defined in
 
-[lib/merkle_map.ts:121](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_map.ts#L121)
+[lib/merkle_map.ts:121](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_map.ts#L121)
 
 ## Properties
 
@@ -72,7 +72,7 @@
 
 #### Defined in
 
-[lib/merkle_map.ts:118](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_map.ts#L118)
+[lib/merkle_map.ts:118](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_map.ts#L118)
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 #### Defined in
 
-[lib/merkle_map.ts:119](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_map.ts#L119)
+[lib/merkle_map.ts:119](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_map.ts#L119)
 
 ## Methods
 
@@ -106,7 +106,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:160](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L160)
+[lib/circuit_value.ts:160](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L160)
 
 ___
 
@@ -130,7 +130,7 @@ A tuple of the computed merkle root, and the key that is connected to the path u
 
 #### Defined in
 
-[lib/merkle_map.ts:132](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_map.ts#L132)
+[lib/merkle_map.ts:132](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_map.ts#L132)
 
 ___
 
@@ -154,7 +154,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:156](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L156)
+[lib/circuit_value.ts:156](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L156)
 
 ___
 
@@ -172,7 +172,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:164](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L164)
+[lib/circuit_value.ts:164](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L164)
 
 ___
 
@@ -190,7 +190,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L152)
+[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L152)
 
 ___
 
@@ -208,7 +208,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L144)
+[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L144)
 
 ___
 
@@ -226,7 +226,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L148)
+[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L148)
 
 ___
 
@@ -257,7 +257,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:193](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L193)
+[lib/circuit_value.ts:193](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L193)
 
 ___
 
@@ -288,7 +288,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L168)
+[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L168)
 
 ___
 
@@ -319,7 +319,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:226](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L226)
+[lib/circuit_value.ts:226](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L226)
 
 ___
 
@@ -350,7 +350,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L89)
+[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L89)
 
 ___
 
@@ -368,7 +368,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L96)
+[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L96)
 
 ___
 
@@ -386,7 +386,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L118)
+[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L118)
 
 ___
 
@@ -417,7 +417,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L207)
+[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L207)
 
 ___
 
@@ -448,7 +448,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L101)
+[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L101)
 
 ___
 
@@ -479,7 +479,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:122](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L122)
+[lib/circuit_value.ts:122](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L122)
 
 ___
 
@@ -510,4 +510,4 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:215](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L215)
+[lib/circuit_value.ts:215](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L215)

--- a/docs/zkapps/o1js-reference/classes/MerkleTree.md
+++ b/docs/zkapps/o1js-reference/classes/MerkleTree.md
@@ -53,7 +53,7 @@ Creates a new, empty [Merkle Tree](https://en.wikipedia.org/wiki/Merkle_tree).
 
 #### Defined in
 
-[lib/merkle_tree.ts:38](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_tree.ts#L38)
+[lib/merkle_tree.ts:38](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_tree.ts#L38)
 
 ## Properties
 
@@ -65,7 +65,7 @@ The height of Merkle Tree.
 
 #### Defined in
 
-[lib/merkle_tree.ts:38](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_tree.ts#L38)
+[lib/merkle_tree.ts:38](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_tree.ts#L38)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[lib/merkle_tree.ts:30](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_tree.ts#L30)
+[lib/merkle_tree.ts:30](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_tree.ts#L30)
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 #### Defined in
 
-[lib/merkle_tree.ts:31](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_tree.ts#L31)
+[lib/merkle_tree.ts:31](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_tree.ts#L31)
 
 ## Accessors
 
@@ -103,7 +103,7 @@ Amount of leaf nodes.
 
 #### Defined in
 
-[lib/merkle_tree.ts:147](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_tree.ts#L147)
+[lib/merkle_tree.ts:147](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_tree.ts#L147)
 
 ## Methods
 
@@ -125,7 +125,7 @@ Fills all leaves of the tree.
 
 #### Defined in
 
-[lib/merkle_tree.ts:137](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_tree.ts#L137)
+[lib/merkle_tree.ts:137](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_tree.ts#L137)
 
 ___
 
@@ -150,7 +150,7 @@ The data of the node.
 
 #### Defined in
 
-[lib/merkle_tree.ts:52](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_tree.ts#L52)
+[lib/merkle_tree.ts:52](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_tree.ts#L52)
 
 ___
 
@@ -168,7 +168,7 @@ The root of the Merkle Tree.
 
 #### Defined in
 
-[lib/merkle_tree.ts:60](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_tree.ts#L60)
+[lib/merkle_tree.ts:60](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_tree.ts#L60)
 
 ___
 
@@ -192,7 +192,7 @@ The witness that belongs to the leaf.
 
 #### Defined in
 
-[lib/merkle_tree.ts:98](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_tree.ts#L98)
+[lib/merkle_tree.ts:98](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_tree.ts#L98)
 
 ___
 
@@ -215,7 +215,7 @@ Sets the value of a leaf node at a given index to a given value.
 
 #### Defined in
 
-[lib/merkle_tree.ts:75](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_tree.ts#L75)
+[lib/merkle_tree.ts:75](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_tree.ts#L75)
 
 ___
 
@@ -237,7 +237,7 @@ ___
 
 #### Defined in
 
-[lib/merkle_tree.ts:65](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_tree.ts#L65)
+[lib/merkle_tree.ts:65](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_tree.ts#L65)
 
 ___
 
@@ -261,4 +261,4 @@ True if the witness for the leaf node is valid.
 
 #### Defined in
 
-[lib/merkle_tree.ts:120](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_tree.ts#L120)
+[lib/merkle_tree.ts:120](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_tree.ts#L120)

--- a/docs/zkapps/o1js-reference/classes/Nullifier.md
+++ b/docs/zkapps/o1js-reference/classes/Nullifier.md
@@ -78,7 +78,7 @@ Struct({
 
 #### Defined in
 
-[lib/circuit_value.ts:367](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L367)
+[lib/circuit_value.ts:366](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L366)
 
 ## Properties
 
@@ -111,7 +111,7 @@ Struct({
 
 #### Defined in
 
-[lib/nullifier.ts:26](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/nullifier.ts#L26)
+[lib/nullifier.ts:26](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/nullifier.ts#L26)
 
 ___
 
@@ -143,7 +143,7 @@ Struct({
 
 #### Defined in
 
-[lib/nullifier.ts:22](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/nullifier.ts#L22)
+[lib/nullifier.ts:22](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/nullifier.ts#L22)
 
 ___
 
@@ -168,7 +168,7 @@ Struct({
 
 #### Defined in
 
-[lib/nullifier.ts:21](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/nullifier.ts#L21)
+[lib/nullifier.ts:21](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/nullifier.ts#L21)
 
 ___
 
@@ -193,7 +193,7 @@ Struct({
 
 #### Defined in
 
-[lib/circuit_value.ts:367](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L367)
+[lib/circuit_value.ts:366](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L366)
 
 ___
 
@@ -240,7 +240,7 @@ Struct({
 
 #### Defined in
 
-[snarky.d.ts:134](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L134)
+[snarky.d.ts:142](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L142)
 
 ___
 
@@ -291,7 +291,7 @@ Struct({
 
 #### Defined in
 
-[snarky.d.ts:115](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L115)
+[snarky.d.ts:123](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L123)
 
 ___
 
@@ -338,7 +338,7 @@ Struct({
 
 #### Defined in
 
-[snarky.d.ts:104](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L104)
+[snarky.d.ts:112](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L112)
 
 ___
 
@@ -384,7 +384,7 @@ Struct({
 
 #### Defined in
 
-[snarky.d.ts:94](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L94)
+[snarky.d.ts:102](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L102)
 
 ___
 
@@ -431,7 +431,7 @@ Struct({
 
 #### Defined in
 
-[lib/circuit_value.ts:370](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L370)
+[lib/circuit_value.ts:369](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L369)
 
 ___
 
@@ -481,7 +481,7 @@ Struct({
 
 #### Defined in
 
-[lib/circuit_value.ts:374](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L374)
+[lib/circuit_value.ts:373](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L373)
 
 ## Methods
 
@@ -511,7 +511,7 @@ nullifier.assertUnused();
 
 #### Defined in
 
-[lib/nullifier.ts:141](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/nullifier.ts#L141)
+[lib/nullifier.ts:141](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/nullifier.ts#L141)
 
 ___
 
@@ -533,7 +533,7 @@ let pk = nullifier.getPublicKey();
 
 #### Defined in
 
-[lib/nullifier.ts:170](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/nullifier.ts#L170)
+[lib/nullifier.ts:170](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/nullifier.ts#L170)
 
 ___
 
@@ -563,7 +563,7 @@ let isUnused = nullifier.isUnused();
 
 #### Defined in
 
-[lib/nullifier.ts:121](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/nullifier.ts#L121)
+[lib/nullifier.ts:121](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/nullifier.ts#L121)
 
 ___
 
@@ -587,7 +587,7 @@ let key = nullifier.key();
 
 #### Defined in
 
-[lib/nullifier.ts:108](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/nullifier.ts#L108)
+[lib/nullifier.ts:108](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/nullifier.ts#L108)
 
 ___
 
@@ -616,7 +616,7 @@ let newRoot = nullifier.setUsed(witness);
 
 #### Defined in
 
-[lib/nullifier.ts:156](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/nullifier.ts#L156)
+[lib/nullifier.ts:156](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/nullifier.ts#L156)
 
 ___
 
@@ -646,7 +646,7 @@ nullifier.verify(nullifierMessage);
 
 #### Defined in
 
-[lib/nullifier.ts:47](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/nullifier.ts#L47)
+[lib/nullifier.ts:47](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/nullifier.ts#L47)
 
 ___
 
@@ -674,7 +674,7 @@ https://eprint.iacr.org/2022/1255.pdf chapter 3 page 14
 
 #### Defined in
 
-[lib/nullifier.ts:183](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/nullifier.ts#L183)
+[lib/nullifier.ts:183](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/nullifier.ts#L183)
 
 ___
 
@@ -709,7 +709,7 @@ Struct({
 
 #### Defined in
 
-[lib/nullifier.ts:32](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/nullifier.ts#L32)
+[lib/nullifier.ts:32](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/nullifier.ts#L32)
 
 ___
 
@@ -744,4 +744,4 @@ Struct({
 
 #### Defined in
 
-[snarky.d.ts:124](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L124)
+[snarky.d.ts:132](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L132)

--- a/docs/zkapps/o1js-reference/classes/PrivateKey.md
+++ b/docs/zkapps/o1js-reference/classes/PrivateKey.md
@@ -65,7 +65,7 @@ A signing key. You can generate one via [random](PrivateKey.md#random).
 
 #### Defined in
 
-[lib/signature.ts:30](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L30)
+[lib/signature.ts:30](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L30)
 
 ## Properties
 
@@ -75,7 +75,7 @@ A signing key. You can generate one via [random](PrivateKey.md#random).
 
 #### Defined in
 
-[lib/signature.ts:28](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L28)
+[lib/signature.ts:28](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L28)
 
 ## Methods
 
@@ -99,7 +99,7 @@ A signing key. You can generate one via [random](PrivateKey.md#random).
 
 #### Defined in
 
-[lib/circuit_value.ts:160](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L160)
+[lib/circuit_value.ts:160](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L160)
 
 ___
 
@@ -123,7 +123,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:156](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L156)
+[lib/circuit_value.ts:156](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L156)
 
 ___
 
@@ -141,7 +141,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:164](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L164)
+[lib/circuit_value.ts:164](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L164)
 
 ___
 
@@ -159,7 +159,7 @@ a base58 encoded string
 
 #### Defined in
 
-[lib/signature.ts:95](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L95)
+[lib/signature.ts:95](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L95)
 
 ___
 
@@ -175,7 +175,7 @@ Convert this [PrivateKey](PrivateKey.md) to a bigint
 
 #### Defined in
 
-[lib/signature.ts:58](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L58)
+[lib/signature.ts:58](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L58)
 
 ___
 
@@ -193,7 +193,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L152)
+[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L152)
 
 ___
 
@@ -211,7 +211,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L144)
+[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L144)
 
 ___
 
@@ -229,7 +229,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L148)
+[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L148)
 
 ___
 
@@ -247,7 +247,7 @@ a [PublicKey](Types.PublicKey.md).
 
 #### Defined in
 
-[lib/signature.ts:77](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L77)
+[lib/signature.ts:77](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L77)
 
 ___
 
@@ -278,7 +278,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:193](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L193)
+[lib/circuit_value.ts:193](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L193)
 
 ___
 
@@ -302,7 +302,7 @@ a [PrivateKey](PrivateKey.md).
 
 #### Defined in
 
-[lib/signature.ts:86](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L86)
+[lib/signature.ts:86](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L86)
 
 ___
 
@@ -327,7 +327,7 @@ Be careful that you don't use this method to create private keys that were sampl
 
 #### Defined in
 
-[lib/signature.ts:68](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L68)
+[lib/signature.ts:68](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L68)
 
 ___
 
@@ -351,7 +351,7 @@ a [PrivateKey](PrivateKey.md).
 
 #### Defined in
 
-[lib/signature.ts:51](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L51)
+[lib/signature.ts:51](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L51)
 
 ___
 
@@ -382,7 +382,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L168)
+[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L168)
 
 ___
 
@@ -413,7 +413,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:226](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L226)
+[lib/circuit_value.ts:226](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L226)
 
 ___
 
@@ -444,7 +444,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L89)
+[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L89)
 
 ___
 
@@ -464,7 +464,7 @@ a new [PrivateKey](PrivateKey.md).
 
 #### Defined in
 
-[lib/signature.ts:41](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L41)
+[lib/signature.ts:41](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L41)
 
 ___
 
@@ -482,7 +482,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L96)
+[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L96)
 
 ___
 
@@ -500,7 +500,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L118)
+[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L118)
 
 ___
 
@@ -525,7 +525,7 @@ a base58 encoded string
 
 #### Defined in
 
-[lib/signature.ts:104](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L104)
+[lib/signature.ts:104](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L104)
 
 ___
 
@@ -556,7 +556,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L207)
+[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L207)
 
 ___
 
@@ -587,7 +587,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L101)
+[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L101)
 
 ___
 
@@ -618,7 +618,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:122](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L122)
+[lib/circuit_value.ts:122](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L122)
 
 ___
 
@@ -649,4 +649,4 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:215](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L215)
+[lib/circuit_value.ts:215](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L215)

--- a/docs/zkapps/o1js-reference/classes/Proof.md
+++ b/docs/zkapps/o1js-reference/classes/Proof.md
@@ -37,6 +37,7 @@
 - [toJSON](Proof.md#tojson)
 - [verify](Proof.md#verify)
 - [verifyIf](Proof.md#verifyif)
+- [dummy](Proof.md#dummy)
 - [fromJSON](Proof.md#fromjson)
 
 ## Constructors
@@ -64,7 +65,7 @@
 
 #### Defined in
 
-[lib/proof_system.ts:119](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L119)
+[lib/proof_system.ts:127](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L127)
 
 ## Properties
 
@@ -74,7 +75,7 @@
 
 #### Defined in
 
-[lib/proof_system.ts:77](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L77)
+[lib/proof_system.ts:85](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L85)
 
 ___
 
@@ -84,7 +85,7 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:76](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L76)
+[lib/proof_system.ts:84](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L84)
 
 ___
 
@@ -94,7 +95,7 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:74](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L74)
+[lib/proof_system.ts:82](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L82)
 
 ___
 
@@ -104,7 +105,7 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:75](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L75)
+[lib/proof_system.ts:83](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L83)
 
 ___
 
@@ -114,7 +115,7 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:78](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L78)
+[lib/proof_system.ts:86](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L86)
 
 ___
 
@@ -124,7 +125,7 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:66](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L66)
+[lib/proof_system.ts:74](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L74)
 
 ___
 
@@ -134,7 +135,7 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:67](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L67)
+[lib/proof_system.ts:75](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L75)
 
 ___
 
@@ -156,7 +157,7 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:68](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L68)
+[lib/proof_system.ts:76](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L76)
 
 ## Methods
 
@@ -170,7 +171,7 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:86](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L86)
+[lib/proof_system.ts:94](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L94)
 
 ___
 
@@ -184,7 +185,7 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:80](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L80)
+[lib/proof_system.ts:88](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L88)
 
 ___
 
@@ -204,7 +205,57 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:83](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L83)
+[lib/proof_system.ts:91](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L91)
+
+___
+
+### dummy
+
+▸ `Static` **dummy**<`Input`, `OutPut`\>(`publicInput`, `publicOutput`, `maxProofsVerified`, `domainLog2?`): `Promise`<[`Proof`](Proof.md)<`Input`, `OutPut`\>\>
+
+Dummy proof. This can be useful for ZkPrograms that handle the base case in the same
+method as the inductive case, using a pattern like this:
+
+```ts
+method(proof: SelfProof<I, O>, isRecursive: Bool) {
+  proof.verifyIf(isRecursive);
+  // ...
+}
+```
+
+To use such a method in the base case, you need a dummy proof:
+
+```ts
+let dummy = await MyProof.dummy(publicInput, publicOutput, 1);
+await myProgram.myMethod(dummy, Bool(false));
+```
+
+**Note**: The types of `publicInput` and `publicOutput`, as well as the `maxProofsVerified` parameter,
+must match your ZkProgram. `maxProofsVerified` is the maximum number of proofs that any of your methods take as arguments.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `Input` |
+| `OutPut` |
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `publicInput` | `Input` | `undefined` |
+| `publicOutput` | `OutPut` | `undefined` |
+| `maxProofsVerified` | ``0`` \| ``2`` \| ``1`` | `undefined` |
+| `domainLog2` | `number` | `14` |
+
+#### Returns
+
+`Promise`<[`Proof`](Proof.md)<`Input`, `OutPut`\>\>
+
+#### Defined in
+
+[lib/proof_system.ts:165](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L165)
 
 ___
 
@@ -231,4 +282,4 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:95](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L95)
+[lib/proof_system.ts:103](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L103)

--- a/docs/zkapps/o1js-reference/classes/Scalar.md
+++ b/docs/zkapps/o1js-reference/classes/Scalar.md
@@ -59,17 +59,17 @@ Represents a [Scalar](Scalar.md).
 
 #### Defined in
 
-[lib/scalar.ts:34](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L34)
+[lib/scalar.ts:37](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L37)
 
 ## Properties
 
 ### constantValue
 
-• `Optional` **constantValue**: `Uint8Array`
+• `Optional` **constantValue**: `ScalarConst`
 
 #### Defined in
 
-[lib/scalar.ts:30](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L30)
+[lib/scalar.ts:33](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L33)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[lib/scalar.ts:29](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L29)
+[lib/scalar.ts:32](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L32)
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 #### Defined in
 
-[lib/scalar.ts:32](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L32)
+[lib/scalar.ts:35](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L35)
 
 ## Methods
 
@@ -109,7 +109,7 @@ ___
 
 #### Defined in
 
-[lib/scalar.ts:112](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L112)
+[lib/scalar.ts:115](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L115)
 
 ___
 
@@ -133,7 +133,7 @@ Add scalar field elements.
 
 #### Defined in
 
-[lib/scalar.ts:132](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L132)
+[lib/scalar.ts:135](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L135)
 
 ___
 
@@ -158,7 +158,7 @@ Throws if the denominator is zero.
 
 #### Defined in
 
-[lib/scalar.ts:169](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L169)
+[lib/scalar.ts:172](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L172)
 
 ___
 
@@ -175,7 +175,7 @@ this is Scalar & Object
 
 #### Defined in
 
-[lib/scalar.ts:59](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L59)
+[lib/scalar.ts:62](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L62)
 
 ___
 
@@ -199,7 +199,7 @@ Multiply scalar field elements.
 
 #### Defined in
 
-[lib/scalar.ts:156](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L156)
+[lib/scalar.ts:159](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L159)
 
 ___
 
@@ -217,7 +217,7 @@ Negate a scalar field element.
 
 #### Defined in
 
-[lib/scalar.ts:121](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L121)
+[lib/scalar.ts:124](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L124)
 
 ___
 
@@ -231,7 +231,7 @@ ___
 
 #### Defined in
 
-[lib/scalar.ts:178](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L178)
+[lib/scalar.ts:181](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L181)
 
 ___
 
@@ -255,7 +255,7 @@ Subtract scalar field elements.
 
 #### Defined in
 
-[lib/scalar.ts:144](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L144)
+[lib/scalar.ts:147](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L147)
 
 ___
 
@@ -271,7 +271,7 @@ Convert this [Scalar](Scalar.md) into a bigint
 
 #### Defined in
 
-[lib/scalar.ts:87](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L87)
+[lib/scalar.ts:90](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L90)
 
 ___
 
@@ -291,7 +291,7 @@ See [FieldVar](../modules.md#fieldvar-1) for an explanation of constants vs. var
 
 #### Defined in
 
-[lib/scalar.ts:70](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L70)
+[lib/scalar.ts:73](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L73)
 
 ___
 
@@ -314,7 +314,7 @@ that can be used outside proofs.
 
 #### Defined in
 
-[lib/scalar.ts:233](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L233)
+[lib/scalar.ts:236](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L236)
 
 ___
 
@@ -340,7 +340,7 @@ is needed to represent all Scalars. However, for a random Scalar, the high bit w
 
 #### Defined in
 
-[lib/scalar.ts:195](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L195)
+[lib/scalar.ts:198](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L198)
 
 ___
 
@@ -356,7 +356,7 @@ Serializes this Scalar to a string
 
 #### Defined in
 
-[lib/scalar.ts:299](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L299)
+[lib/scalar.ts:302](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L302)
 
 ___
 
@@ -370,7 +370,7 @@ ___
 
 #### Defined in
 
-[lib/scalar.ts:182](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L182)
+[lib/scalar.ts:185](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L185)
 
 ___
 
@@ -388,7 +388,7 @@ Does nothing.
 
 #### Defined in
 
-[lib/scalar.ts:269](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L269)
+[lib/scalar.ts:272](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L272)
 
 ___
 
@@ -404,7 +404,7 @@ If the input is too large, it is reduced modulo the scalar field size.
 
 | Name | Type |
 | :------ | :------ |
-| `x` | `string` \| `number` \| `bigint` \| `Uint8Array` \| [`Scalar`](Scalar.md) |
+| `x` | `string` \| `number` \| `bigint` \| [`Scalar`](Scalar.md) \| `ScalarConst` |
 
 #### Returns
 
@@ -412,7 +412,7 @@ If the input is too large, it is reduced modulo the scalar field size.
 
 #### Defined in
 
-[lib/scalar.ts:47](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L47)
+[lib/scalar.ts:50](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L50)
 
 ___
 
@@ -436,7 +436,7 @@ use [from](Scalar.md#from)
 
 #### Defined in
 
-[lib/scalar.ts:80](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L80)
+[lib/scalar.ts:83](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L83)
 
 ___
 
@@ -460,7 +460,7 @@ Creates a data structure from an array of serialized [Bool](Bool.md).
 
 #### Defined in
 
-[lib/scalar.ts:98](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L98)
+[lib/scalar.ts:101](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L101)
 
 ___
 
@@ -484,7 +484,7 @@ Creates a data structure from an array of serialized [Field](Field.md) elements.
 
 #### Defined in
 
-[lib/scalar.ts:251](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L251)
+[lib/scalar.ts:254](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L254)
 
 ___
 
@@ -507,7 +507,7 @@ This operation does _not_ affect the circuit and can't be used to prove anything
 
 #### Defined in
 
-[lib/scalar.ts:307](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L307)
+[lib/scalar.ts:310](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L310)
 
 ___
 
@@ -524,7 +524,7 @@ Randomness can not be proven inside a circuit!
 
 #### Defined in
 
-[lib/scalar.ts:106](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L106)
+[lib/scalar.ts:109](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L109)
 
 ___
 
@@ -542,7 +542,7 @@ Returns the size of this type in [Field](Field.md) elements.
 
 #### Defined in
 
-[lib/scalar.ts:260](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L260)
+[lib/scalar.ts:263](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L263)
 
 ___
 
@@ -560,7 +560,7 @@ Serialize a [Scalar](Scalar.md) into its auxiliary data, which are empty.
 
 #### Defined in
 
-[lib/scalar.ts:242](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L242)
+[lib/scalar.ts:245](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L245)
 
 ___
 
@@ -588,7 +588,7 @@ The fields are not constrained to be boolean.
 
 #### Defined in
 
-[lib/scalar.ts:218](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L218)
+[lib/scalar.ts:221](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L221)
 
 ___
 
@@ -611,4 +611,4 @@ This operation does _not_ affect the circuit and can't be used to prove anything
 
 #### Defined in
 
-[lib/scalar.ts:291](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/scalar.ts#L291)
+[lib/scalar.ts:294](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/scalar.ts#L294)

--- a/docs/zkapps/o1js-reference/classes/SelfProof.md
+++ b/docs/zkapps/o1js-reference/classes/SelfProof.md
@@ -37,6 +37,7 @@
 - [toJSON](SelfProof.md#tojson)
 - [verify](SelfProof.md#verify)
 - [verifyIf](SelfProof.md#verifyif)
+- [dummy](SelfProof.md#dummy)
 - [fromJSON](SelfProof.md#fromjson)
 
 ## Constructors
@@ -68,7 +69,7 @@
 
 #### Defined in
 
-[lib/proof_system.ts:119](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L119)
+[lib/proof_system.ts:127](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L127)
 
 ## Properties
 
@@ -82,7 +83,7 @@
 
 #### Defined in
 
-[lib/proof_system.ts:77](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L77)
+[lib/proof_system.ts:85](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L85)
 
 ___
 
@@ -96,7 +97,7 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:76](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L76)
+[lib/proof_system.ts:84](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L84)
 
 ___
 
@@ -110,7 +111,7 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:74](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L74)
+[lib/proof_system.ts:82](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L82)
 
 ___
 
@@ -124,7 +125,7 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:75](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L75)
+[lib/proof_system.ts:83](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L83)
 
 ___
 
@@ -138,7 +139,7 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:78](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L78)
+[lib/proof_system.ts:86](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L86)
 
 ___
 
@@ -152,7 +153,7 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:66](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L66)
+[lib/proof_system.ts:74](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L74)
 
 ___
 
@@ -166,7 +167,7 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:67](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L67)
+[lib/proof_system.ts:75](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L75)
 
 ___
 
@@ -192,7 +193,7 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:68](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L68)
+[lib/proof_system.ts:76](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L76)
 
 ## Methods
 
@@ -210,7 +211,7 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:86](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L86)
+[lib/proof_system.ts:94](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L94)
 
 ___
 
@@ -228,7 +229,7 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:80](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L80)
+[lib/proof_system.ts:88](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L88)
 
 ___
 
@@ -252,7 +253,61 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:83](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L83)
+[lib/proof_system.ts:91](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L91)
+
+___
+
+### dummy
+
+▸ `Static` **dummy**<`Input`, `OutPut`\>(`publicInput`, `publicOutput`, `maxProofsVerified`, `domainLog2?`): `Promise`<[`Proof`](Proof.md)<`Input`, `OutPut`\>\>
+
+Dummy proof. This can be useful for ZkPrograms that handle the base case in the same
+method as the inductive case, using a pattern like this:
+
+```ts
+method(proof: SelfProof<I, O>, isRecursive: Bool) {
+  proof.verifyIf(isRecursive);
+  // ...
+}
+```
+
+To use such a method in the base case, you need a dummy proof:
+
+```ts
+let dummy = await MyProof.dummy(publicInput, publicOutput, 1);
+await myProgram.myMethod(dummy, Bool(false));
+```
+
+**Note**: The types of `publicInput` and `publicOutput`, as well as the `maxProofsVerified` parameter,
+must match your ZkProgram. `maxProofsVerified` is the maximum number of proofs that any of your methods take as arguments.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `Input` |
+| `OutPut` |
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `publicInput` | `Input` | `undefined` |
+| `publicOutput` | `OutPut` | `undefined` |
+| `maxProofsVerified` | ``0`` \| ``2`` \| ``1`` | `undefined` |
+| `domainLog2` | `number` | `14` |
+
+#### Returns
+
+`Promise`<[`Proof`](Proof.md)<`Input`, `OutPut`\>\>
+
+#### Inherited from
+
+[Proof](Proof.md).[dummy](Proof.md#dummy)
+
+#### Defined in
+
+[lib/proof_system.ts:165](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L165)
 
 ___
 
@@ -283,4 +338,4 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:95](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L95)
+[lib/proof_system.ts:103](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L103)

--- a/docs/zkapps/o1js-reference/classes/Sign.md
+++ b/docs/zkapps/o1js-reference/classes/Sign.md
@@ -69,7 +69,7 @@
 
 #### Defined in
 
-[lib/circuit_value.ts:72](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L72)
+[lib/circuit_value.ts:72](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L72)
 
 ## Properties
 
@@ -79,7 +79,7 @@
 
 #### Defined in
 
-[lib/int.ts:711](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L711)
+[lib/int.ts:714](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L714)
 
 ## Accessors
 
@@ -93,7 +93,7 @@
 
 #### Defined in
 
-[lib/int.ts:716](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L716)
+[lib/int.ts:719](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L719)
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[lib/int.ts:713](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L713)
+[lib/int.ts:716](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L716)
 
 ## Methods
 
@@ -131,7 +131,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:160](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L160)
+[lib/circuit_value.ts:160](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L160)
 
 ___
 
@@ -155,7 +155,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:156](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L156)
+[lib/circuit_value.ts:156](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L156)
 
 ___
 
@@ -173,7 +173,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:164](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L164)
+[lib/circuit_value.ts:164](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L164)
 
 ___
 
@@ -187,7 +187,7 @@ ___
 
 #### Defined in
 
-[lib/int.ts:745](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L745)
+[lib/int.ts:748](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L748)
 
 ___
 
@@ -207,7 +207,7 @@ ___
 
 #### Defined in
 
-[lib/int.ts:742](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L742)
+[lib/int.ts:745](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L745)
 
 ___
 
@@ -221,7 +221,7 @@ ___
 
 #### Defined in
 
-[lib/int.ts:739](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L739)
+[lib/int.ts:742](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L742)
 
 ___
 
@@ -239,7 +239,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L152)
+[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L152)
 
 ___
 
@@ -257,7 +257,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L144)
+[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L144)
 
 ___
 
@@ -275,7 +275,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L148)
+[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L148)
 
 ___
 
@@ -289,7 +289,7 @@ ___
 
 #### Defined in
 
-[lib/int.ts:748](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L748)
+[lib/int.ts:751](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L751)
 
 ___
 
@@ -313,7 +313,7 @@ ___
 
 #### Defined in
 
-[lib/int.ts:719](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L719)
+[lib/int.ts:722](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L722)
 
 ___
 
@@ -327,7 +327,7 @@ ___
 
 #### Defined in
 
-[lib/int.ts:723](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L723)
+[lib/int.ts:726](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L726)
 
 ___
 
@@ -358,7 +358,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L168)
+[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L168)
 
 ___
 
@@ -388,7 +388,7 @@ ___
 
 #### Defined in
 
-[lib/int.ts:734](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L734)
+[lib/int.ts:737](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L737)
 
 ___
 
@@ -419,7 +419,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L89)
+[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L89)
 
 ___
 
@@ -437,7 +437,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L96)
+[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L96)
 
 ___
 
@@ -455,7 +455,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L118)
+[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L118)
 
 ___
 
@@ -486,7 +486,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L207)
+[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L207)
 
 ___
 
@@ -517,7 +517,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L101)
+[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L101)
 
 ___
 
@@ -541,7 +541,7 @@ ___
 
 #### Defined in
 
-[lib/int.ts:726](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L726)
+[lib/int.ts:729](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L729)
 
 ___
 
@@ -565,4 +565,4 @@ ___
 
 #### Defined in
 
-[lib/int.ts:729](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L729)
+[lib/int.ts:732](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L732)

--- a/docs/zkapps/o1js-reference/classes/Signature.md
+++ b/docs/zkapps/o1js-reference/classes/Signature.md
@@ -62,7 +62,7 @@ A Schnorr [Signature](Signature.md) over the Pasta Curves.
 
 #### Defined in
 
-[lib/circuit_value.ts:72](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L72)
+[lib/circuit_value.ts:72](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L72)
 
 ## Properties
 
@@ -72,7 +72,7 @@ A Schnorr [Signature](Signature.md) over the Pasta Curves.
 
 #### Defined in
 
-[lib/signature.ts:231](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L231)
+[lib/signature.ts:231](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L231)
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 #### Defined in
 
-[lib/signature.ts:232](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L232)
+[lib/signature.ts:232](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L232)
 
 ## Methods
 
@@ -106,7 +106,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:160](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L160)
+[lib/circuit_value.ts:160](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L160)
 
 ___
 
@@ -130,7 +130,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:156](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L156)
+[lib/circuit_value.ts:156](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L156)
 
 ___
 
@@ -148,7 +148,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:164](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L164)
+[lib/circuit_value.ts:164](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L164)
 
 ___
 
@@ -164,7 +164,7 @@ Encodes a [Signature](Signature.md) in base58 format.
 
 #### Defined in
 
-[lib/signature.ts:292](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L292)
+[lib/signature.ts:292](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L292)
 
 ___
 
@@ -182,7 +182,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L152)
+[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L152)
 
 ___
 
@@ -200,7 +200,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L144)
+[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L144)
 
 ___
 
@@ -218,7 +218,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L148)
+[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L148)
 
 ___
 
@@ -243,7 +243,7 @@ a [Bool](../modules.md#bool-1)
 
 #### Defined in
 
-[lib/signature.ts:266](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L266)
+[lib/signature.ts:266](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L266)
 
 ___
 
@@ -274,7 +274,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:193](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L193)
+[lib/circuit_value.ts:193](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L193)
 
 ___
 
@@ -299,7 +299,7 @@ a [Signature](Signature.md)
 
 #### Defined in
 
-[lib/signature.ts:238](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L238)
+[lib/signature.ts:238](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L238)
 
 ___
 
@@ -321,7 +321,7 @@ Decodes a base58 encoded signature into a [Signature](Signature.md).
 
 #### Defined in
 
-[lib/signature.ts:282](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L282)
+[lib/signature.ts:282](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L282)
 
 ___
 
@@ -352,7 +352,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L168)
+[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L168)
 
 ___
 
@@ -383,7 +383,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:226](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L226)
+[lib/circuit_value.ts:226](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L226)
 
 ___
 
@@ -414,7 +414,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L89)
+[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L89)
 
 ___
 
@@ -432,7 +432,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L96)
+[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L96)
 
 ___
 
@@ -450,7 +450,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L118)
+[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L118)
 
 ___
 
@@ -481,7 +481,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L207)
+[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L207)
 
 ___
 
@@ -512,7 +512,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L101)
+[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L101)
 
 ___
 
@@ -543,7 +543,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:122](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L122)
+[lib/circuit_value.ts:122](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L122)
 
 ___
 
@@ -574,4 +574,4 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:215](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L215)
+[lib/circuit_value.ts:215](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L215)

--- a/docs/zkapps/o1js-reference/classes/SmartContract.md
+++ b/docs/zkapps/o1js-reference/classes/SmartContract.md
@@ -75,7 +75,7 @@ class YourSmartContract extends SmartContract {
 
 #### Defined in
 
-[lib/zkapp.ts:637](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L637)
+[lib/zkapp.ts:637](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L637)
 
 ## Properties
 
@@ -92,7 +92,7 @@ class YourSmartContract extends SmartContract {
 
 #### Defined in
 
-[lib/zkapp.ts:885](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L885)
+[lib/zkapp.ts:887](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L887)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[lib/zkapp.ts:604](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L604)
+[lib/zkapp.ts:604](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L604)
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[lib/zkapp.ts:601](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L601)
+[lib/zkapp.ts:601](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L601)
 
 ___
 
@@ -128,7 +128,7 @@ A list of event types that can be emitted using this.emitEvent()`.
 
 #### Defined in
 
-[lib/zkapp.ts:996](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L996)
+[lib/zkapp.ts:998](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L998)
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[lib/zkapp.ts:602](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L602)
+[lib/zkapp.ts:602](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L602)
 
 ___
 
@@ -148,7 +148,7 @@ ___
 
 #### Defined in
 
-[lib/zkapp.ts:622](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L622)
+[lib/zkapp.ts:622](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L622)
 
 ___
 
@@ -158,7 +158,7 @@ ___
 
 #### Defined in
 
-[lib/zkapp.ts:611](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L611)
+[lib/zkapp.ts:611](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L611)
 
 ___
 
@@ -168,7 +168,7 @@ ___
 
 #### Defined in
 
-[lib/zkapp.ts:610](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L610)
+[lib/zkapp.ts:610](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L610)
 
 ___
 
@@ -178,7 +178,7 @@ ___
 
 #### Defined in
 
-[lib/zkapp.ts:621](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L621)
+[lib/zkapp.ts:621](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L621)
 
 ___
 
@@ -195,7 +195,7 @@ ___
 
 #### Defined in
 
-[lib/zkapp.ts:623](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L623)
+[lib/zkapp.ts:623](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L623)
 
 ## Accessors
 
@@ -211,7 +211,7 @@ Current account of the [SmartContract](SmartContract.md).
 
 #### Defined in
 
-[lib/zkapp.ts:916](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L916)
+[lib/zkapp.ts:918](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L918)
 
 ___
 
@@ -232,7 +232,7 @@ Balance of this [SmartContract](SmartContract.md).
 
 #### Defined in
 
-[lib/zkapp.ts:990](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L990)
+[lib/zkapp.ts:992](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L992)
 
 ___
 
@@ -250,7 +250,7 @@ or `assertEquals()` (confusing, because the developer can't know the exact slot 
 
 #### Defined in
 
-[lib/zkapp.ts:930](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L930)
+[lib/zkapp.ts:932](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L932)
 
 ___
 
@@ -266,7 +266,7 @@ Current network state of the [SmartContract](SmartContract.md).
 
 #### Defined in
 
-[lib/zkapp.ts:922](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L922)
+[lib/zkapp.ts:924](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L924)
 
 ___
 
@@ -282,7 +282,7 @@ Returns the current [AccountUpdate](AccountUpdate.md) associated to this [SmartC
 
 #### Defined in
 
-[lib/zkapp.ts:842](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L842)
+[lib/zkapp.ts:844](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L844)
 
 ___
 
@@ -303,7 +303,7 @@ A malicious prover could use any other public key without affecting the validity
 
 #### Defined in
 
-[lib/zkapp.ts:895](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L895)
+[lib/zkapp.ts:897](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L897)
 
 ___
 
@@ -328,7 +328,7 @@ Token of the [SmartContract](SmartContract.md).
 
 #### Defined in
 
-[lib/zkapp.ts:936](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L936)
+[lib/zkapp.ts:938](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L938)
 
 ___
 
@@ -350,7 +350,7 @@ use `this.account.tokenSymbol`
 
 #### Defined in
 
-[lib/zkapp.ts:984](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L984)
+[lib/zkapp.ts:986](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L986)
 
 ## Methods
 
@@ -390,7 +390,7 @@ The account update that was approved (needed when passing in a Callback)
 
 #### Defined in
 
-[lib/zkapp.ts:962](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L962)
+[lib/zkapp.ts:964](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L964)
 
 ___
 
@@ -424,7 +424,7 @@ tx.sign([senderKey, zkAppKey]);
 
 #### Defined in
 
-[lib/zkapp.ts:726](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L726)
+[lib/zkapp.ts:728](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L728)
 
 ___
 
@@ -453,7 +453,7 @@ Emits an event. Events will be emitted as a part of the transaction and can be c
 
 #### Defined in
 
-[lib/zkapp.ts:1002](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L1002)
+[lib/zkapp.ts:1004](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L1004)
 
 ___
 
@@ -493,7 +493,7 @@ A promise that resolves to an array of objects, each containing the event type a
 
 #### Defined in
 
-[lib/zkapp.ts:1048](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L1048)
+[lib/zkapp.ts:1050](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L1050)
 
 ___
 
@@ -519,7 +519,7 @@ class MyContract extends SmartContract {
 
 #### Defined in
 
-[lib/zkapp.ts:797](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L797)
+[lib/zkapp.ts:799](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L799)
 
 ___
 
@@ -535,7 +535,7 @@ Same as `SmartContract.self` but explicitly creates a new [AccountUpdate](Accoun
 
 #### Defined in
 
-[lib/zkapp.ts:877](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L877)
+[lib/zkapp.ts:879](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L879)
 
 ___
 
@@ -559,7 +559,7 @@ with the only difference being that quick mock proofs are filled in instead of r
 
 #### Defined in
 
-[lib/zkapp.ts:818](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L818)
+[lib/zkapp.ts:820](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L820)
 
 ___
 
@@ -581,7 +581,7 @@ ___
 
 #### Defined in
 
-[lib/zkapp.ts:974](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L974)
+[lib/zkapp.ts:976](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L976)
 
 ___
 
@@ -605,7 +605,7 @@ use `this.account.permissions.set()`
 
 #### Defined in
 
-[lib/zkapp.ts:1228](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L1228)
+[lib/zkapp.ts:1230](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L1230)
 
 ___
 
@@ -636,7 +636,7 @@ use `this.account.<field>.set()`
 
 #### Defined in
 
-[lib/zkapp.ts:1221](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L1221)
+[lib/zkapp.ts:1223](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L1223)
 
 ___
 
@@ -660,7 +660,7 @@ ___
 
 #### Defined in
 
-[lib/zkapp.ts:824](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L824)
+[lib/zkapp.ts:826](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L826)
 
 ___
 
@@ -681,7 +681,7 @@ authorization flow.
 
 #### Defined in
 
-[lib/zkapp.ts:835](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L835)
+[lib/zkapp.ts:837](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L837)
 
 ___
 
@@ -697,7 +697,7 @@ typeof `__class`
 
 #### Defined in
 
-[lib/zkapp.ts:628](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L628)
+[lib/zkapp.ts:628](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L628)
 
 ___
 
@@ -730,13 +730,13 @@ an object, keyed by method name, each entry containing:
 
 #### Defined in
 
-[lib/zkapp.ts:1168](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L1168)
+[lib/zkapp.ts:1170](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L1170)
 
 ___
 
 ### compile
 
-▸ `Static` **compile**(): `Promise`<{ `provers`: [`Prover`](../modules/Pickles.md#prover)[] ; `verificationKey`: { `data`: `string` = verificationKey\_.data; `hash`: [`Field`](Field.md)  } ; `verify`: (`statement`: [`Statement`](../modules/Pickles.md#statement)<`Uint8Array`\>, `proof`: `unknown`) => `Promise`<`boolean`\>  }\>
+▸ `Static` **compile**(): `Promise`<{ `provers`: [`Prover`](../modules/Pickles.md#prover)[] ; `verificationKey`: { `data`: `string` = verificationKey\_.data; `hash`: [`Field`](Field.md)  } ; `verify`: (`statement`: [`Statement`](../modules/Pickles.md#statement)<[`FieldConst`](../modules.md#fieldconst-1)\>, `proof`: `unknown`) => `Promise`<`boolean`\>  }\>
 
 Compile your smart contract.
 
@@ -753,11 +753,11 @@ up to several minutes if your circuit is large or your hardware is not optimal f
 
 #### Returns
 
-`Promise`<{ `provers`: [`Prover`](../modules/Pickles.md#prover)[] ; `verificationKey`: { `data`: `string` = verificationKey\_.data; `hash`: [`Field`](Field.md)  } ; `verify`: (`statement`: [`Statement`](../modules/Pickles.md#statement)<`Uint8Array`\>, `proof`: `unknown`) => `Promise`<`boolean`\>  }\>
+`Promise`<{ `provers`: [`Prover`](../modules/Pickles.md#prover)[] ; `verificationKey`: { `data`: `string` = verificationKey\_.data; `hash`: [`Field`](Field.md)  } ; `verify`: (`statement`: [`Statement`](../modules/Pickles.md#statement)<[`FieldConst`](../modules.md#fieldconst-1)\>, `proof`: `unknown`) => `Promise`<`boolean`\>  }\>
 
 #### Defined in
 
-[lib/zkapp.ts:664](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L664)
+[lib/zkapp.ts:664](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L664)
 
 ___
 
@@ -777,7 +777,7 @@ the digest, as a hex string
 
 #### Defined in
 
-[lib/zkapp.ts:706](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L706)
+[lib/zkapp.ts:708](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L708)
 
 ___
 
@@ -797,4 +797,4 @@ ___
 
 #### Defined in
 
-[lib/zkapp.ts:1142](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L1142)
+[lib/zkapp.ts:1144](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L1144)

--- a/docs/zkapps/o1js-reference/classes/Token.md
+++ b/docs/zkapps/o1js-reference/classes/Token.md
@@ -39,7 +39,7 @@ use `TokenId` instead of `Token.Id` and `TokenId.derive()` instead of `Token.get
 
 #### Defined in
 
-[lib/account_update.ts:635](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L635)
+[lib/account_update.ts:632](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L632)
 
 ## Properties
 
@@ -49,7 +49,7 @@ use `TokenId` instead of `Token.Id` and `TokenId.derive()` instead of `Token.get
 
 #### Defined in
 
-[lib/account_update.ts:632](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L632)
+[lib/account_update.ts:629](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L629)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:633](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L633)
+[lib/account_update.ts:630](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L630)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:634](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L634)
+[lib/account_update.ts:631](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L631)
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:626](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L626)
+[lib/account_update.ts:623](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L623)
 
 ## Methods
 
@@ -118,4 +118,4 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:628](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L628)
+[lib/account_update.ts:625](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L625)

--- a/docs/zkapps/o1js-reference/classes/TokenSymbol.md
+++ b/docs/zkapps/o1js-reference/classes/TokenSymbol.md
@@ -56,7 +56,7 @@ Struct(TokenSymbolPure).constructor
 
 #### Defined in
 
-[lib/circuit_value.ts:367](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L367)
+[lib/circuit_value.ts:366](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L366)
 
 ## Properties
 
@@ -70,7 +70,7 @@ Struct(TokenSymbolPure).field
 
 #### Defined in
 
-[lib/hash.ts:153](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/hash.ts#L153)
+[lib/hash.ts:153](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/hash.ts#L153)
 
 ___
 
@@ -84,7 +84,7 @@ Struct(TokenSymbolPure).symbol
 
 #### Defined in
 
-[lib/hash.ts:153](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/hash.ts#L153)
+[lib/hash.ts:153](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/hash.ts#L153)
 
 ___
 
@@ -98,7 +98,7 @@ Struct(TokenSymbolPure).\_isStruct
 
 #### Defined in
 
-[lib/circuit_value.ts:367](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L367)
+[lib/circuit_value.ts:366](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L366)
 
 ___
 
@@ -133,7 +133,7 @@ Struct(TokenSymbolPure).check
 
 #### Defined in
 
-[snarky.d.ts:75](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L75)
+[snarky.d.ts:83](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L83)
 
 ___
 
@@ -173,7 +173,7 @@ Struct(TokenSymbolPure).fromFields
 
 #### Defined in
 
-[snarky.d.ts:56](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L56)
+[snarky.d.ts:64](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L64)
 
 ___
 
@@ -206,7 +206,7 @@ Struct(TokenSymbolPure).fromJSON
 
 #### Defined in
 
-[lib/circuit_value.ts:375](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L375)
+[lib/circuit_value.ts:374](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L374)
 
 ___
 
@@ -240,7 +240,7 @@ Struct(TokenSymbolPure).toAuxiliary
 
 #### Defined in
 
-[snarky.d.ts:44](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L44)
+[snarky.d.ts:52](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L52)
 
 ___
 
@@ -274,7 +274,7 @@ Struct(TokenSymbolPure).toFields
 
 #### Defined in
 
-[snarky.d.ts:35](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L35)
+[snarky.d.ts:43](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L43)
 
 ___
 
@@ -309,7 +309,7 @@ Struct(TokenSymbolPure).toInput
 
 #### Defined in
 
-[lib/circuit_value.ts:370](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L370)
+[lib/circuit_value.ts:369](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L369)
 
 ___
 
@@ -339,7 +339,7 @@ Struct(TokenSymbolPure).toJSON
 
 #### Defined in
 
-[lib/circuit_value.ts:374](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L374)
+[lib/circuit_value.ts:373](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L373)
 
 ## Accessors
 
@@ -358,7 +358,7 @@ Struct(TokenSymbolPure).toJSON
 
 #### Defined in
 
-[lib/hash.ts:184](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/hash.ts#L184)
+[lib/hash.ts:184](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/hash.ts#L184)
 
 ## Methods
 
@@ -378,7 +378,7 @@ Struct(TokenSymbolPure).toJSON
 
 #### Defined in
 
-[lib/hash.ts:188](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/hash.ts#L188)
+[lib/hash.ts:188](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/hash.ts#L188)
 
 ___
 
@@ -402,4 +402,4 @@ Struct(TokenSymbolPure).sizeInFields
 
 #### Defined in
 
-[snarky.d.ts:65](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L65)
+[snarky.d.ts:73](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L73)

--- a/docs/zkapps/o1js-reference/classes/Types.PublicKey.md
+++ b/docs/zkapps/o1js-reference/classes/Types.PublicKey.md
@@ -70,7 +70,7 @@ You can derive a [PublicKey](Types.PublicKey.md) directly from a [PrivateKey](Pr
 
 #### Defined in
 
-[lib/circuit_value.ts:72](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L72)
+[lib/circuit_value.ts:72](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L72)
 
 ## Properties
 
@@ -80,7 +80,7 @@ You can derive a [PublicKey](Types.PublicKey.md) directly from a [PrivateKey](Pr
 
 #### Defined in
 
-[lib/signature.ts:119](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L119)
+[lib/signature.ts:119](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L119)
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 #### Defined in
 
-[lib/signature.ts:118](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L118)
+[lib/signature.ts:118](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L118)
 
 ## Methods
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:160](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L160)
+[lib/circuit_value.ts:160](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L160)
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:156](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L156)
+[lib/circuit_value.ts:156](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L156)
 
 ___
 
@@ -156,7 +156,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:164](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L164)
+[lib/circuit_value.ts:164](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L164)
 
 ___
 
@@ -174,7 +174,7 @@ a [Bool](../modules.md#bool-1)
 
 #### Defined in
 
-[lib/signature.ts:176](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L176)
+[lib/signature.ts:176](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L176)
 
 ___
 
@@ -192,7 +192,7 @@ a base58 encoded [PublicKey](Types.PublicKey.md)
 
 #### Defined in
 
-[lib/signature.ts:194](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L194)
+[lib/signature.ts:194](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L194)
 
 ___
 
@@ -210,7 +210,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L152)
+[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L152)
 
 ___
 
@@ -228,7 +228,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L144)
+[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L144)
 
 ___
 
@@ -246,7 +246,7 @@ A [Group](../modules.md#group-1)
 
 #### Defined in
 
-[lib/signature.ts:125](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L125)
+[lib/signature.ts:125](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L125)
 
 ___
 
@@ -264,7 +264,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L148)
+[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L148)
 
 ___
 
@@ -295,7 +295,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:193](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L193)
+[lib/circuit_value.ts:193](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L193)
 
 ___
 
@@ -313,7 +313,7 @@ an empty [PublicKey](Types.PublicKey.md)
 
 #### Defined in
 
-[lib/signature.ts:168](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L168)
+[lib/signature.ts:168](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L168)
 
 ___
 
@@ -339,7 +339,7 @@ a [PublicKey](Types.PublicKey.md).
 
 #### Defined in
 
-[lib/signature.ts:160](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L160)
+[lib/signature.ts:160](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L160)
 
 ___
 
@@ -363,7 +363,7 @@ a [PublicKey](Types.PublicKey.md)
 
 #### Defined in
 
-[lib/signature.ts:185](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L185)
+[lib/signature.ts:185](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L185)
 
 ___
 
@@ -394,7 +394,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L168)
+[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L168)
 
 ___
 
@@ -418,7 +418,7 @@ a [PublicKey](Types.PublicKey.md).
 
 #### Defined in
 
-[lib/signature.ts:143](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L143)
+[lib/signature.ts:143](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L143)
 
 ___
 
@@ -453,7 +453,7 @@ a JSON string
 
 #### Defined in
 
-[lib/signature.ts:222](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L222)
+[lib/signature.ts:222](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L222)
 
 ___
 
@@ -484,7 +484,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L89)
+[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L89)
 
 ___
 
@@ -508,7 +508,7 @@ a [PublicKey](Types.PublicKey.md).
 
 #### Defined in
 
-[lib/signature.ts:152](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L152)
+[lib/signature.ts:152](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L152)
 
 ___
 
@@ -526,7 +526,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L96)
+[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L96)
 
 ___
 
@@ -544,7 +544,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L118)
+[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L118)
 
 ___
 
@@ -568,7 +568,7 @@ a base58 encoded [PublicKey](Types.PublicKey.md)
 
 #### Defined in
 
-[lib/signature.ts:202](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L202)
+[lib/signature.ts:202](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L202)
 
 ___
 
@@ -599,7 +599,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L207)
+[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L207)
 
 ___
 
@@ -630,7 +630,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L101)
+[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L101)
 
 ___
 
@@ -661,7 +661,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:122](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L122)
+[lib/circuit_value.ts:122](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L122)
 
 ___
 
@@ -689,4 +689,4 @@ a JSON string
 
 #### Defined in
 
-[lib/signature.ts:214](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L214)
+[lib/signature.ts:214](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L214)

--- a/docs/zkapps/o1js-reference/classes/UInt32.md
+++ b/docs/zkapps/o1js-reference/classes/UInt32.md
@@ -91,7 +91,7 @@ A 32 bit unsigned integer with values ranging from 0 to 4,294,967,295.
 
 #### Defined in
 
-[lib/circuit_value.ts:72](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L72)
+[lib/circuit_value.ts:72](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L72)
 
 ## Properties
 
@@ -101,7 +101,7 @@ A 32 bit unsigned integer with values ranging from 0 to 4,294,967,295.
 
 #### Defined in
 
-[lib/int.ts:377](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L377)
+[lib/int.ts:379](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L379)
 
 ___
 
@@ -111,7 +111,7 @@ ___
 
 #### Defined in
 
-[lib/int.ts:378](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L378)
+[lib/int.ts:380](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L380)
 
 ## Accessors
 
@@ -127,7 +127,7 @@ Static method to create a [UInt32](UInt32.md) with value `0`.
 
 #### Defined in
 
-[lib/int.ts:390](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L390)
+[lib/int.ts:392](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L392)
 
 ___
 
@@ -143,7 +143,7 @@ Static method to create a [UInt32](UInt32.md) with value `0`.
 
 #### Defined in
 
-[lib/int.ts:383](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L383)
+[lib/int.ts:385](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L385)
 
 ## Methods
 
@@ -165,7 +165,7 @@ Addition with overflow checking.
 
 #### Defined in
 
-[lib/int.ts:529](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L529)
+[lib/int.ts:532](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L532)
 
 ___
 
@@ -189,7 +189,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:160](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L160)
+[lib/circuit_value.ts:160](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L160)
 
 ___
 
@@ -212,7 +212,7 @@ Asserts that a [UInt32](UInt32.md) is greater than another one.
 
 #### Defined in
 
-[lib/int.ts:672](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L672)
+[lib/int.ts:675](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L675)
 
 ___
 
@@ -235,7 +235,7 @@ Asserts that a [UInt32](UInt32.md) is greater than or equal to another one.
 
 #### Defined in
 
-[lib/int.ts:705](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L705)
+[lib/int.ts:708](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L708)
 
 ___
 
@@ -262,7 +262,7 @@ Asserts that a [UInt32](UInt32.md) is greater than another one.
 
 #### Defined in
 
-[lib/int.ts:665](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L665)
+[lib/int.ts:668](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L668)
 
 ___
 
@@ -289,7 +289,7 @@ Asserts that a [UInt32](UInt32.md) is greater than or equal to another one.
 
 #### Defined in
 
-[lib/int.ts:698](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L698)
+[lib/int.ts:701](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L701)
 
 ___
 
@@ -312,7 +312,7 @@ Asserts that a [UInt32](UInt32.md) is less than another one.
 
 #### Defined in
 
-[lib/int.ts:640](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L640)
+[lib/int.ts:643](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L643)
 
 ___
 
@@ -335,7 +335,7 @@ Asserts that a [UInt32](UInt32.md) is less than or equal to another one.
 
 #### Defined in
 
-[lib/int.ts:598](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L598)
+[lib/int.ts:601](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L601)
 
 ___
 
@@ -362,7 +362,7 @@ Asserts that a [UInt32](UInt32.md) is less than another one.
 
 #### Defined in
 
-[lib/int.ts:633](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L633)
+[lib/int.ts:636](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L636)
 
 ___
 
@@ -389,7 +389,7 @@ Asserts that a [UInt32](UInt32.md) is less than or equal to another one.
 
 #### Defined in
 
-[lib/int.ts:591](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L591)
+[lib/int.ts:594](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L594)
 
 ___
 
@@ -414,7 +414,7 @@ Integer division.
 
 #### Defined in
 
-[lib/int.ts:506](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L506)
+[lib/int.ts:509](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L509)
 
 ___
 
@@ -443,7 +443,7 @@ Integer division with remainder.
 
 #### Defined in
 
-[lib/int.ts:464](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L464)
+[lib/int.ts:467](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L467)
 
 ___
 
@@ -467,7 +467,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:156](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L156)
+[lib/circuit_value.ts:156](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L156)
 
 ___
 
@@ -489,7 +489,7 @@ Checks if a [UInt32](UInt32.md) is greater than another one.
 
 #### Defined in
 
-[lib/int.ts:656](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L656)
+[lib/int.ts:659](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L659)
 
 ___
 
@@ -511,7 +511,7 @@ Checks if a [UInt32](UInt32.md) is greater than or equal to another one.
 
 #### Defined in
 
-[lib/int.ts:688](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L688)
+[lib/int.ts:691](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L691)
 
 ___
 
@@ -537,7 +537,7 @@ Checks if a [UInt32](UInt32.md) is greater than another one.
 
 #### Defined in
 
-[lib/int.ts:649](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L649)
+[lib/int.ts:652](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L652)
 
 ___
 
@@ -563,7 +563,7 @@ Checks if a [UInt32](UInt32.md) is greater than or equal to another one.
 
 #### Defined in
 
-[lib/int.ts:681](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L681)
+[lib/int.ts:684](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L684)
 
 ___
 
@@ -581,7 +581,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:164](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L164)
+[lib/circuit_value.ts:164](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L164)
 
 ___
 
@@ -603,7 +603,7 @@ Checks if a [UInt32](UInt32.md) is less than another one.
 
 #### Defined in
 
-[lib/int.ts:624](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L624)
+[lib/int.ts:627](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L627)
 
 ___
 
@@ -625,7 +625,7 @@ Checks if a [UInt32](UInt32.md) is less than or equal to another one.
 
 #### Defined in
 
-[lib/int.ts:568](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L568)
+[lib/int.ts:571](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L571)
 
 ___
 
@@ -651,7 +651,7 @@ Checks if a [UInt32](UInt32.md) is less than another one.
 
 #### Defined in
 
-[lib/int.ts:617](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L617)
+[lib/int.ts:620](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L620)
 
 ___
 
@@ -677,7 +677,7 @@ Checks if a [UInt32](UInt32.md) is less than or equal to another one.
 
 #### Defined in
 
-[lib/int.ts:547](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L547)
+[lib/int.ts:550](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L550)
 
 ___
 
@@ -702,7 +702,7 @@ Integer remainder.
 
 #### Defined in
 
-[lib/int.ts:515](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L515)
+[lib/int.ts:518](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L518)
 
 ___
 
@@ -724,7 +724,7 @@ Multiplication with overflow checking.
 
 #### Defined in
 
-[lib/int.ts:521](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L521)
+[lib/int.ts:524](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L524)
 
 ___
 
@@ -746,7 +746,7 @@ Subtraction with underflow checking.
 
 #### Defined in
 
-[lib/int.ts:537](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L537)
+[lib/int.ts:540](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L540)
 
 ___
 
@@ -762,7 +762,7 @@ Turns the [UInt32](UInt32.md) into a BigInt.
 
 #### Defined in
 
-[lib/int.ts:402](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L402)
+[lib/int.ts:404](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L404)
 
 ___
 
@@ -780,7 +780,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L152)
+[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L152)
 
 ___
 
@@ -798,7 +798,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L144)
+[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L144)
 
 ___
 
@@ -816,7 +816,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L148)
+[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L148)
 
 ___
 
@@ -832,7 +832,7 @@ Turns the [UInt32](UInt32.md) into a string.
 
 #### Defined in
 
-[lib/int.ts:396](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L396)
+[lib/int.ts:398](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L398)
 
 ___
 
@@ -848,7 +848,7 @@ Turns the [UInt32](UInt32.md) into a [UInt64](UInt64.md).
 
 #### Defined in
 
-[lib/int.ts:408](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L408)
+[lib/int.ts:410](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L410)
 
 ___
 
@@ -864,7 +864,7 @@ Creates a [UInt32](UInt32.md) with a value of 4,294,967,295.
 
 #### Defined in
 
-[lib/int.ts:456](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L456)
+[lib/int.ts:458](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L458)
 
 ___
 
@@ -888,7 +888,7 @@ ___
 
 #### Defined in
 
-[lib/int.ts:413](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L413)
+[lib/int.ts:415](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L415)
 
 ___
 
@@ -908,7 +908,7 @@ ___
 
 #### Defined in
 
-[lib/int.ts:434](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L434)
+[lib/int.ts:436](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L436)
 
 ___
 
@@ -930,7 +930,7 @@ Creates a new [UInt32](UInt32.md).
 
 #### Defined in
 
-[lib/int.ts:449](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L449)
+[lib/int.ts:451](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L451)
 
 ___
 
@@ -961,7 +961,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L168)
+[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L168)
 
 ___
 
@@ -993,7 +993,7 @@ Decodes a JSON-like object into this structure.
 
 #### Defined in
 
-[lib/int.ts:430](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L430)
+[lib/int.ts:432](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L432)
 
 ___
 
@@ -1024,7 +1024,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L89)
+[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L89)
 
 ___
 
@@ -1042,7 +1042,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L96)
+[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L96)
 
 ___
 
@@ -1060,7 +1060,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L118)
+[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L118)
 
 ___
 
@@ -1091,7 +1091,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L207)
+[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L207)
 
 ___
 
@@ -1122,7 +1122,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L101)
+[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L101)
 
 ___
 
@@ -1146,7 +1146,7 @@ ___
 
 #### Defined in
 
-[lib/int.ts:417](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L417)
+[lib/int.ts:419](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L419)
 
 ___
 
@@ -1172,4 +1172,4 @@ Encodes this structure into a JSON-like object.
 
 #### Defined in
 
-[lib/int.ts:423](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L423)
+[lib/int.ts:425](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L425)

--- a/docs/zkapps/o1js-reference/classes/UInt64.md
+++ b/docs/zkapps/o1js-reference/classes/UInt64.md
@@ -92,7 +92,7 @@ A 64 bit unsigned integer with values ranging from 0 to 18,446,744,073,709,551,6
 
 #### Defined in
 
-[lib/circuit_value.ts:72](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L72)
+[lib/circuit_value.ts:72](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L72)
 
 ## Properties
 
@@ -102,7 +102,7 @@ A 64 bit unsigned integer with values ranging from 0 to 18,446,744,073,709,551,6
 
 #### Defined in
 
-[lib/int.ts:14](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L14)
+[lib/int.ts:14](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L14)
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[lib/int.ts:15](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L15)
+[lib/int.ts:15](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L15)
 
 ## Accessors
 
@@ -128,7 +128,7 @@ Static method to create a [UInt64](UInt64.md) with value `1`.
 
 #### Defined in
 
-[lib/int.ts:26](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L26)
+[lib/int.ts:26](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L26)
 
 ___
 
@@ -144,7 +144,7 @@ Static method to create a [UInt64](UInt64.md) with value `0`.
 
 #### Defined in
 
-[lib/int.ts:20](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L20)
+[lib/int.ts:20](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L20)
 
 ## Methods
 
@@ -166,7 +166,7 @@ Addition with overflow checking.
 
 #### Defined in
 
-[lib/int.ts:190](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L190)
+[lib/int.ts:192](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L192)
 
 ___
 
@@ -190,7 +190,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:160](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L160)
+[lib/circuit_value.ts:160](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L160)
 
 ___
 
@@ -213,7 +213,7 @@ Asserts that a [UInt64](UInt64.md) is greater than another one.
 
 #### Defined in
 
-[lib/int.ts:337](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L337)
+[lib/int.ts:339](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L339)
 
 ___
 
@@ -236,7 +236,7 @@ Asserts that a [UInt64](UInt64.md) is greater than or equal to another one.
 
 #### Defined in
 
-[lib/int.ts:369](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L369)
+[lib/int.ts:371](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L371)
 
 ___
 
@@ -263,7 +263,7 @@ Asserts that a [UInt64](UInt64.md) is greater than another one.
 
 #### Defined in
 
-[lib/int.ts:330](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L330)
+[lib/int.ts:332](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L332)
 
 ___
 
@@ -290,7 +290,7 @@ Asserts that a [UInt64](UInt64.md) is greater than or equal to another one.
 
 #### Defined in
 
-[lib/int.ts:362](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L362)
+[lib/int.ts:364](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L364)
 
 ___
 
@@ -313,7 +313,7 @@ Asserts that a [UInt64](UInt64.md) is less than another one.
 
 #### Defined in
 
-[lib/int.ts:305](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L305)
+[lib/int.ts:307](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L307)
 
 ___
 
@@ -336,7 +336,7 @@ Asserts that a [UInt64](UInt64.md) is less than or equal to another one.
 
 #### Defined in
 
-[lib/int.ts:261](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L261)
+[lib/int.ts:263](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L263)
 
 ___
 
@@ -363,7 +363,7 @@ Asserts that a [UInt64](UInt64.md) is less than another one.
 
 #### Defined in
 
-[lib/int.ts:298](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L298)
+[lib/int.ts:300](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L300)
 
 ___
 
@@ -390,7 +390,7 @@ Asserts that a [UInt64](UInt64.md) is less than or equal to another one.
 
 #### Defined in
 
-[lib/int.ts:254](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L254)
+[lib/int.ts:256](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L256)
 
 ___
 
@@ -415,7 +415,7 @@ Integer division.
 
 #### Defined in
 
-[lib/int.ts:164](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L164)
+[lib/int.ts:166](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L166)
 
 ___
 
@@ -444,7 +444,7 @@ Integer division with remainder.
 
 #### Defined in
 
-[lib/int.ts:121](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L121)
+[lib/int.ts:123](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L123)
 
 ___
 
@@ -468,7 +468,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:156](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L156)
+[lib/circuit_value.ts:156](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L156)
 
 ___
 
@@ -490,7 +490,7 @@ Checks if a [UInt64](UInt64.md) is greater than another one.
 
 #### Defined in
 
-[lib/int.ts:321](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L321)
+[lib/int.ts:323](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L323)
 
 ___
 
@@ -512,7 +512,7 @@ Checks if a [UInt64](UInt64.md) is greater than or equal to another one.
 
 #### Defined in
 
-[lib/int.ts:353](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L353)
+[lib/int.ts:355](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L355)
 
 ___
 
@@ -538,7 +538,7 @@ Checks if a [UInt64](UInt64.md) is greater than another one.
 
 #### Defined in
 
-[lib/int.ts:314](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L314)
+[lib/int.ts:316](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L316)
 
 ___
 
@@ -564,7 +564,7 @@ Checks if a [UInt64](UInt64.md) is greater than or equal to another one.
 
 #### Defined in
 
-[lib/int.ts:346](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L346)
+[lib/int.ts:348](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L348)
 
 ___
 
@@ -582,7 +582,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:164](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L164)
+[lib/circuit_value.ts:164](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L164)
 
 ___
 
@@ -604,7 +604,7 @@ Checks if a [UInt64](UInt64.md) is less than another one.
 
 #### Defined in
 
-[lib/int.ts:288](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L288)
+[lib/int.ts:290](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L290)
 
 ___
 
@@ -626,7 +626,7 @@ Checks if a [UInt64](UInt64.md) is less than or equal to another one.
 
 #### Defined in
 
-[lib/int.ts:231](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L231)
+[lib/int.ts:233](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L233)
 
 ___
 
@@ -652,7 +652,7 @@ Checks if a [UInt64](UInt64.md) is less than another one.
 
 #### Defined in
 
-[lib/int.ts:280](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L280)
+[lib/int.ts:282](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L282)
 
 ___
 
@@ -678,7 +678,7 @@ Checks if a [UInt64](UInt64.md) is less than or equal to another one.
 
 #### Defined in
 
-[lib/int.ts:210](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L210)
+[lib/int.ts:212](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L212)
 
 ___
 
@@ -703,7 +703,7 @@ Integer remainder.
 
 #### Defined in
 
-[lib/int.ts:174](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L174)
+[lib/int.ts:176](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L176)
 
 ___
 
@@ -725,7 +725,7 @@ Multiplication with overflow checking.
 
 #### Defined in
 
-[lib/int.ts:181](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L181)
+[lib/int.ts:183](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L183)
 
 ___
 
@@ -747,7 +747,7 @@ Subtraction with underflow checking.
 
 #### Defined in
 
-[lib/int.ts:199](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L199)
+[lib/int.ts:201](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L201)
 
 ___
 
@@ -763,7 +763,7 @@ Turns the [UInt64](UInt64.md) into a BigInt.
 
 #### Defined in
 
-[lib/int.ts:40](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L40)
+[lib/int.ts:40](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L40)
 
 ___
 
@@ -781,7 +781,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L152)
+[lib/circuit_value.ts:152](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L152)
 
 ___
 
@@ -799,7 +799,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L144)
+[lib/circuit_value.ts:144](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L144)
 
 ___
 
@@ -817,7 +817,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L148)
+[lib/circuit_value.ts:148](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L148)
 
 ___
 
@@ -833,7 +833,7 @@ Turns the [UInt64](UInt64.md) into a string.
 
 #### Defined in
 
-[lib/int.ts:33](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L33)
+[lib/int.ts:33](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L33)
 
 ___
 
@@ -849,7 +849,7 @@ Turns the [UInt64](UInt64.md) into a [UInt32](UInt32.md), asserting that it fits
 
 #### Defined in
 
-[lib/int.ts:47](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L47)
+[lib/int.ts:47](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L47)
 
 ___
 
@@ -868,7 +868,7 @@ UInt64.from(4294967296).toUInt32Clamped().toString(); // "4294967295"
 
 #### Defined in
 
-[lib/int.ts:59](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L59)
+[lib/int.ts:59](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L59)
 
 ___
 
@@ -884,7 +884,7 @@ Creates a [UInt64](UInt64.md) with a value of 18,446,744,073,709,551,615.
 
 #### Defined in
 
-[lib/int.ts:112](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L112)
+[lib/int.ts:114](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L114)
 
 ___
 
@@ -908,7 +908,7 @@ ___
 
 #### Defined in
 
-[lib/int.ts:68](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L68)
+[lib/int.ts:68](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L68)
 
 ___
 
@@ -928,7 +928,7 @@ ___
 
 #### Defined in
 
-[lib/int.ts:89](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L89)
+[lib/int.ts:91](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L91)
 
 ___
 
@@ -950,7 +950,7 @@ Creates a new [UInt64](UInt64.md).
 
 #### Defined in
 
-[lib/int.ts:104](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L104)
+[lib/int.ts:106](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L106)
 
 ___
 
@@ -981,7 +981,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L168)
+[lib/circuit_value.ts:168](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L168)
 
 ___
 
@@ -1013,7 +1013,7 @@ Decodes a JSON-like object into this structure.
 
 #### Defined in
 
-[lib/int.ts:85](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L85)
+[lib/int.ts:87](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L87)
 
 ___
 
@@ -1044,7 +1044,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L89)
+[lib/circuit_value.ts:89](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L89)
 
 ___
 
@@ -1062,7 +1062,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L96)
+[lib/circuit_value.ts:96](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L96)
 
 ___
 
@@ -1080,7 +1080,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L118)
+[lib/circuit_value.ts:118](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L118)
 
 ___
 
@@ -1111,7 +1111,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L207)
+[lib/circuit_value.ts:207](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L207)
 
 ___
 
@@ -1142,7 +1142,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L101)
+[lib/circuit_value.ts:101](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L101)
 
 ___
 
@@ -1166,7 +1166,7 @@ ___
 
 #### Defined in
 
-[lib/int.ts:72](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L72)
+[lib/int.ts:73](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L73)
 
 ___
 
@@ -1192,4 +1192,4 @@ Encodes this structure into a JSON-like object.
 
 #### Defined in
 
-[lib/int.ts:78](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/int.ts#L78)
+[lib/int.ts:80](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/int.ts#L80)

--- a/docs/zkapps/o1js-reference/classes/VerificationKey.md
+++ b/docs/zkapps/o1js-reference/classes/VerificationKey.md
@@ -56,7 +56,7 @@ Struct({
 
 #### Defined in
 
-[lib/circuit_value.ts:367](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L367)
+[lib/circuit_value.ts:366](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L366)
 
 ## Properties
 
@@ -75,7 +75,7 @@ Struct({
 
 #### Defined in
 
-[lib/zkapp.ts:1484](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L1484)
+[lib/zkapp.ts:1486](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L1486)
 
 ___
 
@@ -94,7 +94,7 @@ Struct({
 
 #### Defined in
 
-[lib/zkapp.ts:1484](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L1484)
+[lib/zkapp.ts:1486](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L1486)
 
 ___
 
@@ -113,7 +113,7 @@ Struct({
 
 #### Defined in
 
-[lib/circuit_value.ts:367](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L367)
+[lib/circuit_value.ts:366](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L366)
 
 ___
 
@@ -153,7 +153,7 @@ Struct({
 
 #### Defined in
 
-[snarky.d.ts:75](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L75)
+[snarky.d.ts:83](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L83)
 
 ___
 
@@ -198,7 +198,7 @@ Struct({
 
 #### Defined in
 
-[snarky.d.ts:56](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L56)
+[snarky.d.ts:64](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L64)
 
 ___
 
@@ -236,7 +236,7 @@ Struct({
 
 #### Defined in
 
-[lib/circuit_value.ts:375](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L375)
+[lib/circuit_value.ts:374](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L374)
 
 ___
 
@@ -275,7 +275,7 @@ Struct({
 
 #### Defined in
 
-[snarky.d.ts:44](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L44)
+[snarky.d.ts:52](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L52)
 
 ___
 
@@ -314,7 +314,7 @@ Struct({
 
 #### Defined in
 
-[snarky.d.ts:35](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L35)
+[snarky.d.ts:43](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L43)
 
 ___
 
@@ -354,7 +354,7 @@ Struct({
 
 #### Defined in
 
-[lib/circuit_value.ts:370](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L370)
+[lib/circuit_value.ts:369](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L369)
 
 ___
 
@@ -389,7 +389,7 @@ Struct({
 
 #### Defined in
 
-[lib/circuit_value.ts:374](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L374)
+[lib/circuit_value.ts:373](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L373)
 
 ## Methods
 
@@ -418,4 +418,4 @@ Struct({
 
 #### Defined in
 
-[snarky.d.ts:65](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L65)
+[snarky.d.ts:73](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L73)

--- a/docs/zkapps/o1js-reference/enums/FieldType.md
+++ b/docs/zkapps/o1js-reference/enums/FieldType.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[lib/field.ts:50](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L50)
+[lib/field.ts:48](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L48)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[lib/field.ts:48](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L48)
+[lib/field.ts:46](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L46)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[lib/field.ts:51](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L51)
+[lib/field.ts:49](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L49)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[lib/field.ts:49](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L49)
+[lib/field.ts:47](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L47)

--- a/docs/zkapps/o1js-reference/interfaces/Mina.TransactionId.md
+++ b/docs/zkapps/o1js-reference/interfaces/Mina.TransactionId.md
@@ -23,7 +23,7 @@
 
 #### Defined in
 
-[lib/mina.ts:69](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L69)
+[lib/mina.ts:69](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L69)
 
 ## Methods
 
@@ -37,7 +37,7 @@
 
 #### Defined in
 
-[lib/mina.ts:71](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L71)
+[lib/mina.ts:71](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L71)
 
 ___
 
@@ -59,4 +59,4 @@ ___
 
 #### Defined in
 
-[lib/mina.ts:70](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L70)
+[lib/mina.ts:70](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L70)

--- a/docs/zkapps/o1js-reference/interfaces/Permissions.md
+++ b/docs/zkapps/o1js-reference/interfaces/Permissions.md
@@ -48,7 +48,7 @@ Permissions\_.access
 
 #### Defined in
 
-[lib/account_update.ts:236](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L236)
+[lib/account_update.ts:236](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L236)
 
 ___
 
@@ -64,7 +64,7 @@ Permissions\_.editActionState
 
 #### Defined in
 
-[lib/account_update.ts:215](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L215)
+[lib/account_update.ts:215](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L215)
 
 ___
 
@@ -81,7 +81,7 @@ Permissions\_.editState
 
 #### Defined in
 
-[lib/account_update.ts:171](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L171)
+[lib/account_update.ts:171](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L171)
 
 ___
 
@@ -95,7 +95,7 @@ Permissions\_.incrementNonce
 
 #### Defined in
 
-[lib/account_update.ts:224](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L224)
+[lib/account_update.ts:224](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L224)
 
 ___
 
@@ -112,7 +112,7 @@ Permissions\_.receive
 
 #### Defined in
 
-[lib/account_update.ts:183](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L183)
+[lib/account_update.ts:183](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L183)
 
 ___
 
@@ -129,7 +129,7 @@ Permissions\_.send
 
 #### Defined in
 
-[lib/account_update.ts:177](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L177)
+[lib/account_update.ts:177](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L177)
 
 ___
 
@@ -146,7 +146,7 @@ Permissions\_.setDelegate
 
 #### Defined in
 
-[lib/account_update.ts:189](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L189)
+[lib/account_update.ts:189](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L189)
 
 ___
 
@@ -163,7 +163,7 @@ Permissions\_.setPermissions
 
 #### Defined in
 
-[lib/account_update.ts:195](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L195)
+[lib/account_update.ts:195](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L195)
 
 ___
 
@@ -177,7 +177,7 @@ Permissions\_.setTiming
 
 #### Defined in
 
-[lib/account_update.ts:226](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L226)
+[lib/account_update.ts:226](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L226)
 
 ___
 
@@ -194,7 +194,7 @@ Permissions\_.setTokenSymbol
 
 #### Defined in
 
-[lib/account_update.ts:221](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L221)
+[lib/account_update.ts:221](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L221)
 
 ___
 
@@ -212,7 +212,7 @@ Permissions\_.setVerificationKey
 
 #### Defined in
 
-[lib/account_update.ts:202](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L202)
+[lib/account_update.ts:202](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L202)
 
 ___
 
@@ -226,7 +226,7 @@ Permissions\_.setVotingFor
 
 #### Defined in
 
-[lib/account_update.ts:225](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L225)
+[lib/account_update.ts:225](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L225)
 
 ___
 
@@ -245,4 +245,4 @@ Permissions\_.setZkappUri
 
 #### Defined in
 
-[lib/account_update.ts:210](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L210)
+[lib/account_update.ts:210](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L210)

--- a/docs/zkapps/o1js-reference/interfaces/Provable.md
+++ b/docs/zkapps/o1js-reference/interfaces/Provable.md
@@ -60,7 +60,7 @@ For instance, calling check function on the type [Bool](../classes/Bool.md) asse
 
 #### Defined in
 
-[snarky.d.ts:75](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L75)
+[snarky.d.ts:83](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L83)
 
 ___
 
@@ -91,7 +91,7 @@ An element of type `T` generated from the given provable and "auxiliary" data.
 
 #### Defined in
 
-[snarky.d.ts:56](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L56)
+[snarky.d.ts:64](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L64)
 
 ___
 
@@ -119,7 +119,7 @@ An array of any type describing how this `T` element is made up of "auxiliary" (
 
 #### Defined in
 
-[snarky.d.ts:44](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L44)
+[snarky.d.ts:52](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L52)
 
 ___
 
@@ -147,7 +147,7 @@ A [Field](../classes/Field.md) array describing how this `T` element is made up 
 
 #### Defined in
 
-[snarky.d.ts:35](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L35)
+[snarky.d.ts:43](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L43)
 
 ## Methods
 
@@ -167,4 +167,4 @@ A `number` representing the size of the `T` type in terms of [Field](../classes/
 
 #### Defined in
 
-[snarky.d.ts:65](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L65)
+[snarky.d.ts:73](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L73)

--- a/docs/zkapps/o1js-reference/interfaces/ProvablePure.md
+++ b/docs/zkapps/o1js-reference/interfaces/ProvablePure.md
@@ -65,7 +65,7 @@ For instance, calling check function on the type [Bool](../classes/Bool.md) asse
 
 #### Defined in
 
-[snarky.d.ts:134](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L134)
+[snarky.d.ts:142](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L142)
 
 ___
 
@@ -99,7 +99,7 @@ An element of type `T` generated from the given provable data.
 
 #### Defined in
 
-[snarky.d.ts:115](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L115)
+[snarky.d.ts:123](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L123)
 
 ___
 
@@ -132,7 +132,7 @@ An empty array, as any element of the interface `ProvablePure<T>` includes no "a
 
 #### Defined in
 
-[snarky.d.ts:104](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L104)
+[snarky.d.ts:112](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L112)
 
 ___
 
@@ -164,7 +164,7 @@ A [Field](../classes/Field.md) array describing how this `T` element is made up 
 
 #### Defined in
 
-[snarky.d.ts:94](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L94)
+[snarky.d.ts:102](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L102)
 
 ## Methods
 
@@ -188,4 +188,4 @@ A `number` representing the size of the `T` type in terms of [Field](../classes/
 
 #### Defined in
 
-[snarky.d.ts:124](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L124)
+[snarky.d.ts:132](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L132)

--- a/docs/zkapps/o1js-reference/modules.md
+++ b/docs/zkapps/o1js-reference/modules.md
@@ -9,10 +9,12 @@
 - [Encoding](modules/Encoding.md)
 - [Encryption](modules/Encryption.md)
 - [Experimental](modules/Experimental.md)
+- [Lightnet](modules/Lightnet.md)
 - [Mina](modules/Mina.md)
 - [Pickles](modules/Pickles.md)
 - [Snarky](modules/Snarky.md)
 - [Types](modules/Types.md)
+- [ZkProgram](modules/ZkProgram.md)
 
 ### Enumerations
 
@@ -61,16 +63,19 @@
 - [ConstantField](modules.md#constantfield)
 - [DeployArgs](modules.md#deployargs)
 - [Empty](modules.md#empty)
+- [FeatureFlags](modules.md#featureflags)
 - [Field](modules.md#field)
 - [FieldConst](modules.md#fieldconst)
 - [FieldVar](modules.md#fieldvar)
 - [FlexibleProvable](modules.md#flexibleprovable)
 - [FlexibleProvablePure](modules.md#flexibleprovablepure)
 - [Gate](modules.md#gate)
+- [GateType](modules.md#gatetype)
 - [Group](modules.md#group)
 - [InferProvable](modules.md#inferprovable)
 - [JsonGate](modules.md#jsongate)
 - [JsonProof](modules.md#jsonproof)
+- [MlFeatureFlags](modules.md#mlfeatureflags)
 - [MlPublicKey](modules.md#mlpublickey)
 - [MlPublicKeyVar](modules.md#mlpublickeyvar)
 - [Provable](modules.md#provable)
@@ -88,6 +93,7 @@
 - [Empty](modules.md#empty-1)
 - [FieldConst](modules.md#fieldconst-1)
 - [FieldVar](modules.md#fieldvar-1)
+- [Gadgets](modules.md#gadgets)
 - [Permissions](modules.md#permissions)
 - [Pickles](modules.md#pickles)
 - [Poseidon](modules.md#poseidon)
@@ -110,6 +116,7 @@
 - [Reducer](modules.md#reducer-1)
 - [State](modules.md#state-1)
 - [Struct](modules.md#struct-1)
+- [ZkProgram](modules.md#zkprogram)
 - [addCachedAccount](modules.md#addcachedaccount)
 - [arrayProp](modules.md#arrayprop)
 - [checkZkappTransaction](modules.md#checkzkapptransaction)
@@ -137,6 +144,7 @@
 - [shutdown](modules.md#shutdown)
 - [state](modules.md#state-2)
 - [toConstantField](modules.md#toconstantfield)
+- [toFp](modules.md#tofp)
 - [verify](modules.md#verify)
 - [withMessage](modules.md#withmessage)
 
@@ -148,9 +156,9 @@
 
 #### Defined in
 
-[lib/core.ts:70](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/core.ts#L70)
+[lib/core.ts:70](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/core.ts#L70)
 
-[lib/core.ts:71](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/core.ts#L71)
+[lib/core.ts:71](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/core.ts#L71)
 
 ___
 
@@ -160,7 +168,7 @@ ___
 
 #### Defined in
 
-[lib/bool.ts:17](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L17)
+[lib/bool.ts:17](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L17)
 
 ___
 
@@ -170,7 +178,7 @@ ___
 
 #### Defined in
 
-[lib/field.ts:96](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L96)
+[lib/field.ts:94](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L94)
 
 ___
 
@@ -180,7 +188,7 @@ ___
 
 #### Defined in
 
-[lib/zkapp.ts:1505](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L1505)
+[lib/zkapp.ts:1507](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L1507)
 
 ___
 
@@ -190,9 +198,32 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:60](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L60)
+[lib/proof_system.ts:68](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L68)
 
-[lib/proof_system.ts:61](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L61)
+[lib/proof_system.ts:69](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L69)
+
+___
+
+### FeatureFlags
+
+Ƭ **FeatureFlags**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `foreignFieldAdd` | `boolean` |
+| `foreignFieldMul` | `boolean` |
+| `lookup` | `boolean` |
+| `rangeCheck0` | `boolean` |
+| `rangeCheck1` | `boolean` |
+| `rot` | `boolean` |
+| `runtimeTables` | `boolean` |
+| `xor` | `boolean` |
+
+#### Defined in
+
+[snarky.d.ts:578](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L578)
 
 ___
 
@@ -202,21 +233,21 @@ ___
 
 #### Defined in
 
-[lib/core.ts:42](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/core.ts#L42)
+[lib/core.ts:42](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/core.ts#L42)
 
-[lib/core.ts:43](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/core.ts#L43)
+[lib/core.ts:43](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/core.ts#L43)
 
 ___
 
 ### FieldConst
 
-Ƭ **FieldConst**: `Uint8Array`
+Ƭ **FieldConst**: [``0``, `bigint`]
 
 #### Defined in
 
-[lib/field.ts:24](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L24)
+[lib/field.ts:25](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L25)
 
-[lib/field.ts:33](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L33)
+[lib/field.ts:34](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L34)
 
 ___
 
@@ -238,9 +269,9 @@ Both constants and variables can be combined into an AST using the Add and Scale
 
 #### Defined in
 
-[lib/field.ts:67](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L67)
+[lib/field.ts:65](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L65)
 
-[lib/field.ts:75](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L75)
+[lib/field.ts:73](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L73)
 
 ___
 
@@ -256,7 +287,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:62](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L62)
+[lib/circuit_value.ts:62](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L62)
 
 ___
 
@@ -272,7 +303,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:63](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L63)
+[lib/circuit_value.ts:63](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L63)
 
 ___
 
@@ -285,12 +316,22 @@ ___
 | Name | Type |
 | :------ | :------ |
 | `coeffs` | `string`[] |
-| `type` | `string` |
+| `type` | [`GateType`](modules.md#gatetype) |
 | `wires` | { `col`: `number` ; `row`: `number`  }[] |
 
 #### Defined in
 
-[snarky.d.ts:367](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L367)
+[snarky.d.ts:447](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L447)
+
+___
+
+### GateType
+
+Ƭ **GateType**: ``"Zero"`` \| ``"Generic"`` \| ``"Poseidon"`` \| ``"CompleteAdd"`` \| ``"VarbaseMul"`` \| ``"EndoMul"`` \| ``"EndoMulScalar"`` \| ``"Lookup"`` \| ``"RangeCheck0"`` \| ``"RangeCheck1"`` \| ``"ForeignFieldAdd"`` \| ``"ForeignFieldMul"`` \| ``"Xor16"`` \| ``"Rot64"``
+
+#### Defined in
+
+[snarky.d.ts:424](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L424)
 
 ___
 
@@ -300,9 +341,9 @@ ___
 
 #### Defined in
 
-[lib/core.ts:76](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/core.ts#L76)
+[lib/core.ts:76](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/core.ts#L76)
 
-[lib/core.ts:77](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/core.ts#L77)
+[lib/core.ts:77](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/core.ts#L77)
 
 ___
 
@@ -318,7 +359,7 @@ ___
 
 #### Defined in
 
-bindings/lib/provable-snarky.ts:277
+bindings/lib/provable-snarky.ts:274
 
 ___
 
@@ -330,13 +371,13 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `coeffs` | `number`[][] |
-| `typ` | `string` |
+| `coeffs` | `string`[] |
+| `typ` | [`GateType`](modules.md#gatetype) |
 | `wires` | { `col`: `number` ; `row`: `number`  }[] |
 
 #### Defined in
 
-[snarky.d.ts:360](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L360)
+[snarky.d.ts:440](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L440)
 
 ___
 
@@ -355,7 +396,17 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:171](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L171)
+[lib/proof_system.ts:215](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L215)
+
+___
+
+### MlFeatureFlags
+
+Ƭ **MlFeatureFlags**: [\_: 0, rangeCheck0: MlBool, rangeCheck1: MlBool, foreignFieldAdd: MlBool, foreignFieldMul: MlBool, xor: MlBool, rot: MlBool, lookup: MlBool, runtimeTables: MlBool]
+
+#### Defined in
+
+[snarky.d.ts:589](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L589)
 
 ___
 
@@ -365,7 +416,7 @@ ___
 
 #### Defined in
 
-[snarky.d.ts:380](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L380)
+[snarky.d.ts:460](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L460)
 
 ___
 
@@ -375,7 +426,7 @@ ___
 
 #### Defined in
 
-[snarky.d.ts:381](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L381)
+[snarky.d.ts:461](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L461)
 
 ___
 
@@ -395,9 +446,9 @@ You will find this as the required input type in a few places in o1js. One conve
 
 #### Defined in
 
-[lib/provable.ts:45](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/provable.ts#L45)
+[lib/provable.ts:45](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/provable.ts#L45)
 
-[lib/provable.ts:47](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/provable.ts#L47)
+[lib/provable.ts:47](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/provable.ts#L47)
 
 ___
 
@@ -414,7 +465,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:52](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L52)
+[lib/circuit_value.ts:52](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L52)
 
 ___
 
@@ -436,9 +487,9 @@ ___
 
 #### Defined in
 
-[lib/zkapp.ts:1233](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L1233)
+[lib/zkapp.ts:1235](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L1235)
 
-[lib/zkapp.ts:1552](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L1552)
+[lib/zkapp.ts:1554](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L1554)
 
 ___
 
@@ -468,9 +519,9 @@ Gettable and settable state that can be checked for equality.
 
 #### Defined in
 
-[lib/state.ts:73](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/state.ts#L73)
+[lib/state.ts:73](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/state.ts#L73)
 
-[lib/state.ts:20](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/state.ts#L20)
+[lib/state.ts:20](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/state.ts#L20)
 
 ___
 
@@ -486,9 +537,9 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:359](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L359)
+[lib/circuit_value.ts:359](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L359)
 
-[lib/circuit_value.ts:57](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L57)
+[lib/circuit_value.ts:57](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L57)
 
 ___
 
@@ -504,7 +555,7 @@ UNKNOWN: The transaction has either been snarked, reached finality through conse
 
 #### Defined in
 
-[lib/fetch.ts:650](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/fetch.ts#L650)
+[lib/fetch.ts:668](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/fetch.ts#L668)
 
 ___
 
@@ -514,9 +565,9 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:57](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L57)
+[lib/proof_system.ts:65](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L65)
 
-[lib/proof_system.ts:58](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L58)
+[lib/proof_system.ts:66](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L66)
 
 ___
 
@@ -526,9 +577,9 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:62](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L62)
+[lib/proof_system.ts:70](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L70)
 
-[lib/proof_system.ts:63](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L63)
+[lib/proof_system.ts:71](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L71)
 
 ___
 
@@ -558,9 +609,9 @@ transaction.
 
 #### Defined in
 
-[lib/account_update.ts:1967](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1967)
+[lib/account_update.ts:1961](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1961)
 
-[lib/account_update.ts:1971](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1971)
+[lib/account_update.ts:1965](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1965)
 
 ## Variables
 
@@ -570,9 +621,9 @@ transaction.
 
 #### Defined in
 
-[lib/proof_system.ts:60](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L60)
+[lib/proof_system.ts:68](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L68)
 
-[lib/proof_system.ts:61](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L61)
+[lib/proof_system.ts:69](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L69)
 
 ___
 
@@ -584,18 +635,18 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `-1` | `Uint8Array` |
-| `0` | `Uint8Array` |
-| `1` | `Uint8Array` |
-| `fromBigint` | (`x`: `bigint`) => `Uint8Array` |
-| `toBigint` | (`x`: `Uint8Array`) => `Fp` |
-| `equal` | (`x`: `Uint8Array`, `y`: `Uint8Array`) => `boolean` |
+| `-1` | [`FieldConst`](modules.md#fieldconst-1) |
+| `0` | [`FieldConst`](modules.md#fieldconst-1) |
+| `1` | [`FieldConst`](modules.md#fieldconst-1) |
+| `fromBigint` | (`x`: `bigint`) => [`FieldConst`](modules.md#fieldconst-1) |
+| `toBigint` | (`x`: [`FieldConst`](modules.md#fieldconst-1)) => `Fp` |
+| `equal` | (`x`: [`FieldConst`](modules.md#fieldconst-1), `y`: [`FieldConst`](modules.md#fieldconst-1)) => `boolean` |
 
 #### Defined in
 
-[lib/field.ts:24](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L24)
+[lib/field.ts:25](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L25)
 
-[lib/field.ts:33](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L33)
+[lib/field.ts:34](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L34)
 
 ___
 
@@ -607,19 +658,37 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `-1` | [[`Constant`](enums/FieldType.md#constant), `Uint8Array`] |
-| `0` | [[`Constant`](enums/FieldType.md#constant), `Uint8Array`] |
-| `1` | [[`Constant`](enums/FieldType.md#constant), `Uint8Array`] |
+| `-1` | [[`Constant`](enums/FieldType.md#constant), [`FieldConst`](modules.md#fieldconst-1)] |
+| `0` | [[`Constant`](enums/FieldType.md#constant), [`FieldConst`](modules.md#fieldconst-1)] |
+| `1` | [[`Constant`](enums/FieldType.md#constant), [`FieldConst`](modules.md#fieldconst-1)] |
 | `add` | (`x`: [`FieldVar`](modules.md#fieldvar-1), `y`: [`FieldVar`](modules.md#fieldvar-1)) => [`FieldVar`](modules.md#fieldvar-1) |
-| `constant` | (`x`: `bigint` \| `Uint8Array`) => `ConstantFieldVar` |
+| `constant` | (`x`: `bigint` \| [`FieldConst`](modules.md#fieldconst-1)) => `ConstantFieldVar` |
 | `isConstant` | (`x`: [`FieldVar`](modules.md#fieldvar-1)) => x is ConstantFieldVar |
-| `scale` | (`c`: `Uint8Array`, `x`: [`FieldVar`](modules.md#fieldvar-1)) => [`FieldVar`](modules.md#fieldvar-1) |
+| `scale` | (`c`: [`FieldConst`](modules.md#fieldconst-1), `x`: [`FieldVar`](modules.md#fieldvar-1)) => [`FieldVar`](modules.md#fieldvar-1) |
 
 #### Defined in
 
-[lib/field.ts:67](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L67)
+[lib/field.ts:65](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L65)
 
-[lib/field.ts:75](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L75)
+[lib/field.ts:73](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L73)
+
+___
+
+### Gadgets
+
+• `Const` **Gadgets**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `rangeCheck64` | (`x`: [`Field`](classes/Field.md)) => `void` |
+| `rotate` | (`field`: [`Field`](classes/Field.md), `bits`: `number`, `direction`: ``"left"`` \| ``"right"``) => [`Field`](classes/Field.md) |
+| `xor` | (`a`: [`Field`](classes/Field.md), `b`: [`Field`](classes/Field.md), `length`: `number`) => [`Field`](classes/Field.md) |
+
+#### Defined in
+
+[lib/gadgets/gadgets.ts:10](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/gadgets/gadgets.ts#L10)
 
 ___
 
@@ -645,9 +714,9 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:166](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L166)
+[lib/account_update.ts:166](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L166)
 
-[lib/account_update.ts:238](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L238)
+[lib/account_update.ts:238](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L238)
 
 ___
 
@@ -659,19 +728,19 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `compile` | (`rules`: `MlArray`<[`Rule`](modules/Pickles.md#rule)\>, `signature`: { `publicInputSize`: `number` ; `publicOutputSize`: `number`  }) => { `getVerificationKey`: () => [\_: 0, data: string, hash: Uint8Array] ; `provers`: `MlArray`<[`Prover`](modules/Pickles.md#prover)\> ; `tag`: `unknown` ; `verify`: (`statement`: [`Statement`](modules/Pickles.md#statement)<`Uint8Array`\>, `proof`: `unknown`) => `Promise`<`boolean`\>  } |
-| `dummyBase64Proof` | () => `string` |
-| `dummyVerificationKey` | () => [\_: 0, data: string, hash: Uint8Array] |
-| `proofOfBase64` | (`base64`: `string`, `maxProofsVerified`: ``0`` \| ``2`` \| ``1``) => [``0`` \| ``2`` \| ``1``, `unknown`] |
+| `compile` | (`rules`: `MlArray`<[`Rule`](modules/Pickles.md#rule)\>, `signature`: { `overrideWrapDomain?`: ``0`` \| ``2`` \| ``1`` ; `publicInputSize`: `number` ; `publicOutputSize`: `number`  }) => { `getVerificationKey`: () => [\_: 0, data: string, hash: FieldConst] ; `provers`: `MlArray`<[`Prover`](modules/Pickles.md#prover)\> ; `tag`: `unknown` ; `verify`: (`statement`: [`Statement`](modules/Pickles.md#statement)<[`FieldConst`](modules.md#fieldconst-1)\>, `proof`: `unknown`) => `Promise`<`boolean`\>  } |
+| `dummyProof` | <N\>(`maxProofsVerified`: `N`, `domainLog2`: `number`) => [`N`, `unknown`] |
+| `dummyVerificationKey` | () => [\_: 0, data: string, hash: FieldConst] |
+| `proofOfBase64` | <N\>(`base64`: `string`, `maxProofsVerified`: `N`) => [`N`, `unknown`] |
 | `proofToBase64` | (`proof`: [``0`` \| ``2`` \| ``1``, `unknown`]) => `string` |
 | `proofToBase64Transaction` | (`proof`: `unknown`) => `string` |
-| `verify` | (`statement`: [`Statement`](modules/Pickles.md#statement)<`Uint8Array`\>, `proof`: `unknown`, `verificationKey`: `string`) => `Promise`<`boolean`\> |
+| `verify` | (`statement`: [`Statement`](modules/Pickles.md#statement)<[`FieldConst`](modules.md#fieldconst-1)\>, `proof`: `unknown`, `verificationKey`: `string`) => `Promise`<`boolean`\> |
 
 #### Defined in
 
-[snarky.d.ts:498](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L498)
+[snarky.d.ts:601](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L601)
 
-[snarky.d.ts:516](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L516)
+[snarky.d.ts:634](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L634)
 
 ___
 
@@ -691,7 +760,7 @@ ___
 
 #### Defined in
 
-[lib/hash.ts:42](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/hash.ts#L42)
+[lib/hash.ts:42](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/hash.ts#L42)
 
 ___
 
@@ -719,9 +788,9 @@ ___
 
 #### Defined in
 
-[lib/provable.ts:45](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/provable.ts#L45)
+[lib/provable.ts:45](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/provable.ts#L45)
 
-[lib/provable.ts:47](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/provable.ts#L47)
+[lib/provable.ts:47](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/provable.ts#L47)
 
 ___
 
@@ -743,14 +812,14 @@ Note for devs: This module is intended to closely mirror snarky-ml's core, low-l
 | `bool.equals` | [object Object] | - |
 | `bool.not` | [object Object] | - |
 | `bool.or` | [object Object] | - |
-| `circuit` | { `keypair`: { `getConstraintSystemJSON`: (`keypair`: `unknown`) => `JsonConstraintSystem` ; `getVerificationKey`: (`keypair`: `unknown`) => `unknown`  } ; `compile`: (`main`: [`Main`](modules/Snarky.md#main), `publicInputSize`: `number`) => `unknown` ; `prove`: (`main`: [`Main`](modules/Snarky.md#main), `publicInputSize`: `number`, `publicInput`: `MlArray`<`Uint8Array`\>, `keypair`: `unknown`) => `unknown` ; `verify`: (`publicInput`: `MlArray`<`Uint8Array`\>, `proof`: `unknown`, `verificationKey`: `unknown`) => `boolean`  } | The circuit API is a low level interface to create zero-knowledge proofs |
+| `circuit` | { `keypair`: { `getConstraintSystemJSON`: (`keypair`: `unknown`) => `JsonConstraintSystem` ; `getVerificationKey`: (`keypair`: `unknown`) => `unknown`  } ; `compile`: (`main`: [`Main`](modules/Snarky.md#main), `publicInputSize`: `number`) => `unknown` ; `prove`: (`main`: [`Main`](modules/Snarky.md#main), `publicInputSize`: `number`, `publicInput`: `MlArray`<[`FieldConst`](modules.md#fieldconst-1)\>, `keypair`: `unknown`) => `unknown` ; `verify`: (`publicInput`: `MlArray`<[`FieldConst`](modules.md#fieldconst-1)\>, `proof`: `unknown`, `verificationKey`: `unknown`) => `boolean`  } | The circuit API is a low level interface to create zero-knowledge proofs |
 | `circuit.keypair` | { `getConstraintSystemJSON`: (`keypair`: `unknown`) => `JsonConstraintSystem` ; `getVerificationKey`: (`keypair`: `unknown`) => `unknown`  } | - |
 | `circuit.keypair.getConstraintSystemJSON` | [object Object] | Returns a low-level JSON representation of the circuit: a list of gates, each of which represents a row in a table, with certain coefficients and wires to other (row, column) pairs |
 | `circuit.keypair.getVerificationKey` | [object Object] | - |
 | `circuit.compile` | [object Object] | Generates a proving key and a verification key for the provable function `main` |
 | `circuit.prove` | [object Object] | Proves a statement using the private input, public input and the keypair of the circuit. |
 | `circuit.verify` | [object Object] | Verifies a proof using the public input, the proof and the verification key of the circuit. |
-| `field` | { `add`: (`x`: [`FieldVar`](modules.md#fieldvar-1), `y`: [`FieldVar`](modules.md#fieldvar-1)) => [`FieldVar`](modules.md#fieldvar-1) ; `assertBoolean`: (`x`: [`FieldVar`](modules.md#fieldvar-1)) => `void` ; `assertEqual`: (`x`: [`FieldVar`](modules.md#fieldvar-1), `y`: [`FieldVar`](modules.md#fieldvar-1)) => `void` ; `assertMul`: (`x`: [`FieldVar`](modules.md#fieldvar-1), `y`: [`FieldVar`](modules.md#fieldvar-1), `z`: [`FieldVar`](modules.md#fieldvar-1)) => `void` ; `assertSquare`: (`x`: [`FieldVar`](modules.md#fieldvar-1), `y`: [`FieldVar`](modules.md#fieldvar-1)) => `void` ; `compare`: (`bitLength`: `number`, `x`: [`FieldVar`](modules.md#fieldvar-1), `y`: [`FieldVar`](modules.md#fieldvar-1)) => [\_: 0, less: FieldVar, lessOrEqual: FieldVar] ; `fromBits`: (`bits`: `MlArray`<[`FieldVar`](modules.md#fieldvar-1)\>) => [`FieldVar`](modules.md#fieldvar-1) ; `mul`: (`x`: [`FieldVar`](modules.md#fieldvar-1), `y`: [`FieldVar`](modules.md#fieldvar-1)) => [`FieldVar`](modules.md#fieldvar-1) ; `readVar`: (`x`: [`FieldVar`](modules.md#fieldvar-1)) => `Uint8Array` ; `scale`: (`c`: `Uint8Array`, `x`: [`FieldVar`](modules.md#fieldvar-1)) => [`FieldVar`](modules.md#fieldvar-1) ; `seal`: (`x`: [`FieldVar`](modules.md#fieldvar-1)) => [`FieldVar`](modules.md#fieldvar-1) ; `toBits`: (`length`: `number`, `x`: [`FieldVar`](modules.md#fieldvar-1)) => `MlArray`<[`FieldVar`](modules.md#fieldvar-1)\> ; `toConstantAndTerms`: (`x`: [`FieldVar`](modules.md#fieldvar-1)) => [\_: 0, constant: MlOption<Uint8Array\>, terms: MlList<MlTuple<Uint8Array, number\>\>] ; `truncateToBits16`: (`lengthDiv16`: `number`, `x`: [`FieldVar`](modules.md#fieldvar-1)) => [`FieldVar`](modules.md#fieldvar-1)  } | APIs to add constraints on field variables |
+| `field` | { `add`: (`x`: [`FieldVar`](modules.md#fieldvar-1), `y`: [`FieldVar`](modules.md#fieldvar-1)) => [`FieldVar`](modules.md#fieldvar-1) ; `assertBoolean`: (`x`: [`FieldVar`](modules.md#fieldvar-1)) => `void` ; `assertEqual`: (`x`: [`FieldVar`](modules.md#fieldvar-1), `y`: [`FieldVar`](modules.md#fieldvar-1)) => `void` ; `assertMul`: (`x`: [`FieldVar`](modules.md#fieldvar-1), `y`: [`FieldVar`](modules.md#fieldvar-1), `z`: [`FieldVar`](modules.md#fieldvar-1)) => `void` ; `assertSquare`: (`x`: [`FieldVar`](modules.md#fieldvar-1), `y`: [`FieldVar`](modules.md#fieldvar-1)) => `void` ; `compare`: (`bitLength`: `number`, `x`: [`FieldVar`](modules.md#fieldvar-1), `y`: [`FieldVar`](modules.md#fieldvar-1)) => [\_: 0, less: FieldVar, lessOrEqual: FieldVar] ; `fromBits`: (`bits`: `MlArray`<[`FieldVar`](modules.md#fieldvar-1)\>) => [`FieldVar`](modules.md#fieldvar-1) ; `mul`: (`x`: [`FieldVar`](modules.md#fieldvar-1), `y`: [`FieldVar`](modules.md#fieldvar-1)) => [`FieldVar`](modules.md#fieldvar-1) ; `readVar`: (`x`: [`FieldVar`](modules.md#fieldvar-1)) => [`FieldConst`](modules.md#fieldconst-1) ; `scale`: (`c`: [`FieldConst`](modules.md#fieldconst-1), `x`: [`FieldVar`](modules.md#fieldvar-1)) => [`FieldVar`](modules.md#fieldvar-1) ; `seal`: (`x`: [`FieldVar`](modules.md#fieldvar-1)) => [`FieldVar`](modules.md#fieldvar-1) ; `toBits`: (`length`: `number`, `x`: [`FieldVar`](modules.md#fieldvar-1)) => `MlArray`<[`FieldVar`](modules.md#fieldvar-1)\> ; `toConstantAndTerms`: (`x`: [`FieldVar`](modules.md#fieldvar-1)) => [\_: 0, constant: MlOption<FieldConst\>, terms: MlList<MlTuple<FieldConst, number\>\>] ; `truncateToBits16`: (`lengthDiv16`: `number`, `x`: [`FieldVar`](modules.md#fieldvar-1)) => [`FieldVar`](modules.md#fieldvar-1)  } | APIs to add constraints on field variables |
 | `field.add` | [object Object] | add x, y to get a new AST node Add(x, y); handles if x, y are constants |
 | `field.assertBoolean` | [object Object] | x*x === x without handling of constants |
 | `field.assertEqual` | [object Object] | x === y without handling of constants |
@@ -765,6 +834,11 @@ Note for devs: This module is intended to closely mirror snarky-ml's core, low-l
 | `field.toBits` | [object Object] |  |
 | `field.toConstantAndTerms` | [object Object] | Unfolds AST to get `x = c + c0*Var(i0) + ... + cn*Var(in)`, returns `(c, [(c0, i0), ..., (cn, in)])`; c is optional |
 | `field.truncateToBits16` | [object Object] | returns x truncated to the lowest `16 * lengthDiv16` bits => can be used to assert that x fits in `16 * lengthDiv16` bits. more efficient than `toBits()` because it uses the EC_endoscalar gate; does 16 bits per row (vs 1 bits per row that you can do with generic gates). |
+| `gates` | { `rangeCheck0`: (`v0`: [`FieldVar`](modules.md#fieldvar-1), `v0p`: [``0``, [`FieldVar`](modules.md#fieldvar-1), [`FieldVar`](modules.md#fieldvar-1), [`FieldVar`](modules.md#fieldvar-1), [`FieldVar`](modules.md#fieldvar-1), [`FieldVar`](modules.md#fieldvar-1), [`FieldVar`](modules.md#fieldvar-1)], `v0c`: [``0``, [`FieldVar`](modules.md#fieldvar-1), [`FieldVar`](modules.md#fieldvar-1), [`FieldVar`](modules.md#fieldvar-1), [`FieldVar`](modules.md#fieldvar-1), [`FieldVar`](modules.md#fieldvar-1), [`FieldVar`](modules.md#fieldvar-1), [`FieldVar`](modules.md#fieldvar-1), [`FieldVar`](modules.md#fieldvar-1)], `compact`: [`FieldConst`](modules.md#fieldconst-1)) => `void` ; `rotate`: (`field`: [`FieldVar`](modules.md#fieldvar-1), `rotated`: [`FieldVar`](modules.md#fieldvar-1), `excess`: [`FieldVar`](modules.md#fieldvar-1), `limbs`: `MlArray`<[`FieldVar`](modules.md#fieldvar-1)\>, `crumbs`: `MlArray`<[`FieldVar`](modules.md#fieldvar-1)\>, `two_to_rot`: [`FieldConst`](modules.md#fieldconst-1)) => `void` ; `xor`: (`in1`: [`FieldVar`](modules.md#fieldvar-1), `in2`: [`FieldVar`](modules.md#fieldvar-1), `out`: [`FieldVar`](modules.md#fieldvar-1), `in1_0`: [`FieldVar`](modules.md#fieldvar-1), `in1_1`: [`FieldVar`](modules.md#fieldvar-1), `in1_2`: [`FieldVar`](modules.md#fieldvar-1), `in1_3`: [`FieldVar`](modules.md#fieldvar-1), `in2_0`: [`FieldVar`](modules.md#fieldvar-1), `in2_1`: [`FieldVar`](modules.md#fieldvar-1), `in2_2`: [`FieldVar`](modules.md#fieldvar-1), `in2_3`: [`FieldVar`](modules.md#fieldvar-1), `out_0`: [`FieldVar`](modules.md#fieldvar-1), `out_1`: [`FieldVar`](modules.md#fieldvar-1), `out_2`: [`FieldVar`](modules.md#fieldvar-1), `out_3`: [`FieldVar`](modules.md#fieldvar-1)) => `void` ; `zero`: (`in1`: [`FieldVar`](modules.md#fieldvar-1), `in2`: [`FieldVar`](modules.md#fieldvar-1), `out`: [`FieldVar`](modules.md#fieldvar-1)) => `void`  } | - |
+| `gates.rangeCheck0` | [object Object] | Range check gate |
+| `gates.rotate` | [object Object] | - |
+| `gates.xor` | [object Object] | - |
+| `gates.zero` | [object Object] | - |
 | `group` | { `ecadd`: (`p1`: `MlGroup`, `p2`: `MlGroup`, `p3`: `MlGroup`, `inf`: [`FieldVar`](modules.md#fieldvar-1), `same_x`: [`FieldVar`](modules.md#fieldvar-1), `slope`: [`FieldVar`](modules.md#fieldvar-1), `inf_z`: [`FieldVar`](modules.md#fieldvar-1), `x21_inv`: [`FieldVar`](modules.md#fieldvar-1)) => `MlGroup` ; `scale`: (`p`: `MlGroup`, `s`: `MlArray`<[`FieldVar`](modules.md#fieldvar-1)\>) => `MlGroup`  } | - |
 | `group.ecadd` | [object Object] | Low-level Elliptic Curve Addition gate. |
 | `group.scale` | [object Object] | - |
@@ -781,14 +855,14 @@ Note for devs: This module is intended to closely mirror snarky-ml's core, low-l
 | `run.inProverBlock` | [object Object] | Check whether we are inside an asProver or exists block |
 | `run.runAndCheck` | [object Object] | Runs code and checks its correctness. |
 | `run.runUnchecked` | [object Object] | Runs code in prover mode, without checking correctness. |
-| `exists` | (`sizeInFields`: `number`, `compute`: () => `MlArray`<`Uint8Array`\>) => `MlArray`<[`FieldVar`](modules.md#fieldvar-1)\> | witness `sizeInFields` field element variables Note: this is called "exists" because in a proof, you use it like this: > "I prove that there exists x, such that (some statement)" |
-| `existsVar` | (`compute`: () => `Uint8Array`) => [`FieldVar`](modules.md#fieldvar-1) | witness a single field element variable |
+| `exists` | (`sizeInFields`: `number`, `compute`: () => `MlArray`<[`FieldConst`](modules.md#fieldconst-1)\>) => `MlArray`<[`FieldVar`](modules.md#fieldvar-1)\> | witness `sizeInFields` field element variables Note: this is called "exists" because in a proof, you use it like this: > "I prove that there exists x, such that (some statement)" |
+| `existsVar` | (`compute`: () => [`FieldConst`](modules.md#fieldconst-1)) => [`FieldVar`](modules.md#fieldvar-1) | witness a single field element variable |
 
 #### Defined in
 
-[snarky.d.ts:139](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L139)
+[snarky.d.ts:147](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L147)
 
-[snarky.d.ts:151](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L151)
+[snarky.d.ts:159](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L159)
 
 ___
 
@@ -800,7 +874,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `encoding` | { `memoHashBase58`: (`memoBase58`: `string`) => `Uint8Array` ; `memoToBase58`: (`memoString`: `string`) => `string` ; `ofBase58`: (`base58`: `string`, `versionByte`: `number`) => `MlBytes` ; `privateKeyOfBase58`: (`privateKeyBase58`: `string`) => `Uint8Array` ; `privateKeyToBase58`: (`privateKey`: `Uint8Array`) => `string` ; `publicKeyOfBase58`: (`publicKeyBase58`: `string`) => [`MlPublicKey`](modules.md#mlpublickey) ; `publicKeyToBase58`: (`publicKey`: [`MlPublicKey`](modules.md#mlpublickey)) => `string` ; `toBase58`: (`s`: `MlBytes`, `versionByte`: `number`) => `string` ; `tokenIdOfBase58`: (`fieldBase58`: `string`) => `Uint8Array` ; `tokenIdToBase58`: (`field`: `Uint8Array`) => `string`  } |
+| `encoding` | { `memoHashBase58`: (`memoBase58`: `string`) => [`FieldConst`](modules.md#fieldconst-1) ; `memoToBase58`: (`memoString`: `string`) => `string` ; `ofBase58`: (`base58`: `string`, `versionByte`: `number`) => `MlBytes` ; `privateKeyOfBase58`: (`privateKeyBase58`: `string`) => `ScalarConst` ; `privateKeyToBase58`: (`privateKey`: `ScalarConst`) => `string` ; `publicKeyOfBase58`: (`publicKeyBase58`: `string`) => [`MlPublicKey`](modules.md#mlpublickey) ; `publicKeyToBase58`: (`publicKey`: [`MlPublicKey`](modules.md#mlpublickey)) => `string` ; `toBase58`: (`s`: `MlBytes`, `versionByte`: `number`) => `string` ; `tokenIdOfBase58`: (`fieldBase58`: `string`) => [`FieldConst`](modules.md#fieldconst-1) ; `tokenIdToBase58`: (`field`: [`FieldConst`](modules.md#fieldconst-1)) => `string`  } |
 | `encoding.memoHashBase58` | [object Object] |
 | `encoding.memoToBase58` | [object Object] |
 | `encoding.ofBase58` | [object Object] |
@@ -811,13 +885,13 @@ ___
 | `encoding.toBase58` | [object Object] |
 | `encoding.tokenIdOfBase58` | [object Object] |
 | `encoding.tokenIdToBase58` | [object Object] |
-| `fieldsFromJson` | { `accountUpdate`: (`json`: `string`) => `MlArray`<`Uint8Array`\>  } |
+| `fieldsFromJson` | { `accountUpdate`: (`json`: `string`) => `MlArray`<[`FieldConst`](modules.md#fieldconst-1)\>  } |
 | `fieldsFromJson.accountUpdate` | [object Object] |
-| `hashFromJson` | { `accountUpdate`: (`json`: `string`) => `Uint8Array` ; `transactionCommitments`: (`txJson`: `string`) => { `commitment`: [`FieldConst`](modules.md#fieldconst-1) ; `feePayerHash`: [`FieldConst`](modules.md#fieldconst-1) ; `fullCommitment`: [`FieldConst`](modules.md#fieldconst-1)  } ; `zkappPublicInput`: (`txJson`: `string`, `accountUpdateIndex`: `number`) => { `accountUpdate`: [`FieldConst`](modules.md#fieldconst-1) ; `calls`: [`FieldConst`](modules.md#fieldconst-1)  }  } |
+| `hashFromJson` | { `accountUpdate`: (`json`: `string`) => [`FieldConst`](modules.md#fieldconst-1) ; `transactionCommitments`: (`txJson`: `string`) => { `commitment`: [`FieldConst`](modules.md#fieldconst-1) ; `feePayerHash`: [`FieldConst`](modules.md#fieldconst-1) ; `fullCommitment`: [`FieldConst`](modules.md#fieldconst-1)  } ; `zkappPublicInput`: (`txJson`: `string`, `accountUpdateIndex`: `number`) => { `accountUpdate`: [`FieldConst`](modules.md#fieldconst-1) ; `calls`: [`FieldConst`](modules.md#fieldconst-1)  }  } |
 | `hashFromJson.accountUpdate` | [object Object] |
 | `hashFromJson.transactionCommitments` | [object Object] |
 | `hashFromJson.zkappPublicInput` | [object Object] |
-| `hashInputFromJson` | { `accountPrecondition`: (`json`: `String`) => `MlHashInput` ; `body`: (`json`: `String`) => `MlHashInput` ; `networkPrecondition`: (`json`: `String`) => `MlHashInput` ; `packInput`: (`input`: `MlHashInput`) => `MlArray`<`Uint8Array`\> ; `permissions`: (`json`: `String`) => `MlHashInput` ; `timing`: (`json`: `String`) => `MlHashInput` ; `update`: (`json`: `String`) => `MlHashInput`  } |
+| `hashInputFromJson` | { `accountPrecondition`: (`json`: `String`) => `MlHashInput` ; `body`: (`json`: `String`) => `MlHashInput` ; `networkPrecondition`: (`json`: `String`) => `MlHashInput` ; `packInput`: (`input`: `MlHashInput`) => `MlArray`<[`FieldConst`](modules.md#fieldconst-1)\> ; `permissions`: (`json`: `String`) => `MlHashInput` ; `timing`: (`json`: `String`) => `MlHashInput` ; `update`: (`json`: `String`) => `MlHashInput`  } |
 | `hashInputFromJson.accountPrecondition` | [object Object] |
 | `hashInputFromJson.body` | [object Object] |
 | `hashInputFromJson.networkPrecondition` | [object Object] |
@@ -825,12 +899,12 @@ ___
 | `hashInputFromJson.permissions` | [object Object] |
 | `hashInputFromJson.timing` | [object Object] |
 | `hashInputFromJson.update` | [object Object] |
-| `poseidon` | { `hashToGroup`: (`input`: `MlArray`<`Uint8Array`\>) => `MlTuple`<`Uint8Array`, `Uint8Array`\>  } |
+| `poseidon` | { `hashToGroup`: (`input`: `MlArray`<[`FieldConst`](modules.md#fieldconst-1)\>) => `MlTuple`<[`FieldConst`](modules.md#fieldconst-1), [`FieldConst`](modules.md#fieldconst-1)\>  } |
 | `poseidon.hashToGroup` | [object Object] |
-| `signature` | { `dummySignature`: () => `string` ; `signFieldElement`: (`messageHash`: `Uint8Array`, `privateKey`: `Uint8Array`, `isMainnet`: `boolean`) => `string`  } |
+| `signature` | { `dummySignature`: () => `string` ; `signFieldElement`: (`messageHash`: [`FieldConst`](modules.md#fieldconst-1), `privateKey`: `ScalarConst`, `isMainnet`: `boolean`) => `string`  } |
 | `signature.dummySignature` | [object Object] |
 | `signature.signFieldElement` | [object Object] |
-| `tokenId` | { `derive`: (`publicKey`: [`MlPublicKey`](modules.md#mlpublickey), `tokenId`: `Uint8Array`) => `Uint8Array` ; `deriveChecked`: (`publicKey`: [`MlPublicKeyVar`](modules.md#mlpublickeyvar), `tokenId`: [`FieldVar`](modules.md#fieldvar-1)) => [`FieldVar`](modules.md#fieldvar-1)  } |
+| `tokenId` | { `derive`: (`publicKey`: [`MlPublicKey`](modules.md#mlpublickey), `tokenId`: [`FieldConst`](modules.md#fieldconst-1)) => [`FieldConst`](modules.md#fieldconst-1) ; `deriveChecked`: (`publicKey`: [`MlPublicKeyVar`](modules.md#mlpublickeyvar), `tokenId`: [`FieldVar`](modules.md#fieldvar-1)) => [`FieldVar`](modules.md#fieldvar-1)  } |
 | `tokenId.derive` | [object Object] |
 | `tokenId.deriveChecked` | [object Object] |
 | `transactionHash` | { `examplePayment`: () => `string` ; `hashPayment`: (`payment`: `string`) => `string` ; `hashPaymentV1`: (`payment`: `string`) => `string` ; `serializeCommon`: (`common`: `string`) => { `data`: `Uint8Array`  } ; `serializePayment`: (`payment`: `string`) => { `data`: `Uint8Array`  } ; `serializePaymentV1`: (`payment`: `string`) => `string`  } |
@@ -843,7 +917,7 @@ ___
 
 #### Defined in
 
-[snarky.d.ts:415](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L415)
+[snarky.d.ts:495](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L495)
 
 ___
 
@@ -871,7 +945,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:610](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L610)
+[lib/account_update.ts:607](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L607)
 
 ___
 
@@ -881,9 +955,9 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:57](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L57)
+[lib/proof_system.ts:65](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L65)
 
-[lib/proof_system.ts:58](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L58)
+[lib/proof_system.ts:66](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L66)
 
 ___
 
@@ -893,9 +967,9 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:62](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L62)
+[lib/proof_system.ts:70](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L70)
 
-[lib/proof_system.ts:63](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L63)
+[lib/proof_system.ts:71](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L71)
 
 ___
 
@@ -905,9 +979,9 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1967](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1967)
+[lib/account_update.ts:1961](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1961)
 
-[lib/account_update.ts:1971](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1971)
+[lib/account_update.ts:1965](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1965)
 
 ___
 
@@ -921,7 +995,7 @@ ___
 
 #### Defined in
 
-[index.ts:113](https://github.com/o1-labs/o1js/blob/fec4d35f/src/index.ts#L113)
+[index.ts:119](https://github.com/o1-labs/o1js/blob/42a18c8d/src/index.ts#L119)
 
 ## Functions
 
@@ -942,7 +1016,7 @@ ___
 
 #### Defined in
 
-[lib/zkapp.ts:1512](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L1512)
+[lib/zkapp.ts:1514](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L1514)
 
 ___
 
@@ -988,7 +1062,7 @@ const b: Bool = Field(5).equals(6);
 
 #### Defined in
 
-[lib/core.ts:81](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/core.ts#L81)
+[lib/core.ts:81](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/core.ts#L81)
 
 ___
 
@@ -1033,7 +1107,7 @@ A Field itself is also defined as a "field-like" element.
 
 | Name | Type |
 | :------ | :------ |
-| `...args` | [x: string \| number \| bigint \| Uint8Array \| FieldVar \| Field] |
+| `...args` | [x: string \| number \| bigint \| FieldVar \| FieldConst \| Field] |
 
 #### Returns
 
@@ -1043,7 +1117,7 @@ A [Field](modules.md#field-1) with the value converted from the argument
 
 #### Defined in
 
-[lib/core.ts:81](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/core.ts#L81)
+[lib/core.ts:81](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/core.ts#L81)
 
 ___
 
@@ -1065,7 +1139,7 @@ An element of a Group.
 
 #### Defined in
 
-[lib/core.ts:81](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/core.ts#L81)
+[lib/core.ts:81](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/core.ts#L81)
 
 ___
 
@@ -1089,7 +1163,7 @@ A circuit-compatible Merkle Witness.
 
 #### Defined in
 
-[lib/merkle_tree.ts:238](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/merkle_tree.ts#L238)
+[lib/merkle_tree.ts:238](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/merkle_tree.ts#L238)
 
 ___
 
@@ -1117,7 +1191,7 @@ ___
 
 #### Defined in
 
-[lib/zkapp.ts:1552](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L1552)
+[lib/zkapp.ts:1554](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L1554)
 
 ___
 
@@ -1137,13 +1211,13 @@ ___
 
 #### Defined in
 
-[lib/state.ts:73](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/state.ts#L73)
+[lib/state.ts:73](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/state.ts#L73)
 
 ___
 
 ### Struct
 
-▸ **Struct**<`A`, `T`, `J`, `Pure`\>(`type`, `options?`): (`value`: `T`) => `T` & { `_isStruct`: ``true``  } & `Pure` extends ``true`` ? [`ProvablePure`](interfaces/ProvablePure.md)<`T`\> : [`Provable`](modules.md#provable-1)<`T`\> & { `fromJSON`: (`x`: `J`) => `T` ; `toInput`: (`x`: `T`) => { `fields?`: [`Field`](modules.md#field-1)[] ; `packed?`: [[`Field`](modules.md#field-1), `number`][]  } ; `toJSON`: (`x`: `T`) => `J`  }
+▸ **Struct**<`A`, `T`, `J`, `Pure`\>(`type`): (`value`: `T`) => `T` & { `_isStruct`: ``true``  } & `Pure` extends ``true`` ? [`ProvablePure`](interfaces/ProvablePure.md)<`T`\> : [`Provable`](modules.md#provable-1)<`T`\> & { `fromJSON`: (`x`: `J`) => `T` ; `toInput`: (`x`: `T`) => { `fields?`: [`Field`](modules.md#field-1)[] ; `packed?`: [[`Field`](modules.md#field-1), `number`][]  } ; `toJSON`: (`x`: `T`) => `J`  }
 
 `Struct` lets you declare composite types for use in o1js circuits.
 
@@ -1224,8 +1298,6 @@ From the circuit point of view, it simply doesn't exist!
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `type` | `A` | Object specifying the layout of the `Struct` |
-| `options` | `Object` | Advanced option which allows you to force a certain order of object keys |
-| `options.customObjectKeys?` | `string`[] | - |
 
 #### Returns
 
@@ -1235,7 +1307,34 @@ Class which you can extend
 
 #### Defined in
 
-[lib/circuit_value.ts:359](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L359)
+[lib/circuit_value.ts:359](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L359)
+
+___
+
+### ZkProgram
+
+▸ **ZkProgram**<`StatementType`, `Types`\>(`config`): { `analyzeMethods`: () => `ReturnType`<typeof `analyzeMethod`\>[] ; `compile`: () => `Promise`<{ `verificationKey`: `string`  }\> ; `digest`: () => `string` ; `name`: `string` ; `publicInputType`: `ProvableOrUndefined`<`Get`<`StatementType`, ``"publicInput"``\>\> ; `publicOutputType`: `ProvableOrVoid`<`Get`<`StatementType`, ``"publicOutput"``\>\> ; `verify`: (`proof`: [`Proof`](classes/Proof.md)<`InferProvableOrUndefined`<`Get`<`StatementType`, ``"publicInput"``\>\>, `InferProvableOrVoid`<`Get`<`StatementType`, ``"publicOutput"``\>\>\>) => `Promise`<`boolean`\>  } & { [I in keyof Types]: Prover<InferProvableOrUndefined<Get<StatementType, "publicInput"\>\>, InferProvableOrVoid<Get<StatementType, "publicOutput"\>\>, Types[I]\> }
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `StatementType` | extends `Object` |
+| `Types` | extends `Object` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `config` | `StatementType` & { `methods`: { [I in string \| number \| symbol]: Method<InferProvableOrUndefined<Get<StatementType, "publicInput"\>\>, InferProvableOrVoid<Get<StatementType, "publicOutput"\>\>, Types[I]\> } ; `name`: `string` ; `overrideWrapDomain?`: ``0`` \| ``2`` \| ``1``  } |
+
+#### Returns
+
+{ `analyzeMethods`: () => `ReturnType`<typeof `analyzeMethod`\>[] ; `compile`: () => `Promise`<{ `verificationKey`: `string`  }\> ; `digest`: () => `string` ; `name`: `string` ; `publicInputType`: `ProvableOrUndefined`<`Get`<`StatementType`, ``"publicInput"``\>\> ; `publicOutputType`: `ProvableOrVoid`<`Get`<`StatementType`, ``"publicOutput"``\>\> ; `verify`: (`proof`: [`Proof`](classes/Proof.md)<`InferProvableOrUndefined`<`Get`<`StatementType`, ``"publicInput"``\>\>, `InferProvableOrVoid`<`Get`<`StatementType`, ``"publicOutput"``\>\>\>) => `Promise`<`boolean`\>  } & { [I in keyof Types]: Prover<InferProvableOrUndefined<Get<StatementType, "publicInput"\>\>, InferProvableOrVoid<Get<StatementType, "publicOutput"\>\>, Types[I]\> }
+
+#### Defined in
+
+[lib/proof_system.ts:233](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L233)
 
 ___
 
@@ -1258,7 +1357,7 @@ Adds an account to the local cache, indexed by a GraphQL endpoint.
 
 #### Defined in
 
-[lib/fetch.ts:351](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/fetch.ts#L351)
+[lib/fetch.ts:369](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/fetch.ts#L369)
 
 ___
 
@@ -1298,7 +1397,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:264](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L264)
+[lib/circuit_value.ts:264](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L264)
 
 ___
 
@@ -1318,7 +1417,7 @@ ___
 
 #### Defined in
 
-[lib/fetch.ts:498](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/fetch.ts#L498)
+[lib/fetch.ts:516](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/fetch.ts#L516)
 
 ___
 
@@ -1340,7 +1439,7 @@ ___
 
 #### Defined in
 
-[lib/circuit.ts:232](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L232)
+[lib/circuit.ts:232](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L232)
 
 ___
 
@@ -1382,7 +1481,7 @@ Note that a method of the same name must still be defined on the class, just wit
 
 #### Defined in
 
-[lib/zkapp.ts:1538](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L1538)
+[lib/zkapp.ts:1540](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L1540)
 
 ___
 
@@ -1442,7 +1541,7 @@ declareState(MyContract, { x: Field });
 
 #### Defined in
 
-[lib/state.ts:163](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/state.ts#L163)
+[lib/state.ts:163](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/state.ts#L163)
 
 ___
 
@@ -1476,7 +1575,7 @@ zkapp information on the specified account or an error is thrown
 
 #### Defined in
 
-[lib/fetch.ts:131](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/fetch.ts#L131)
+[lib/fetch.ts:149](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/fetch.ts#L149)
 
 ___
 
@@ -1518,7 +1617,7 @@ A promise that resolves to an array of objects containing event data, block info
 
 #### Defined in
 
-[lib/fetch.ts:820](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/fetch.ts#L820)
+[lib/fetch.ts:838](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/fetch.ts#L838)
 
 ___
 
@@ -1540,7 +1639,7 @@ Fetches the last block on the Mina network.
 
 #### Defined in
 
-[lib/fetch.ts:394](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/fetch.ts#L394)
+[lib/fetch.ts:412](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/fetch.ts#L412)
 
 ___
 
@@ -1563,7 +1662,7 @@ Fetches the status of a transaction.
 
 #### Defined in
 
-[lib/fetch.ts:625](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/fetch.ts#L625)
+[lib/fetch.ts:643](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/fetch.ts#L643)
 
 ___
 
@@ -1583,7 +1682,7 @@ ___
 
 #### Defined in
 
-[lib/bool.ts:371](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/bool.ts#L371)
+[lib/bool.ts:371](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/bool.ts#L371)
 
 ___
 
@@ -1603,7 +1702,7 @@ x is Field
 
 #### Defined in
 
-[lib/field.ts:1281](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1281)
+[lib/field.ts:1282](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1282)
 
 ___
 
@@ -1644,7 +1743,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:273](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L273)
+[lib/circuit_value.ts:273](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L273)
 
 ___
 
@@ -1665,7 +1764,7 @@ You can use inside your zkApp class as:
 
 | Name | Type |
 | :------ | :------ |
-| `T` | extends [`SmartContract`](classes/SmartContract.md)<`T`\> |
+| `T` | extends [`SmartContract`](classes/SmartContract.md) |
 
 #### Parameters
 
@@ -1681,7 +1780,7 @@ You can use inside your zkApp class as:
 
 #### Defined in
 
-[lib/zkapp.ts:84](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/zkapp.ts#L84)
+[lib/zkapp.ts:84](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/zkapp.ts#L84)
 
 ___
 
@@ -1703,7 +1802,7 @@ ___
 
 #### Defined in
 
-[lib/circuit_value.ts:249](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit_value.ts#L249)
+[lib/circuit_value.ts:249](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit_value.ts#L249)
 
 ___
 
@@ -1723,7 +1822,6 @@ ___
 | :------ | :------ |
 | `typeObj` | `A` |
 | `options?` | `Object` |
-| `options.customObjectKeys?` | `string`[] |
 | `options.isPure?` | `boolean` |
 
 #### Returns
@@ -1738,7 +1836,7 @@ ___
 
 ### provablePure
 
-▸ **provablePure**<`A`\>(`typeObj`, `options?`): [`ProvablePure`](interfaces/ProvablePure.md)<[`InferProvable`](modules.md#inferprovable)<`A`\>\> & `ProvableExtension`<[`InferProvable`](modules.md#inferprovable)<`A`\>, `InferJson`<`A`\>\>
+▸ **provablePure**<`A`\>(`typeObj`): [`ProvablePure`](interfaces/ProvablePure.md)<[`InferProvable`](modules.md#inferprovable)<`A`\>\> & `ProvableExtension`<[`InferProvable`](modules.md#inferprovable)<`A`\>, `InferJson`<`A`\>\>
 
 #### Type parameters
 
@@ -1751,8 +1849,6 @@ ___
 | Name | Type |
 | :------ | :------ |
 | `typeObj` | `A` |
-| `options` | `Object` |
-| `options.customObjectKeys?` | `string`[] |
 
 #### Returns
 
@@ -1760,7 +1856,7 @@ ___
 
 #### Defined in
 
-bindings/lib/provable-snarky.ts:224
+bindings/lib/provable-snarky.ts:222
 
 ___
 
@@ -1782,7 +1878,7 @@ ___
 
 #### Defined in
 
-[lib/circuit.ts:196](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/circuit.ts#L196)
+[lib/circuit.ts:196](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/circuit.ts#L196)
 
 ___
 
@@ -1804,7 +1900,7 @@ ___
 
 #### Defined in
 
-[lib/field.ts:1334](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1334)
+[lib/field.ts:1335](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1335)
 
 ___
 
@@ -1825,7 +1921,7 @@ ___
 
 #### Defined in
 
-[lib/signature.ts:301](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/signature.ts#L301)
+[lib/signature.ts:301](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/signature.ts#L301)
 
 ___
 
@@ -1850,7 +1946,7 @@ Sends a zkApp command (transaction) to the specified GraphQL endpoint.
 
 #### Defined in
 
-[lib/fetch.ts:655](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/fetch.ts#L655)
+[lib/fetch.ts:673](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/fetch.ts#L673)
 
 ___
 
@@ -1872,7 +1968,7 @@ Sets up a GraphQL endpoint to be used for fetching information from an Archive N
 
 #### Defined in
 
-[lib/fetch.ts:100](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/fetch.ts#L100)
+[lib/fetch.ts:104](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/fetch.ts#L104)
 
 ___
 
@@ -1892,7 +1988,7 @@ ___
 
 #### Defined in
 
-[lib/fetch.ts:78](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/fetch.ts#L78)
+[lib/fetch.ts:82](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/fetch.ts#L82)
 
 ___
 
@@ -1912,7 +2008,7 @@ ___
 
 #### Defined in
 
-[lib/fetch.ts:71](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/fetch.ts#L71)
+[lib/fetch.ts:75](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/fetch.ts#L75)
 
 ___
 
@@ -1930,7 +2026,7 @@ ___
 
 #### Defined in
 
-[index.ts:118](https://github.com/o1-labs/o1js/blob/fec4d35f/src/index.ts#L118)
+[index.ts:124](https://github.com/o1-labs/o1js/blob/42a18c8d/src/index.ts#L124)
 
 ___
 
@@ -1978,7 +2074,7 @@ you can use the following in the declaration of your zkapp:
 
 #### Defined in
 
-[lib/state.ts:87](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/state.ts#L87)
+[lib/state.ts:87](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/state.ts#L87)
 
 ___
 
@@ -2001,7 +2097,27 @@ ___
 
 #### Defined in
 
-[lib/field.ts:1309](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1309)
+[lib/field.ts:1310](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1310)
+
+___
+
+### toFp
+
+▸ **toFp**(`x`): `Fp`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `x` | `string` \| `number` \| `bigint` \| [`Field`](classes/Field.md) |
+
+#### Returns
+
+`Fp`
+
+#### Defined in
+
+[lib/field.ts:1296](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1296)
 
 ___
 
@@ -2022,7 +2138,7 @@ ___
 
 #### Defined in
 
-[lib/proof_system.ts:137](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L137)
+[lib/proof_system.ts:181](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L181)
 
 ___
 
@@ -2043,4 +2159,4 @@ ___
 
 #### Defined in
 
-[lib/field.ts:1303](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/field.ts#L1303)
+[lib/field.ts:1304](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/field.ts#L1304)

--- a/docs/zkapps/o1js-reference/modules/Encryption.md
+++ b/docs/zkapps/o1js-reference/modules/Encryption.md
@@ -30,7 +30,7 @@ Decrypts a CipherText using a [PrivateKey](../classes/PrivateKey.md).^
 
 #### Defined in
 
-[lib/encryption.ts:45](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/encryption.ts#L45)
+[lib/encryption.ts:45](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/encryption.ts#L45)
 
 ___
 
@@ -58,4 +58,4 @@ Public Key Encryption, using a given array of [Field](../modules.md#field-1) ele
 
 #### Defined in
 
-[lib/encryption.ts:16](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/encryption.ts#L16)
+[lib/encryption.ts:16](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/encryption.ts#L16)

--- a/docs/zkapps/o1js-reference/modules/Experimental.md
+++ b/docs/zkapps/o1js-reference/modules/Experimental.md
@@ -35,9 +35,9 @@ This module exposes APIs that are unstable, in the sense that the API surface is
 
 #### Defined in
 
-[index.ts:101](https://github.com/o1-labs/o1js/blob/fec4d35f/src/index.ts#L101)
+[index.ts:107](https://github.com/o1-labs/o1js/blob/42a18c8d/src/index.ts#L107)
 
-[index.ts:102](https://github.com/o1-labs/o1js/blob/fec4d35f/src/index.ts#L102)
+[index.ts:108](https://github.com/o1-labs/o1js/blob/42a18c8d/src/index.ts#L108)
 
 ## Variables
 
@@ -47,15 +47,20 @@ This module exposes APIs that are unstable, in the sense that the API surface is
 
 #### Defined in
 
-[index.ts:101](https://github.com/o1-labs/o1js/blob/fec4d35f/src/index.ts#L101)
+[index.ts:107](https://github.com/o1-labs/o1js/blob/42a18c8d/src/index.ts#L107)
 
-[index.ts:102](https://github.com/o1-labs/o1js/blob/fec4d35f/src/index.ts#L102)
+[index.ts:108](https://github.com/o1-labs/o1js/blob/42a18c8d/src/index.ts#L108)
 
 ## Functions
 
 ### ZkProgram
 
-▸ **ZkProgram**<`StatementType`, `Types`\>(`config`): { `analyzeMethods`: () => `ReturnType`<typeof `analyzeMethod`\>[] ; `compile`: () => `Promise`<{ `verificationKey`: `string`  }\> ; `digest`: () => `string` ; `name`: `string` ; `publicInputType`: `ProvableOrUndefined`<`Get`<`StatementType`, ``"publicInput"``\>\> ; `publicOutputType`: `ProvableOrVoid`<`Get`<`StatementType`, ``"publicOutput"``\>\> ; `verify`: (`proof`: [`Proof`](../classes/Proof.md)<`InferProvableOrUndefined`<`Get`<`StatementType`, ``"publicInput"``\>\>, `InferProvableOrVoid`<`Get`<`StatementType`, ``"publicOutput"``\>\>\>) => `Promise`<`boolean`\>  } & { [I in keyof Types]: Prover<InferProvableOrUndefined<Get<StatementType, "publicInput"\>\>, InferProvableOrVoid<Get<StatementType, "publicOutput"\>\>, Types[I]\> }
+▸ **ZkProgram**<`StatementType`, `Types`\>(`config`): { `analyzeMethods`: () => { `digest`: `string` ; `gates`: [`Gate`](../modules.md#gate)[] ; `publicInputSize`: `number` ; `result`: `unknown` ; `rows`: `number`  }[] ; `compile`: () => `Promise`<{ `verificationKey`: `string`  }\> ; `digest`: () => `string` ; `name`: `string` ; `publicInputType`: `ProvableOrUndefined`<`Get`<`StatementType`, ``"publicInput"``\>\> ; `publicOutputType`: `ProvableOrVoid`<`Get`<`StatementType`, ``"publicOutput"``\>\> ; `verify`: (`proof`: [`Proof`](../classes/Proof.md)<`InferProvableOrUndefined`<`Get`<`StatementType`, ``"publicInput"``\>\>, `InferProvableOrVoid`<`Get`<`StatementType`, ``"publicOutput"``\>\>\>) => `Promise`<`boolean`\>  } & { [I in string \| number \| symbol]: Prover<InferProvableOrUndefined<Get<StatementType, "publicInput"\>\>, InferProvableOrVoid<Get<StatementType, "publicOutput"\>\>, Types[I]\> }
+
+**`Deprecated`**
+
+`ZkProgram` has moved out of the Experimental namespace and is now directly available as a top-level import `ZkProgram`.
+The old `Experimental.ZkProgram` API has been deprecated in favor of the new `ZkProgram` top-level import.
 
 #### Type parameters
 
@@ -68,15 +73,15 @@ This module exposes APIs that are unstable, in the sense that the API surface is
 
 | Name | Type |
 | :------ | :------ |
-| `config` | `StatementType` & { `methods`: { [I in string \| number \| symbol]: Method<InferProvableOrUndefined<Get<StatementType, "publicInput"\>\>, InferProvableOrVoid<Get<StatementType, "publicOutput"\>\>, Types[I]\> }  } |
+| `config` | `StatementType` & { `methods`: { [I in string \| number \| symbol]: Method<InferProvableOrUndefined<Get<StatementType, "publicInput"\>\>, InferProvableOrVoid<Get<StatementType, "publicOutput"\>\>, Types[I]\> } ; `name?`: `string` ; `overrideWrapDomain?`: ``0`` \| ``2`` \| ``1``  } |
 
 #### Returns
 
-{ `analyzeMethods`: () => `ReturnType`<typeof `analyzeMethod`\>[] ; `compile`: () => `Promise`<{ `verificationKey`: `string`  }\> ; `digest`: () => `string` ; `name`: `string` ; `publicInputType`: `ProvableOrUndefined`<`Get`<`StatementType`, ``"publicInput"``\>\> ; `publicOutputType`: `ProvableOrVoid`<`Get`<`StatementType`, ``"publicOutput"``\>\> ; `verify`: (`proof`: [`Proof`](../classes/Proof.md)<`InferProvableOrUndefined`<`Get`<`StatementType`, ``"publicInput"``\>\>, `InferProvableOrVoid`<`Get`<`StatementType`, ``"publicOutput"``\>\>\>) => `Promise`<`boolean`\>  } & { [I in keyof Types]: Prover<InferProvableOrUndefined<Get<StatementType, "publicInput"\>\>, InferProvableOrVoid<Get<StatementType, "publicOutput"\>\>, Types[I]\> }
+{ `analyzeMethods`: () => { `digest`: `string` ; `gates`: [`Gate`](../modules.md#gate)[] ; `publicInputSize`: `number` ; `result`: `unknown` ; `rows`: `number`  }[] ; `compile`: () => `Promise`<{ `verificationKey`: `string`  }\> ; `digest`: () => `string` ; `name`: `string` ; `publicInputType`: `ProvableOrUndefined`<`Get`<`StatementType`, ``"publicInput"``\>\> ; `publicOutputType`: `ProvableOrVoid`<`Get`<`StatementType`, ``"publicOutput"``\>\> ; `verify`: (`proof`: [`Proof`](../classes/Proof.md)<`InferProvableOrUndefined`<`Get`<`StatementType`, ``"publicInput"``\>\>, `InferProvableOrVoid`<`Get`<`StatementType`, ``"publicOutput"``\>\>\>) => `Promise`<`boolean`\>  } & { [I in string \| number \| symbol]: Prover<InferProvableOrUndefined<Get<StatementType, "publicInput"\>\>, InferProvableOrVoid<Get<StatementType, "publicOutput"\>\>, Types[I]\> }
 
 #### Defined in
 
-[lib/proof_system.ts:189](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/proof_system.ts#L189)
+[lib/proof_system.ts:1029](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L1029)
 
 ___
 
@@ -98,7 +103,7 @@ ___
 
 #### Defined in
 
-[lib/account_update.ts:1709](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/account_update.ts#L1709)
+[lib/account_update.ts:1703](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/account_update.ts#L1703)
 
 ___
 
@@ -128,4 +133,4 @@ for reuse by the prover. This is needed to witness non-deterministic values.
 
 #### Defined in
 
-[lib/provable.ts:456](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/provable.ts#L456)
+[lib/provable.ts:456](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/provable.ts#L456)

--- a/docs/zkapps/o1js-reference/modules/Lightnet.md
+++ b/docs/zkapps/o1js-reference/modules/Lightnet.md
@@ -1,0 +1,66 @@
+[o1js](../README.md) / [Modules](../modules.md) / Lightnet
+
+# Namespace: Lightnet
+
+## Table of contents
+
+### Functions
+
+- [acquireKeyPair](Lightnet.md#acquirekeypair)
+- [releaseKeyPair](Lightnet.md#releasekeypair)
+
+## Functions
+
+### acquireKeyPair
+
+▸ **acquireKeyPair**(`options?`): `Promise`<{ `privateKey`: [`PrivateKey`](../classes/PrivateKey.md) ; `publicKey`: [`PublicKey`](../classes/Types.PublicKey.md)  }\>
+
+Gets random key pair (public and private keys) from account manager
+that operates with accounts configured in target network Genesis Ledger.
+
+If an error is returned by the specified endpoint, an error is thrown. Otherwise,
+the data is returned.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options` | `Object` | - |
+| `options.isRegularAccount?` | `boolean` | Whether to acquire regular or zkApp account (one with already configured verification key) |
+| `options.lightnetAccountManagerEndpoint?` | `string` | Account manager endpoint to fetch from |
+
+#### Returns
+
+`Promise`<{ `privateKey`: [`PrivateKey`](../classes/PrivateKey.md) ; `publicKey`: [`PublicKey`](../classes/Types.PublicKey.md)  }\>
+
+Key pair
+
+#### Defined in
+
+[lib/fetch.ts:1026](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/fetch.ts#L1026)
+
+___
+
+### releaseKeyPair
+
+▸ **releaseKeyPair**(`options`): `Promise`<`string` \| ``null``\>
+
+Releases previously acquired key pair by public key.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options` | `Object` | - |
+| `options.lightnetAccountManagerEndpoint?` | `string` | Account manager endpoint to fetch from |
+| `options.publicKey` | `string` | Public key of previously acquired key pair to release |
+
+#### Returns
+
+`Promise`<`string` \| ``null``\>
+
+Response message from the account manager as string or null if the request failed
+
+#### Defined in
+
+[lib/fetch.ts:1069](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/fetch.ts#L1069)

--- a/docs/zkapps/o1js-reference/modules/Mina.md
+++ b/docs/zkapps/o1js-reference/modules/Mina.md
@@ -60,7 +60,7 @@
 
 #### Defined in
 
-[lib/mina.ts:161](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L161)
+[lib/mina.ts:161](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L161)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[lib/mina.ts:119](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L119)
+[lib/mina.ts:119](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L119)
 
 ___
 
@@ -92,7 +92,7 @@ Allows you to specify information about the fee payer account and the transactio
 
 #### Defined in
 
-[lib/mina.ts:132](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L132)
+[lib/mina.ts:132](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L132)
 
 ___
 
@@ -114,9 +114,9 @@ ___
 
 #### Defined in
 
-[lib/mina.ts:74](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L74)
+[lib/mina.ts:74](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L74)
 
-[lib/mina.ts:111](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L111)
+[lib/mina.ts:111](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L111)
 
 ## Variables
 
@@ -132,9 +132,9 @@ ___
 
 #### Defined in
 
-[lib/mina.ts:74](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L74)
+[lib/mina.ts:74](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L74)
 
-[lib/mina.ts:111](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L111)
+[lib/mina.ts:111](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L111)
 
 ___
 
@@ -144,7 +144,7 @@ ___
 
 #### Defined in
 
-[lib/mina.ts:966](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L966)
+[lib/mina.ts:996](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L996)
 
 ## Functions
 
@@ -169,7 +169,7 @@ The name `BerkeleyQANet` was misleading because it suggested that this is specif
 
 #### Defined in
 
-[lib/mina.ts:962](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L962)
+[lib/mina.ts:992](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L992)
 
 ___
 
@@ -217,7 +217,7 @@ A mock Mina blockchain running locally and useful for testing.
 
 #### Defined in
 
-[lib/mina.ts:376](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L376)
+[lib/mina.ts:376](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L376)
 
 ___
 
@@ -239,17 +239,18 @@ Represents the Mina blockchain running on a real network
 
 #### Defined in
 
-[lib/mina.ts:667](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L667)
+[lib/mina.ts:679](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L679)
 
-▸ **Network**(`graphqlEndpoints`): `Mina`
+▸ **Network**(`endpoints`): `Mina`
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `graphqlEndpoints` | `Object` |
-| `graphqlEndpoints.archive` | `string` \| `string`[] |
-| `graphqlEndpoints.mina` | `string` \| `string`[] |
+| `endpoints` | `Object` |
+| `endpoints.archive?` | `string` \| `string`[] |
+| `endpoints.lightnetAccountManager?` | `string` |
+| `endpoints.mina` | `string` \| `string`[] |
 
 #### Returns
 
@@ -257,7 +258,7 @@ Represents the Mina blockchain running on a real network
 
 #### Defined in
 
-[lib/mina.ts:668](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L668)
+[lib/mina.ts:680](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L680)
 
 ___
 
@@ -273,7 +274,7 @@ Returns the default account creation fee.
 
 #### Defined in
 
-[lib/mina.ts:1167](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L1167)
+[lib/mina.ts:1197](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L1197)
 
 ___
 
@@ -299,7 +300,7 @@ ___
 
 #### Defined in
 
-[lib/mina.ts:174](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L174)
+[lib/mina.ts:174](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L174)
 
 ___
 
@@ -315,7 +316,7 @@ The current slot number, according to the active Mina instance.
 
 #### Defined in
 
-[lib/mina.ts:1132](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L1132)
+[lib/mina.ts:1162](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L1162)
 
 ___
 
@@ -329,7 +330,7 @@ ___
 
 #### Defined in
 
-[lib/global-context.ts:6](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/global-context.ts#L6)
+[lib/global-context.ts:6](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/global-context.ts#L6)
 
 ___
 
@@ -352,7 +353,7 @@ Requests the [testnet faucet](https://faucet.minaprotocol.com/api/v1/faucet) to 
 
 #### Defined in
 
-[lib/mina.ts:1547](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L1547)
+[lib/mina.ts:1577](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L1577)
 
 ___
 
@@ -376,7 +377,7 @@ A list of emitted sequencing actions associated to the given public key.
 
 #### Defined in
 
-[lib/mina.ts:1189](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L1189)
+[lib/mina.ts:1219](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L1219)
 
 ___
 
@@ -400,7 +401,7 @@ A list of emitted events associated to the given public key.
 
 #### Defined in
 
-[lib/mina.ts:1178](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L1178)
+[lib/mina.ts:1208](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L1208)
 
 ___
 
@@ -426,7 +427,7 @@ ___
 
 #### Defined in
 
-[lib/mina.ts:1504](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L1504)
+[lib/mina.ts:1534](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L1534)
 
 ___
 
@@ -449,7 +450,7 @@ The account data associated to the given public key.
 
 #### Defined in
 
-[lib/mina.ts:1139](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L1139)
+[lib/mina.ts:1169](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L1169)
 
 ___
 
@@ -473,7 +474,7 @@ A list of emitted sequencing actions associated to the given public key.
 
 #### Defined in
 
-[lib/mina.ts:1200](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L1200)
+[lib/mina.ts:1230](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L1230)
 
 ___
 
@@ -496,7 +497,7 @@ The balance associated to the given public key.
 
 #### Defined in
 
-[lib/mina.ts:1160](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L1160)
+[lib/mina.ts:1190](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L1190)
 
 ___
 
@@ -512,7 +513,7 @@ Data associated with the current state of the Mina network.
 
 #### Defined in
 
-[lib/mina.ts:1153](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L1153)
+[lib/mina.ts:1183](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L1183)
 
 ___
 
@@ -526,7 +527,7 @@ ___
 
 #### Defined in
 
-[lib/mina.ts:1208](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L1208)
+[lib/mina.ts:1238](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L1238)
 
 ___
 
@@ -549,7 +550,7 @@ Checks if an account exists within the ledger.
 
 #### Defined in
 
-[lib/mina.ts:1146](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L1146)
+[lib/mina.ts:1176](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L1176)
 
 ___
 
@@ -569,7 +570,7 @@ ___
 
 #### Defined in
 
-[lib/mina.ts:1171](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L1171)
+[lib/mina.ts:1201](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L1201)
 
 ___
 
@@ -587,7 +588,7 @@ Throws an error if not inside a transaction, or the sender wasn't passed in.
 
 #### Defined in
 
-[lib/mina.ts:1108](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L1108)
+[lib/mina.ts:1138](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L1138)
 
 ___
 
@@ -609,7 +610,7 @@ Set the currently used Mina instance.
 
 #### Defined in
 
-[lib/mina.ts:1048](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L1048)
+[lib/mina.ts:1078](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L1078)
 
 ___
 
@@ -642,7 +643,7 @@ A transaction that can subsequently be submitted to the chain.
 
 #### Defined in
 
-[lib/mina.ts:1065](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L1065)
+[lib/mina.ts:1095](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L1095)
 
 ▸ **transaction**(`f`): `Promise`<[`Transaction`](Mina.md#transaction-1)\>
 
@@ -658,7 +659,7 @@ A transaction that can subsequently be submitted to the chain.
 
 #### Defined in
 
-[lib/mina.ts:1066](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L1066)
+[lib/mina.ts:1096](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L1096)
 
 ▸ **transaction**(`sender`, `f`): `Promise`<[`Transaction`](Mina.md#transaction-1)\>
 
@@ -688,7 +689,7 @@ Mina.transaction({ feePayerKey: privateKey }, ...);
 
 #### Defined in
 
-[lib/mina.ts:1079](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L1079)
+[lib/mina.ts:1109](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L1109)
 
 ___
 
@@ -708,4 +709,4 @@ ___
 
 #### Defined in
 
-[lib/mina.ts:1523](https://github.com/o1-labs/o1js/blob/fec4d35f/src/lib/mina.ts#L1523)
+[lib/mina.ts:1553](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/mina.ts#L1553)

--- a/docs/zkapps/o1js-reference/modules/Pickles.md
+++ b/docs/zkapps/o1js-reference/modules/Pickles.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[snarky.d.ts:499](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L499)
+[snarky.d.ts:602](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L602)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[snarky.d.ts:510](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L510)
+[snarky.d.ts:628](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L628)
 
 ___
 
@@ -52,17 +52,20 @@ ___
 
 Ƭ **Rule**: `Object`
 
+A "rule" is a circuit plus some metadata for `Pickles.compile`
+
 #### Type declaration
 
-| Name | Type |
-| :------ | :------ |
-| `identifier` | `string` |
-| `main` | (`publicInput`: `MlArray`<[`FieldVar`](../modules.md#fieldvar-1)\>) => { `previousStatements`: `MlArray`<[`Statement`](Pickles.md#statement)<[`FieldVar`](../modules.md#fieldvar-1)\>\> ; `publicOutput`: `MlArray`<[`FieldVar`](../modules.md#fieldvar-1)\> ; `shouldVerify`: `MlArray`<[`BoolVar`](../modules.md#boolvar)\>  } |
-| `proofsToVerify` | `MlArray`<{ `isSelf`: ``true``  } \| { `isSelf`: ``false`` ; `tag`: `unknown`  }\> |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `featureFlags` | [`MlFeatureFlags`](../modules.md#mlfeatureflags) | Feature flags which enable certain custom gates |
+| `identifier` | `string` | - |
+| `main` | (`publicInput`: `MlArray`<[`FieldVar`](../modules.md#fieldvar-1)\>) => { `previousStatements`: `MlArray`<[`Statement`](Pickles.md#statement)<[`FieldVar`](../modules.md#fieldvar-1)\>\> ; `publicOutput`: `MlArray`<[`FieldVar`](../modules.md#fieldvar-1)\> ; `shouldVerify`: `MlArray`<[`BoolVar`](../modules.md#boolvar)\>  } | The main circuit functions |
+| `proofsToVerify` | `MlArray`<{ `isSelf`: ``true``  } \| { `isSelf`: ``false`` ; `tag`: `unknown`  }\> | Description of previous proofs to verify in this rule |
 
 #### Defined in
 
-[snarky.d.ts:501](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L501)
+[snarky.d.ts:608](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L608)
 
 ___
 
@@ -78,4 +81,4 @@ ___
 
 #### Defined in
 
-[snarky.d.ts:500](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L500)
+[snarky.d.ts:603](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L603)

--- a/docs/zkapps/o1js-reference/modules/Snarky.md
+++ b/docs/zkapps/o1js-reference/modules/Snarky.md
@@ -23,7 +23,7 @@ Note for devs: This module is intended to closely mirror snarky-ml's core, low-l
 
 #### Defined in
 
-[snarky.d.ts:141](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L141)
+[snarky.d.ts:149](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L149)
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 #### Defined in
 
-[snarky.d.ts:140](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L140)
+[snarky.d.ts:148](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L148)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[snarky.d.ts:143](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L143)
+[snarky.d.ts:151](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L151)
 
 ___
 
@@ -67,4 +67,4 @@ ___
 
 #### Defined in
 
-[snarky.d.ts:142](https://github.com/o1-labs/o1js/blob/fec4d35f/src/snarky.d.ts#L142)
+[snarky.d.ts:150](https://github.com/o1-labs/o1js/blob/42a18c8d/src/snarky.d.ts#L150)

--- a/docs/zkapps/o1js-reference/modules/ZkProgram.md
+++ b/docs/zkapps/o1js-reference/modules/ZkProgram.md
@@ -1,0 +1,39 @@
+[o1js](../README.md) / [Modules](../modules.md) / ZkProgram
+
+# Namespace: ZkProgram
+
+## Table of contents
+
+### Functions
+
+- [Proof](ZkProgram.md#proof)
+
+## Functions
+
+### Proof
+
+▸ **Proof**<`PublicInputType`, `PublicOutputType`\>(`program`): typeof `ZkProgramProof`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `PublicInputType` | extends [`FlexibleProvablePure`](../modules.md#flexibleprovablepure)<`any`\> |
+| `PublicOutputType` | extends [`FlexibleProvablePure`](../modules.md#flexibleprovablepure)<`any`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `program` | `Object` |
+| `program.name` | `string` |
+| `program.publicInputType` | `PublicInputType` |
+| `program.publicOutputType` | `PublicOutputType` |
+
+#### Returns
+
+typeof `ZkProgramProof`
+
+#### Defined in
+
+[lib/proof_system.ts:867](https://github.com/o1-labs/o1js/blob/42a18c8d/src/lib/proof_system.ts#L867)

--- a/sidebars.js
+++ b/sidebars.js
@@ -292,6 +292,11 @@ module.exports = {
                 },
                 {
                   type: 'doc',
+                  id: 'zkapps/o1js-reference/modules/Lightnet',
+                  label: 'Lightnet',
+                },
+                {
+                  type: 'doc',
                   id: 'zkapps/o1js-reference/modules/Mina',
                   label: 'Mina',
                 },
@@ -314,6 +319,11 @@ module.exports = {
                   type: 'doc',
                   id: 'zkapps/o1js-reference/modules/Types',
                   label: 'Types',
+                },
+                {
+                  type: 'doc',
+                  id: 'zkapps/o1js-reference/modules/ZkProgram',
+                  label: 'ZkProgram',
                 },
               ],
             },
@@ -347,7 +357,7 @@ module.exports = {
         'mina-protocol/hardforks',
         'mina-protocol/time-locked-accounts',
         'mina-protocol/sending-a-payment',
-        'mina-protocol/lifecycle-of-a-payment'
+        'mina-protocol/lifecycle-of-a-payment',
       ],
     },
     {
@@ -362,7 +372,7 @@ module.exports = {
             'node-operators/foundation-delegation-program',
             'node-operators/delegation-tiebreak',
             'node-operators/bp-sidecar',
-            'node-operators/uptime-tracking-system'
+            'node-operators/uptime-tracking-system',
           ],
         },
         'node-operators/getting-started',
@@ -371,7 +381,7 @@ module.exports = {
         'node-operators/connecting-to-devnet',
         'node-operators/staking-and-snarking',
         'node-operators/hot-cold-block-production',
-        'node-operators/seed-peers',        
+        'node-operators/seed-peers',
         'node-operators/staking-service-guidelines',
         'node-operators/mina-signer',
         {
@@ -381,12 +391,12 @@ module.exports = {
             'node-operators/querying-data',
             'node-operators/archive-node',
             'node-operators/archive-redundancy',
-            'node-operators/rosetta'
+            'node-operators/rosetta',
           ],
         },
         'node-operators/mina-cli-reference',
         'node-operators/troubleshooting',
-        'node-operators/faq'
+        'node-operators/faq',
       ],
     },
     {
@@ -408,10 +418,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Exchange Operators',
-      items: [
-        'exchange-operators/rosetta2',
-        'exchange-operators/faq'
-    ],
+      items: ['exchange-operators/rosetta2', 'exchange-operators/faq'],
     },
     {
       type: 'category',
@@ -424,9 +431,9 @@ module.exports = {
         'test-world-2/incentives',
         'test-world-2/bug-reporting',
         'test-world-2/launching-a-node',
-        'test-world-2/questions'
+        'test-world-2/questions',
       ],
-    },    
+    },
     {
       type: 'category',
       label: 'Participate',


### PR DESCRIPTION
# Summary

Manually updates the API reference docs. The [GitHub Actions job](https://github.com/o1-labs/docs2/blob/main/.github/workflows/o1js-api-reference.yml) to generate the API docs is broken, but there is a [fix for it.](https://github.com/o1-labs/o1js/pull/1203)