### PR TITLE
Rolled back mina-generate-keypair image tag

### DIFF
--- a/docs/node-operators/generating-a-keypair.mdx
+++ b/docs/node-operators/generating-a-keypair.mdx
@@ -108,7 +108,7 @@ Make sure to set a new and secure password for the following commands. Mina will
     
     ```
     cd ~
-    docker run --interactive --tty --rm --volume $(pwd)/keys:/keys minaprotocol/mina-generate-keypair:1.4.0-c980ba8 --privkey-path /keys/my-wallet
+    docker run --interactive --tty --rm --volume $(pwd)/keys:/keys minaprotocol/mina-generate-keypair:1.3.1-3e3abec --privkey-path /keys/my-wallet
     ```
     
 1. When prompted, type in the password you intend to use to secure this key. <em>Do NOT forget this password.</em>
@@ -139,7 +139,7 @@ mina-validate-keypair --privkey-path <path-to-the-private-key-file>
 On Docker:
 
 ```
-docker run --interactive --tty --rm --entrypoint=mina-validate-keypair --volume $(pwd)/keys:/keys minaprotocol/mina-generate-keypair:1.4.0-c980ba8 --privkey-path /keys/my-wallet
+docker run --interactive --tty --rm --entrypoint=mina-validate-keypair --volume $(pwd)/keys:/keys minaprotocol/mina-generate-keypair:1.3.1-3e3abec --privkey-path /keys/my-wallet
 ```
 
 ## Ledger Hardware Wallet


### PR DESCRIPTION
The tag proposed for the `mina-generate-keypair` container is not available in DockerHub, which produces the following error for the user when trying a `docker pull` command:

`reading manifest 1.4.0-c980ba8 in docker.io/minaprotocol/mina-generate-keypair: manifest unknown`

This commit rolls back the container image tag to `1.3.1-3e3abec`, which has been tested by generating and validating new keys. Current available tags are: 
* 1.2.0-fe51f1e, 
* 1.3.0-9b0369c, and 
* 1.3.1-3e3abec. 
 
This change essentially reverts the tag changes made in following commit: https://github.com/o1-labs/docs2/commit/3e8bd3d7f3a6e872a1c702d54eca3c056f1ca121#diff-e1d8c3378956b70b87f883d6ab02e1183db818ac511ceac7824b80bc25c887e2