### PR TITLE
Update zkapp-cli and o1js versions required for 03-deploying-to-a-network.mdx 

### DIFF
--- a/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
+++ b/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
@@ -34,9 +34,11 @@ Mina zkApps are available only on feature-complete Berkeley, Mina's public Testn
 
 ## Prerequisites
 
-This tutorial has been tested with [Mina zkApp CLI](https://github.com/o1-labs/zkapp-cli) version `0.10.0` and [SnarkyJS](https://www.npmjs.com/package/snarkyjs) `0.11.3`.
+This tutorial has been tested with [Mina zkApp CLI](https://github.com/o1-labs/zkapp-cli) version `0.15.0`, [O1js](https://www.npmjs.com/package/o1js) version `0.14.1` and [npm](https://www.npmjs.com/package/npm) version 0.20.9.
 
 Ensure your environment meets the [Prerequisites](/zkapps/tutorials#prerequisites) for zkApp Developer Tutorials.
+
+> *⚠️ Warning: If you have previously installed the [Prerequisites](/zkapps/tutorials#prerequisites): reinstall to make sure you are using the correct version of the zkapp-cli and o1js.*
 
 ## Create a project
 


### PR DESCRIPTION
Updating the zkapp-cli, o1js and npm versions required to make this work and adding a warning so that previous snarkyJS users are prompted to update their existing installs.