### PR TITLE
Changed the publicInputType to publicInput to avoid the type error for the method

### DIFF
--- a/docs/zkapps/o1js/recursion.mdx
+++ b/docs/zkapps/o1js/recursion.mdx
@@ -55,7 +55,7 @@ import { Field, ZkProgram } from 'o1js';
 
 const SimpleProgram = ZkProgram({
   name: "simple-program-example",
-  publicInputType: Field,
+  publicInput: Field,
 
   methods: {
     run: {


### PR DESCRIPTION
<img width="479" alt="zkRescurssion" src="https://github.com/o1-labs/docs2/assets/55076843/9d746c8b-e3ca-4355-80d0-ed51ecb70725">


In above if you will see we are getting the type error in method as the type of publicInput is not matching.
So, just modified the publicInputType to publicInput similar to the previous versions.