### PR TITLE
docs: add broken link detection to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ npm install
 npm run dev
 ```
 
+The `npm run dev` command does not run with broken link detection.
+
 ## Debugging build errors
 
-If you need to debug Vercel CI failures, you can gather more information on your local build:
+To build the site with broken link detection and to debug Vercel CI failures, you can gather more information on your local build:
 
 ```sh
 npm run build


### PR DESCRIPTION
To assist with MF urgent doc PRs, this PR adds more context to the self-help steps for local builds. 