### PR TITLE
#749  Rename deprecated assert* to require* in o1js precondition APIs 

### DIFF
--- a/docs/zkapps/faq.mdx
+++ b/docs/zkapps/faq.mdx
@@ -103,7 +103,7 @@ As represented in the tutorial example code:
 ```TypeScript
 const currentState = this.num.get();
 
-this.num.assertEquals(currentState);
+this.num.requireEquals(currentState);
 ```
 
 - The first line of code executes before the proof is generated. 

--- a/docs/zkapps/o1js/interact-with-mina.md
+++ b/docs/zkapps/o1js/interact-with-mina.md
@@ -116,7 +116,7 @@ Other fields in this account update are:
 
   - `publicKey` – the zkApp address (like other non-human-readable strings, this is truncated by `tx.toPretty()`)
   - `update: { appState: [...] }` – shows how the method updates the on-chain state, using `this.<state>.set()`. The names and pretty types defined using `@state` are removed in this representation, showing a raw list of 8 field elements or `null` for state fields that aren't updated.
-  - `preconditions: { account: { state: [...] } }` – similar to the `update`, one entry per field of on-chain state for the preconditions created with `this.<state>.assertEquals()`. This example accepts transactions only if the first of the 8 state fields equals 0. The `null` values mean that no condition is set on the other 7 state fields.
+  - `preconditions: { account: { state: [...] } }` – similar to the `update`, one entry per field of on-chain state for the preconditions created with `this.<state>.requireEquals()`. This example accepts transactions only if the first of the 8 state fields equals 0. The `null` values mean that no condition is set on the other 7 state fields.
   - `authorizationKind: 'Proof'` – indicates this account update must be authorized with a proof. Proof authorization is the default when calling a zkApp method, but not necessarily for other account updates.
   - `authorization: undefined` – the proof needed on this update isn't there yet. You learn how to add it in a minute.
 

--- a/docs/zkapps/o1js/merkle-tree.mdx
+++ b/docs/zkapps/o1js/merkle-tree.mdx
@@ -111,14 +111,14 @@ class Leaderboard extends SmartContract {
   @method guessPreimage(guess: Field, account: Account, path: MerkleWitness) {
     // we fetch z from the chain
     const z = this.z.get();
-    this.z.assertEquals(z);
+    this.z.requireEquals(z);
 
     // if our guess preimage hashes to our target, we won a point!
     Poseidon.hash([guess]).assertEquals(z);
 
     // we fetch the on-chain commitment/root
     const root = this.root.get();
-    this.root.assertEquals(root);
+    this.root.requireEquals(root);
 
     // we check that the account is within the committed Merkle Tree
     path.calculateRoot(account.hash()).assertEquals(root);
@@ -135,7 +135,7 @@ class Leaderboard extends SmartContract {
   @method claimReward(account: Account, path: MerkleWitness) {
     // we fetch the on-chain commitment
     const root = this.root.get();
-    this.root.assertEquals(root);
+    this.root.requireEquals(root);
 
     // we check that the account is within the committed Merkle Tree
     path.calculateRoot(account.hash()).assertEquals(root);

--- a/docs/zkapps/o1js/on-chain-values.mdx
+++ b/docs/zkapps/o1js/on-chain-values.mdx
@@ -38,15 +38,15 @@ For example, the timestamp on `this.network.timestamp` has four methods:
 
 ```ts
 this.network.timestamp.get();
-this.network.timestamp.assertEquals(timestamp);
-this.network.timestamp.assertBetween(lower, upper);
+this.network.timestamp.requireEquals(timestamp);
+this.network.timestamp.requireBetween(lower, upper);
 ```
 
-The familiar on-chain state has the same `get()` and `assertEquals()` methods. The `assertBetween()` method has even more power: it allows you to make assert that the timestamp is between `lower` and `upper` (inclusive).
+The familiar on-chain state has the same `get()` and `requireEquals()` methods. The `requireBetween()` method has even more power: it allows you to make assert that the timestamp is between `lower` and `upper` (inclusive).
 
 ### Example: restricting timestamps
 
-You can see how to use the `assertBetween()` method in the voting example that was mentioned earlier. Assume you want to allow voting throughout September 2022. Timestamps are represented as a `UInt64` in milliseconds since the [UNIX epoch](https://en.wikipedia.org/wiki/Unix_time). You can use the JS `Date` object to easily convert to this representation. In the simplest case, a zkApp could just hard-code the dates:
+You can see how to use the `requireBetween()` method in the voting example that was mentioned earlier. Assume you want to allow voting throughout September 2022. Timestamps are represented as a `UInt64` in milliseconds since the [UNIX epoch](https://en.wikipedia.org/wiki/Unix_time). You can use the JS `Date` object to easily convert to this representation. In the simplest case, a zkApp could just hard-code the dates:
 
 ```ts
 const startDate = UInt64.from(Date.UTC(2022, 9, 1));
@@ -56,7 +56,7 @@ class VotingApp extends SmartContract {
   // ...
 
   @method vote(...) {
-    this.network.timestamp.assertBetween(startDate, endDate);
+    this.network.timestamp.requireBetween(startDate, endDate);
     // ...
   }
 }
@@ -68,15 +68,15 @@ In addition to using a predefined range, you can also construct a range that dep
 
 ```ts
 const now = this.network.timestamp.get();
-this.network.timestamp.assertBetween(now, now.add(60 * 60 * 1000));
+this.network.timestamp.requireBetween(now, now.add(60 * 60 * 1000));
 ```
 
 ### Network reference
 
 For completeness, here is the full list of network states you can use and make assertions about in your zkApp.
 
-All of these fields have a `get()` and an `assertEquals()` method. The subset that represents
-"ordered values" (those that are `UInt32` or `UInt64`) also have `assertBetween()`.
+All of these fields have a `get()` and an `requireEquals()` method. The subset that represents
+"ordered values" (those that are `UInt32` or `UInt64`) also have `requireBetween()`.
 
 Of course, there's no need to remember this -- just type `this.network.` and let intelligent code complete guide you!
 
@@ -112,8 +112,8 @@ this.network.nextEpochData.startCheckpoint.get(): Field;
 
 ### Account reference
 
-Here's the full list of values you can access on the zkApp account. Like the network states, these values have `get()` and `assertEquals()`.
-Balance and nonce also have `assertBetween()`.
+Here's the full list of values you can access on the zkApp account. Like the network states, these values have `get()` and `requireEquals()`.
+Balance and nonce also have `requireBetween()`.
 
 ```ts
 // the account balance; this might be nanoMINA or a custom token
@@ -134,13 +134,13 @@ this.account.receiptChainHash.get(): Field;
 ### Bailing out
 
 In some rare cases, you might, for whatever reason, want to `get()` an on-chain value _without_ constraining it to any value.
-If you try this, o1js throws a helpful error reminding you to use `assertEquals()` and `asserBetween()`.
+If you try this, o1js throws a helpful error reminding you to use `requireEquals()` and `requireBetween()`.
 As an escape hatch, if you want to `get()` a value and are really sure you want to not constrain the on-chain value in any way,
-there's `assertNothing()` on all of these fields (including on-chain state). **Use at your own risk.**
+there's `requireNothing()` on all of these fields (including on-chain state). **Use at your own risk.**
 
 :::danger
 
-`assertNothing()` should be rarely used and could cause security issues through unexpected behavior if used improperly. Be certain you know what you're doing before using this.
+`requireNothing()` should be rarely used and could cause security issues through unexpected behavior if used improperly. Be certain you know what you're doing before using this.
 
 :::
 

--- a/docs/zkapps/o1js/smart-contracts.md
+++ b/docs/zkapps/o1js/smart-contracts.md
@@ -175,7 +175,7 @@ class HelloWorld extends SmartContract {
   @method increment() {
     // read state
     const x = this.x.get();
-    this.x.assertEquals(x);
+    this.x.requireEquals(x);
 
     // write state
     this.x.set(x.add(1));
@@ -189,20 +189,20 @@ Later, it sets the new state to `x + 1` using `this.x.set()`. Simple!
 There's another line though, which looks weird at first:
 
 ```ts
-this.x.assertEquals(x);
+this.x.requireEquals(x);
 ```
 
 To understand it, we have to take a step back, and understand what it means to "use an on-chain value" during off-chain execution.
 
 For sure, when we use an on-chain value, we have to _prove_ that this is the on-chain value. Verification has to fail if it's a different value! Otherwise, a malicious user could modify o1js and make it just use any other value than the current on-chain state – breaking our zkApp.
 
-To prevent that, we link "`x` at proving time" to be the same as "`x` at verification time". We call this a _precondition_ – a condition that is checked by the verifier (a Mina node) when it receives the proof in a transaction. This is what `this.x.assertEquals(x)` does: it adds the precondition that `this.x` – the on-chain state at verification time – has to equal `x` – the value we fetched from the chain on the client-side. In zkSNARK language, `x` becomes part of the public input.
+To prevent that, we link "`x` at proving time" to be the same as "`x` at verification time". We call this a _precondition_ – a condition that is checked by the verifier (a Mina node) when it receives the proof in a transaction. This is what `this.x.requireEquals(x)` does: it adds the precondition that `this.x` – the on-chain state at verification time – has to equal `x` – the value we fetched from the chain on the client-side. In zkSNARK language, `x` becomes part of the public input.
 
-Side note: `this.<state>.assertEquals` is more flexible than equating with the current value. For example, `this.x.assertEquals(10)` fixes the on-chain `x` to the number `10`.
+Side note: `this.<state>.requireEquals` is more flexible than equating with the current value. For example, `this.x.requireEquals(10)` fixes the on-chain `x` to the number `10`.
 
 :::note
 
-Why didn't we just make `this.x.get()` add the precondition, automatically, so that you didn't have to write `this.x.assertEquals(x)`?
+Why didn't we just make `this.x.get()` add the precondition, automatically, so that you didn't have to write `this.x.requireEquals(x)`?
 Well, we like to keep things explicit. The assertion reminds us that we add logic which can make the proof fail: If `x` isn't the same at verification time, the transaction will be rejected. So, reading on-chain values has to be done with care if many users are supposed to read and update state concurrently. It is applicable in some situations, but might cause races, and call for workarounds, in other situations.
 One such workaround is the use of actions – see [Actions and Reducer](./actions-and-reducer).
 
@@ -220,7 +220,7 @@ class HelloWorld extends SmartContract {
 
   @method increment(xPlus1: Field) {
     const x = this.x.get();
-    this.x.assertEquals(x);
+    this.x.requireEquals(x);
 
     x.add(1).assertEquals(xPlus1);
 
@@ -283,7 +283,7 @@ class HelloWorld extends SmartContract {
 
   @method incrementSecret(secret: Field) {
     const x = this.x.get();
-    this.x.assertEquals(x);
+    this.x.requireEquals(x);
 
     Poseidon.hash(secret).assertEquals(x);
     this.x.set(Poseidon.hash(secret.add(1)));
@@ -392,7 +392,7 @@ export class Grid extends SmartContract {
 
   @method move(newPoint: Point) {
     const point = this.p.get();
-    this.p.assertEquals(point);
+    this.p.requireEquals(point);
 
     const newX = point.x.add(newPoint.x);
     const newY = point.y.add(newPoint.y);

--- a/docs/zkapps/tutorials/01-hello-world.mdx
+++ b/docs/zkapps/tutorials/01-hello-world.mdx
@@ -253,7 +253,7 @@ Finally, this code adds the `update()` function:
 16
 17   @method update(square: Field) {
 18     const currentState = this.num.get();
-19     this.num.assertEquals(currentState);
+19     this.num.requireEquals(currentState);
 20     square.assertEquals(currentState.mul(currentState));
 21     this.num.set(square);
 22   }

--- a/docs/zkapps/tutorials/02-private-inputs-hash-functions.mdx
+++ b/docs/zkapps/tutorials/02-private-inputs-hash-functions.mdx
@@ -216,7 +216,7 @@ This method updates the state:
   9
  10   @method incrementSecret(salt: Field, secret: Field) {
  11     const x = this.x.get();
- 12     this.x.assertEquals(x);
+ 12     this.x.requireEquals(x);
  13
  14     Poseidon.hash([ salt, secret ]).assertEquals(x);
  15     this.x.set(Poseidon.hash([ salt, secret.add(1) ]));

--- a/docs/zkapps/tutorials/05-common-types-and-functions.mdx
+++ b/docs/zkapps/tutorials/05-common-types-and-functions.mdx
@@ -333,7 +333,7 @@ For example, to put a condition on a leaf update, the `update` function checks t
     incrementAmount: Field
   ) {
     const initialRoot = this.treeRoot.get();
-    this.treeRoot.assertEquals(initialRoot);
+    this.treeRoot.requireEquals(initialRoot);
 
     incrementAmount.assertLt(Field(10));
 
@@ -456,7 +456,7 @@ It can be used inside smart contracts with a witness, similar to merkle trees
     incrementAmount: Field,
   ) {
     const initialRoot = this.mapRoot.get();
-    this.mapRoot.assertEquals(initialRoot);
+    this.mapRoot.requireEquals(initialRoot);
 
     incrementAmount.assertLt(Field(10));
 

--- a/docs/zkapps/tutorials/07-oracle.mdx
+++ b/docs/zkapps/tutorials/07-oracle.mdx
@@ -297,10 +297,10 @@ To get the oracle's public key from the on-chain state, verify the signature of 
 ```ts
 // Get the oracle public key from the contract state
 const oraclePublicKey = this.oraclePublicKey.get();
-this.oraclePublicKey.assertEquals(oraclePublicKey);
+this.oraclePublicKey.requireEquals(oraclePublicKey);
 ```
 
-`assertEquals()` ensures that the public key that is retrieved at execution time is the same as the public key that exists within the zkApp account on the Mina network when the transaction is processed by the network.
+`requireEquals()` ensures that the public key that is retrieved at execution time is the same as the public key that exists within the zkApp account on the Mina network when the transaction is processed by the network.
 
 ### Verify the signature
 

--- a/docs/zkapps/tutorials/08-custom-tokens.mdx
+++ b/docs/zkapps/tutorials/08-custom-tokens.mdx
@@ -123,7 +123,7 @@ Next, add an init method and a method that mints tokens.
     adminSignature: Signature
   ) {
     let totalAmountInCirculation = this.totalAmountInCirculation.get();
-    this.totalAmountInCirculation.assertEquals(totalAmountInCirculation);
+    this.totalAmountInCirculation.requireEquals(totalAmountInCirculation);
 
     let newTotalAmountInCirculation = totalAmountInCirculation.add(amount);
 

--- a/docs/zkapps/tutorials/09-recursion.mdx
+++ b/docs/zkapps/tutorials/09-recursion.mdx
@@ -215,7 +215,7 @@ class RollupContract extends SmartContract {
 
   @method update(rollupStateProof: RollupProof) {
     const currentState = this.state.get();
-    this.state.assertEquals(currentState);
+    this.state.requireEquals(currentState);
 
     rollupStateProof.publicInput.initialRoot.assertEquals(currentState);
 

--- a/docs/zkapps/tutorials/10-account-updates.mdx
+++ b/docs/zkapps/tutorials/10-account-updates.mdx
@@ -121,7 +121,7 @@ This zkApp has methods that call other methods to let you explore the impacts to
     }
 
     @method init() {
-      this.account.provedState.assertEquals(this.account.provedState.get());
+      this.account.provedState.requireEquals(this.account.provedState.get());
       this.account.provedState.get().assertFalse();
 
       super.init();
@@ -146,22 +146,22 @@ This zkApp has methods that call other methods to let you explore the impacts to
     ...
 
     @method add(incrementBy: Field) {
-      this.account.provedState.assertEquals(this.account.provedState.get());
+      this.account.provedState.requireEquals(this.account.provedState.get());
       this.account.provedState.get().assertTrue();
 
       const num = this.num.get();
-      this.num.assertEquals(num);
+      this.num.requireEquals(num);
       this.num.set(num.add(incrementBy));
 
       this.incrementCalls();
     }
 
     @method incrementCalls() {
-      this.account.provedState.assertEquals(this.account.provedState.get());
+      this.account.provedState.requireEquals(this.account.provedState.get());
       this.account.provedState.get().assertTrue();
 
       const calls = this.calls.get();
-      this.calls.assertEquals(calls);
+      this.calls.requireEquals(calls);
       this.calls.set(calls.add(Field(1)));
     }
 
@@ -182,13 +182,13 @@ This zkApp has methods that call other methods to let you explore the impacts to
     ...
 
     @method callSecondary(secondaryAddr: PublicKey) {
-      this.account.provedState.assertEquals(this.account.provedState.get());
+      this.account.provedState.requireEquals(this.account.provedState.get());
       this.account.provedState.get().assertTrue();
 
       const secondaryContract = new SecondaryZkApp(secondaryAddr);
 
       const num = this.num.get();
-      this.num.assertEquals(num);
+      this.num.requireEquals(num);
 
       secondaryContract.add(num);
 
@@ -212,18 +212,18 @@ export class SecondaryZkApp extends SmartContract {
   @method init() {
     super.init();
 
-    this.account.provedState.assertEquals(this.account.provedState.get());
+    this.account.provedState.requireEquals(this.account.provedState.get());
     this.account.provedState.get().assertFalse();
 
     this.num.set(Field(12));
   }
 
   @method add(incrementBy: Field) {
-    this.account.provedState.assertEquals(this.account.provedState.get());
+    this.account.provedState.requireEquals(this.account.provedState.get());
     this.account.provedState.get().assertTrue();
 
     const num = this.num.get();
-    this.num.assertEquals(num);
+    this.num.requireEquals(num);
     this.num.set(num.add(incrementBy));
   }
 }
@@ -342,22 +342,22 @@ As a reminder, this update corresponds to code:
 ```typescript
   ...
   @method add(incrementBy: Field) {
-    this.account.provedState.assertEquals(this.account.provedState.get());
+    this.account.provedState.requireEquals(this.account.provedState.get());
     this.account.provedState.get().assertTrue();
 
     const num = this.num.get();
-    this.num.assertEquals(num);
+    this.num.requireEquals(num);
     this.num.set(num.add(incrementBy));
 
     this.incrementCalls();
   }
 
   @method incrementCalls() {
-    this.account.provedState.assertEquals(this.account.provedState.get());
+    this.account.provedState.requireEquals(this.account.provedState.get());
     this.account.provedState.get().assertTrue();
 
     const calls = this.calls.get();
-    this.calls.assertEquals(calls);
+    this.calls.requireEquals(calls);
     this.calls.set(calls.add(Field(1)));
   }
   ...
@@ -393,13 +393,13 @@ And a quick reminder of the code for `callSecondary()`:
 
 ```typescript
   @method callSecondary(secondaryAddr: PublicKey) {
-    this.account.provedState.assertEquals(this.account.provedState.get());
+    this.account.provedState.requireEquals(this.account.provedState.get());
     this.account.provedState.get().assertTrue();
 
     const secondaryContract = new SecondaryZkApp(secondaryAddr);
 
     const num = this.num.get();
-    this.num.assertEquals(num);
+    this.num.requireEquals(num);
 
     secondaryContract.add(num);
 

--- a/examples/zkapps/01-hello-world/package-lock.json
+++ b/examples/zkapps/01-hello-world/package-lock.json
@@ -15,7 +15,7 @@
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "eslint": "^8.7.0",
-        "eslint-plugin-o1js": "^0.1.0",
+        "eslint-plugin-o1js": "^0.4.0",
         "husky": "^7.0.1",
         "jest": "^27.3.1",
         "lint-staged": "^11.0.1",
@@ -24,7 +24,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "^0.12.1"
+        "o1js": "0.15.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3292,6 +3292,15 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -3865,9 +3874,9 @@
       }
     },
     "node_modules/eslint-plugin-o1js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.1.0.tgz",
-      "integrity": "sha512-ir0fK7RLXfAK4GC11PpCPEC1fTFK1R/uK9DCxQH/rmcgDC0j6AncWRdo7ewkwSNiodmXODWLcuYYt4L4U6KA3A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.4.0.tgz",
+      "integrity": "sha512-12qI6OvAMtUIh8x9lB5uVzJbRMSR6tGrbCRM98fcCmll1FNvVSUIaat3CWhH17tkcjoyVSaFy0I/WzZcqPqaUA==",
       "dev": true
     },
     "node_modules/eslint-scope": {
@@ -7205,12 +7214,13 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.12.1.tgz",
-      "integrity": "sha512-1Z7+FUzARe+1pSLpeaWqzb2kXbPRbZBLBp9MgzIkNJTIFYFAijVdSyqnBJulYyidq7BNCd0R91+hX8sVGQlhnw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
+      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",
+        "cachedir": "^2.4.0",
         "detect-gpu": "^5.0.5",
         "isomorphic-fetch": "^3.0.0",
         "js-sha256": "^0.9.0",
@@ -11080,6 +11090,12 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "peer": true
+    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -11675,9 +11691,9 @@
       }
     },
     "eslint-plugin-o1js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.1.0.tgz",
-      "integrity": "sha512-ir0fK7RLXfAK4GC11PpCPEC1fTFK1R/uK9DCxQH/rmcgDC0j6AncWRdo7ewkwSNiodmXODWLcuYYt4L4U6KA3A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.4.0.tgz",
+      "integrity": "sha512-12qI6OvAMtUIh8x9lB5uVzJbRMSR6tGrbCRM98fcCmll1FNvVSUIaat3CWhH17tkcjoyVSaFy0I/WzZcqPqaUA==",
       "dev": true
     },
     "eslint-scope": {
@@ -14041,12 +14057,13 @@
       "dev": true
     },
     "o1js": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.12.1.tgz",
-      "integrity": "sha512-1Z7+FUzARe+1pSLpeaWqzb2kXbPRbZBLBp9MgzIkNJTIFYFAijVdSyqnBJulYyidq7BNCd0R91+hX8sVGQlhnw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
+      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
       "peer": true,
       "requires": {
         "blakejs": "1.2.1",
+        "cachedir": "^2.4.0",
         "detect-gpu": "^5.0.5",
         "isomorphic-fetch": "^3.0.0",
         "js-sha256": "^0.9.0",

--- a/examples/zkapps/01-hello-world/package-lock.json
+++ b/examples/zkapps/01-hello-world/package-lock.json
@@ -24,7 +24,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "0.15.0"
+        "o1js": "0.15.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7214,9 +7214,9 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
-      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.1.tgz",
+      "integrity": "sha512-B5GHUNfwOW3uc9clgCKktZDlZUJ2052QiG8ZF/VX8IK2lo4nZKe4C5wJOExgj1o+T0d/NKrBpLRS9LqIvDW6Ug==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",
@@ -14057,9 +14057,9 @@
       "dev": true
     },
     "o1js": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
-      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.1.tgz",
+      "integrity": "sha512-B5GHUNfwOW3uc9clgCKktZDlZUJ2052QiG8ZF/VX8IK2lo4nZKe4C5wJOExgj1o+T0d/NKrBpLRS9LqIvDW6Ug==",
       "peer": true,
       "requires": {
         "blakejs": "1.2.1",

--- a/examples/zkapps/01-hello-world/package.json
+++ b/examples/zkapps/01-hello-world/package.json
@@ -43,6 +43,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "^0.12.1"
+    "o1js": "0.15.0"
   }
 }

--- a/examples/zkapps/01-hello-world/package.json
+++ b/examples/zkapps/01-hello-world/package.json
@@ -43,6 +43,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "0.15.0"
+    "o1js": "0.15.1"
   }
 }

--- a/examples/zkapps/01-hello-world/src/Square.ts
+++ b/examples/zkapps/01-hello-world/src/Square.ts
@@ -16,7 +16,7 @@ export class Square extends SmartContract {
 
   @method update(square: Field) {
     const currentState = this.num.get();
-    this.num.assertEquals(currentState);
+    this.num.requireEquals(currentState);
     square.assertEquals(currentState.mul(currentState));
     this.num.set(square);
   }

--- a/examples/zkapps/02-private-inputs-and-hash-functions/package-lock.json
+++ b/examples/zkapps/02-private-inputs-and-hash-functions/package-lock.json
@@ -15,7 +15,7 @@
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "eslint": "^8.7.0",
-        "eslint-plugin-o1js": "^0.1.0",
+        "eslint-plugin-o1js": "^0.4.0",
         "husky": "^7.0.1",
         "jest": "^27.3.1",
         "lint-staged": "^11.0.1",
@@ -24,7 +24,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "^0.12.1"
+        "o1js": "0.15.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3292,6 +3292,15 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -3865,9 +3874,9 @@
       }
     },
     "node_modules/eslint-plugin-o1js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.1.0.tgz",
-      "integrity": "sha512-ir0fK7RLXfAK4GC11PpCPEC1fTFK1R/uK9DCxQH/rmcgDC0j6AncWRdo7ewkwSNiodmXODWLcuYYt4L4U6KA3A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.4.0.tgz",
+      "integrity": "sha512-12qI6OvAMtUIh8x9lB5uVzJbRMSR6tGrbCRM98fcCmll1FNvVSUIaat3CWhH17tkcjoyVSaFy0I/WzZcqPqaUA==",
       "dev": true
     },
     "node_modules/eslint-scope": {
@@ -7205,12 +7214,13 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.12.1.tgz",
-      "integrity": "sha512-1Z7+FUzARe+1pSLpeaWqzb2kXbPRbZBLBp9MgzIkNJTIFYFAijVdSyqnBJulYyidq7BNCd0R91+hX8sVGQlhnw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
+      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",
+        "cachedir": "^2.4.0",
         "detect-gpu": "^5.0.5",
         "isomorphic-fetch": "^3.0.0",
         "js-sha256": "^0.9.0",
@@ -11080,6 +11090,12 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "peer": true
+    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -11675,9 +11691,9 @@
       }
     },
     "eslint-plugin-o1js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.1.0.tgz",
-      "integrity": "sha512-ir0fK7RLXfAK4GC11PpCPEC1fTFK1R/uK9DCxQH/rmcgDC0j6AncWRdo7ewkwSNiodmXODWLcuYYt4L4U6KA3A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.4.0.tgz",
+      "integrity": "sha512-12qI6OvAMtUIh8x9lB5uVzJbRMSR6tGrbCRM98fcCmll1FNvVSUIaat3CWhH17tkcjoyVSaFy0I/WzZcqPqaUA==",
       "dev": true
     },
     "eslint-scope": {
@@ -14041,12 +14057,13 @@
       "dev": true
     },
     "o1js": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.12.1.tgz",
-      "integrity": "sha512-1Z7+FUzARe+1pSLpeaWqzb2kXbPRbZBLBp9MgzIkNJTIFYFAijVdSyqnBJulYyidq7BNCd0R91+hX8sVGQlhnw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
+      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
       "peer": true,
       "requires": {
         "blakejs": "1.2.1",
+        "cachedir": "^2.4.0",
         "detect-gpu": "^5.0.5",
         "isomorphic-fetch": "^3.0.0",
         "js-sha256": "^0.9.0",

--- a/examples/zkapps/02-private-inputs-and-hash-functions/package-lock.json
+++ b/examples/zkapps/02-private-inputs-and-hash-functions/package-lock.json
@@ -24,7 +24,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "0.15.0"
+        "o1js": "0.15.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7214,9 +7214,9 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
-      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.1.tgz",
+      "integrity": "sha512-B5GHUNfwOW3uc9clgCKktZDlZUJ2052QiG8ZF/VX8IK2lo4nZKe4C5wJOExgj1o+T0d/NKrBpLRS9LqIvDW6Ug==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",
@@ -14057,9 +14057,9 @@
       "dev": true
     },
     "o1js": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
-      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.1.tgz",
+      "integrity": "sha512-B5GHUNfwOW3uc9clgCKktZDlZUJ2052QiG8ZF/VX8IK2lo4nZKe4C5wJOExgj1o+T0d/NKrBpLRS9LqIvDW6Ug==",
       "peer": true,
       "requires": {
         "blakejs": "1.2.1",

--- a/examples/zkapps/02-private-inputs-and-hash-functions/package.json
+++ b/examples/zkapps/02-private-inputs-and-hash-functions/package.json
@@ -43,6 +43,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "^0.12.1"
+    "o1js": "0.15.0"
   }
 }

--- a/examples/zkapps/02-private-inputs-and-hash-functions/package.json
+++ b/examples/zkapps/02-private-inputs-and-hash-functions/package.json
@@ -43,6 +43,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "0.15.0"
+    "o1js": "0.15.1"
   }
 }

--- a/examples/zkapps/02-private-inputs-and-hash-functions/src/IncrementSecret.ts
+++ b/examples/zkapps/02-private-inputs-and-hash-functions/src/IncrementSecret.ts
@@ -9,7 +9,7 @@ export class IncrementSecret extends SmartContract {
 
   @method incrementSecret(salt: Field, secret: Field) {
     const x = this.x.get();
-    this.x.assertEquals(x);
+    this.x.requireEquals(x);
 
     Poseidon.hash([salt, secret]).assertEquals(x);
     this.x.set(Poseidon.hash([salt, secret.add(1)]));

--- a/examples/zkapps/04-zkapp-browser-ui/contracts/package-lock.json
+++ b/examples/zkapps/04-zkapp-browser-ui/contracts/package-lock.json
@@ -24,7 +24,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "0.15.0"
+        "o1js": "0.15.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -7479,9 +7479,9 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
-      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.1.tgz",
+      "integrity": "sha512-B5GHUNfwOW3uc9clgCKktZDlZUJ2052QiG8ZF/VX8IK2lo4nZKe4C5wJOExgj1o+T0d/NKrBpLRS9LqIvDW6Ug==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",

--- a/examples/zkapps/04-zkapp-browser-ui/contracts/package-lock.json
+++ b/examples/zkapps/04-zkapp-browser-ui/contracts/package-lock.json
@@ -24,7 +24,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "0.13.*"
+        "o1js": "0.15.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3630,6 +3630,15 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -7470,12 +7479,13 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.13.1.tgz",
-      "integrity": "sha512-7QHHRRLmmyR8e+YmIFcgatS2q1on+SDD9h4NIK8JR/82eim7w8bQyBZqAwfCU2PmaQtqlZhkLoL4PmZRnxDzQQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
+      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",
+        "cachedir": "^2.4.0",
         "detect-gpu": "^5.0.5",
         "isomorphic-fetch": "^3.0.0",
         "js-sha256": "^0.9.0",

--- a/examples/zkapps/04-zkapp-browser-ui/contracts/package.json
+++ b/examples/zkapps/04-zkapp-browser-ui/contracts/package.json
@@ -45,6 +45,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "0.15.0"
+    "o1js": "0.15.1"
   }
 }

--- a/examples/zkapps/04-zkapp-browser-ui/contracts/package.json
+++ b/examples/zkapps/04-zkapp-browser-ui/contracts/package.json
@@ -45,6 +45,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "0.13.*"
+    "o1js": "0.15.0"
   }
 }

--- a/examples/zkapps/04-zkapp-browser-ui/contracts/src/Add.ts
+++ b/examples/zkapps/04-zkapp-browser-ui/contracts/src/Add.ts
@@ -18,7 +18,7 @@ export class Add extends SmartContract {
   }
 
   @method update() {
-    const currentState = this.num.getAndAssertEquals();
+    const currentState = this.num.getAndRequireEquals();
     const newState = currentState.add(2);
     this.num.set(newState);
   }

--- a/examples/zkapps/05-common-types-and-functions/package-lock.json
+++ b/examples/zkapps/05-common-types-and-functions/package-lock.json
@@ -15,7 +15,7 @@
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "eslint": "^8.7.0",
-        "eslint-plugin-o1js": "^0.1.0",
+        "eslint-plugin-o1js": "^0.4.0",
         "husky": "^7.0.1",
         "jest": "^27.3.1",
         "lint-staged": "^11.0.1",
@@ -24,7 +24,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "^0.12.1"
+        "o1js": "0.15.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3292,6 +3292,15 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -3865,9 +3874,9 @@
       }
     },
     "node_modules/eslint-plugin-o1js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.1.0.tgz",
-      "integrity": "sha512-ir0fK7RLXfAK4GC11PpCPEC1fTFK1R/uK9DCxQH/rmcgDC0j6AncWRdo7ewkwSNiodmXODWLcuYYt4L4U6KA3A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.4.0.tgz",
+      "integrity": "sha512-12qI6OvAMtUIh8x9lB5uVzJbRMSR6tGrbCRM98fcCmll1FNvVSUIaat3CWhH17tkcjoyVSaFy0I/WzZcqPqaUA==",
       "dev": true
     },
     "node_modules/eslint-scope": {
@@ -7205,12 +7214,13 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.12.1.tgz",
-      "integrity": "sha512-1Z7+FUzARe+1pSLpeaWqzb2kXbPRbZBLBp9MgzIkNJTIFYFAijVdSyqnBJulYyidq7BNCd0R91+hX8sVGQlhnw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
+      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",
+        "cachedir": "^2.4.0",
         "detect-gpu": "^5.0.5",
         "isomorphic-fetch": "^3.0.0",
         "js-sha256": "^0.9.0",
@@ -11080,6 +11090,12 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "peer": true
+    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -11675,9 +11691,9 @@
       }
     },
     "eslint-plugin-o1js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.1.0.tgz",
-      "integrity": "sha512-ir0fK7RLXfAK4GC11PpCPEC1fTFK1R/uK9DCxQH/rmcgDC0j6AncWRdo7ewkwSNiodmXODWLcuYYt4L4U6KA3A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.4.0.tgz",
+      "integrity": "sha512-12qI6OvAMtUIh8x9lB5uVzJbRMSR6tGrbCRM98fcCmll1FNvVSUIaat3CWhH17tkcjoyVSaFy0I/WzZcqPqaUA==",
       "dev": true
     },
     "eslint-scope": {
@@ -14041,12 +14057,13 @@
       "dev": true
     },
     "o1js": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.12.1.tgz",
-      "integrity": "sha512-1Z7+FUzARe+1pSLpeaWqzb2kXbPRbZBLBp9MgzIkNJTIFYFAijVdSyqnBJulYyidq7BNCd0R91+hX8sVGQlhnw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
+      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
       "peer": true,
       "requires": {
         "blakejs": "1.2.1",
+        "cachedir": "^2.4.0",
         "detect-gpu": "^5.0.5",
         "isomorphic-fetch": "^3.0.0",
         "js-sha256": "^0.9.0",

--- a/examples/zkapps/05-common-types-and-functions/package-lock.json
+++ b/examples/zkapps/05-common-types-and-functions/package-lock.json
@@ -24,7 +24,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "0.15.0"
+        "o1js": "0.15.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7214,9 +7214,9 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
-      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.1.tgz",
+      "integrity": "sha512-B5GHUNfwOW3uc9clgCKktZDlZUJ2052QiG8ZF/VX8IK2lo4nZKe4C5wJOExgj1o+T0d/NKrBpLRS9LqIvDW6Ug==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",
@@ -14057,9 +14057,9 @@
       "dev": true
     },
     "o1js": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
-      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.1.tgz",
+      "integrity": "sha512-B5GHUNfwOW3uc9clgCKktZDlZUJ2052QiG8ZF/VX8IK2lo4nZKe4C5wJOExgj1o+T0d/NKrBpLRS9LqIvDW6Ug==",
       "peer": true,
       "requires": {
         "blakejs": "1.2.1",

--- a/examples/zkapps/05-common-types-and-functions/package.json
+++ b/examples/zkapps/05-common-types-and-functions/package.json
@@ -43,6 +43,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "^0.12.1"
+    "o1js": "0.15.0"
   }
 }

--- a/examples/zkapps/05-common-types-and-functions/package.json
+++ b/examples/zkapps/05-common-types-and-functions/package.json
@@ -43,6 +43,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "0.15.0"
+    "o1js": "0.15.1"
   }
 }

--- a/examples/zkapps/05-common-types-and-functions/src/BasicMerkleTreeContract.ts
+++ b/examples/zkapps/05-common-types-and-functions/src/BasicMerkleTreeContract.ts
@@ -22,7 +22,7 @@ export class BasicMerkleTreeContract extends SmartContract {
     incrementAmount: Field
   ) {
     const initialRoot = this.treeRoot.get();
-    this.treeRoot.assertEquals(initialRoot);
+    this.treeRoot.requireEquals(initialRoot);
 
     incrementAmount.assertLessThan(Field(10));
 

--- a/examples/zkapps/05-common-types-and-functions/src/LedgerContract.ts
+++ b/examples/zkapps/05-common-types-and-functions/src/LedgerContract.ts
@@ -31,7 +31,7 @@ export class LedgerContract extends SmartContract {
     sendAmount: Field
   ) {
     const initialLedgerRoot = this.ledgerRoot.get();
-    this.ledgerRoot.assertEquals(initialLedgerRoot);
+    this.ledgerRoot.requireEquals(initialLedgerRoot);
 
     // check the sender's signature
     senderSignature

--- a/examples/zkapps/07-oracles/contracts/package-lock.json
+++ b/examples/zkapps/07-oracles/contracts/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "package-name",
+  "name": "contracts",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "package-name",
+      "name": "contracts",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
@@ -24,7 +24,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "0.13.*"
+        "o1js": "0.15.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3610,6 +3610,15 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -7457,12 +7466,13 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.13.1.tgz",
-      "integrity": "sha512-7QHHRRLmmyR8e+YmIFcgatS2q1on+SDD9h4NIK8JR/82eim7w8bQyBZqAwfCU2PmaQtqlZhkLoL4PmZRnxDzQQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
+      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",
+        "cachedir": "^2.4.0",
         "detect-gpu": "^5.0.5",
         "isomorphic-fetch": "^3.0.0",
         "js-sha256": "^0.9.0",

--- a/examples/zkapps/07-oracles/contracts/package-lock.json
+++ b/examples/zkapps/07-oracles/contracts/package-lock.json
@@ -24,7 +24,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "0.15.0"
+        "o1js": "0.15.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -7466,9 +7466,9 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
-      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.1.tgz",
+      "integrity": "sha512-B5GHUNfwOW3uc9clgCKktZDlZUJ2052QiG8ZF/VX8IK2lo4nZKe4C5wJOExgj1o+T0d/NKrBpLRS9LqIvDW6Ug==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",

--- a/examples/zkapps/07-oracles/contracts/package.json
+++ b/examples/zkapps/07-oracles/contracts/package.json
@@ -45,6 +45,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "0.15.0"
+    "o1js": "0.15.1"
   }
 }

--- a/examples/zkapps/07-oracles/contracts/package.json
+++ b/examples/zkapps/07-oracles/contracts/package.json
@@ -45,6 +45,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "0.13.*"
+    "o1js": "0.15.0"
   }
 }

--- a/examples/zkapps/07-oracles/contracts/src/OracleExample.ts
+++ b/examples/zkapps/07-oracles/contracts/src/OracleExample.ts
@@ -32,7 +32,7 @@ export class OracleExample extends SmartContract {
   @method verify(id: Field, creditScore: Field, signature: Signature) {
     // Get the oracle public key from the contract state
     const oraclePublicKey = this.oraclePublicKey.get();
-    this.oraclePublicKey.assertEquals(oraclePublicKey);
+    this.oraclePublicKey.requireEquals(oraclePublicKey);
     // Evaluate whether the signature is valid for the provided data
     const validSignature = signature.verify(oraclePublicKey, [id, creditScore]);
     // Check that the signature is valid

--- a/examples/zkapps/08-custom-tokens/package-lock.json
+++ b/examples/zkapps/08-custom-tokens/package-lock.json
@@ -15,7 +15,7 @@
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "eslint": "^8.7.0",
-        "eslint-plugin-o1js": "^0.1.0",
+        "eslint-plugin-o1js": "^0.4.0",
         "husky": "^7.0.1",
         "jest": "^27.3.1",
         "lint-staged": "^11.0.1",
@@ -24,7 +24,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "^0.12.1"
+        "o1js": "0.15.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3292,6 +3292,15 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -3865,9 +3874,9 @@
       }
     },
     "node_modules/eslint-plugin-o1js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.1.0.tgz",
-      "integrity": "sha512-ir0fK7RLXfAK4GC11PpCPEC1fTFK1R/uK9DCxQH/rmcgDC0j6AncWRdo7ewkwSNiodmXODWLcuYYt4L4U6KA3A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.4.0.tgz",
+      "integrity": "sha512-12qI6OvAMtUIh8x9lB5uVzJbRMSR6tGrbCRM98fcCmll1FNvVSUIaat3CWhH17tkcjoyVSaFy0I/WzZcqPqaUA==",
       "dev": true
     },
     "node_modules/eslint-scope": {
@@ -7205,12 +7214,13 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.12.1.tgz",
-      "integrity": "sha512-1Z7+FUzARe+1pSLpeaWqzb2kXbPRbZBLBp9MgzIkNJTIFYFAijVdSyqnBJulYyidq7BNCd0R91+hX8sVGQlhnw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
+      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",
+        "cachedir": "^2.4.0",
         "detect-gpu": "^5.0.5",
         "isomorphic-fetch": "^3.0.0",
         "js-sha256": "^0.9.0",
@@ -11080,6 +11090,12 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "peer": true
+    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -11675,9 +11691,9 @@
       }
     },
     "eslint-plugin-o1js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.1.0.tgz",
-      "integrity": "sha512-ir0fK7RLXfAK4GC11PpCPEC1fTFK1R/uK9DCxQH/rmcgDC0j6AncWRdo7ewkwSNiodmXODWLcuYYt4L4U6KA3A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.4.0.tgz",
+      "integrity": "sha512-12qI6OvAMtUIh8x9lB5uVzJbRMSR6tGrbCRM98fcCmll1FNvVSUIaat3CWhH17tkcjoyVSaFy0I/WzZcqPqaUA==",
       "dev": true
     },
     "eslint-scope": {
@@ -14041,12 +14057,13 @@
       "dev": true
     },
     "o1js": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.12.1.tgz",
-      "integrity": "sha512-1Z7+FUzARe+1pSLpeaWqzb2kXbPRbZBLBp9MgzIkNJTIFYFAijVdSyqnBJulYyidq7BNCd0R91+hX8sVGQlhnw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
+      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
       "peer": true,
       "requires": {
         "blakejs": "1.2.1",
+        "cachedir": "^2.4.0",
         "detect-gpu": "^5.0.5",
         "isomorphic-fetch": "^3.0.0",
         "js-sha256": "^0.9.0",

--- a/examples/zkapps/08-custom-tokens/package-lock.json
+++ b/examples/zkapps/08-custom-tokens/package-lock.json
@@ -24,7 +24,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "0.15.0"
+        "o1js": "0.15.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7214,9 +7214,9 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
-      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.1.tgz",
+      "integrity": "sha512-B5GHUNfwOW3uc9clgCKktZDlZUJ2052QiG8ZF/VX8IK2lo4nZKe4C5wJOExgj1o+T0d/NKrBpLRS9LqIvDW6Ug==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",
@@ -14057,9 +14057,9 @@
       "dev": true
     },
     "o1js": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
-      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.1.tgz",
+      "integrity": "sha512-B5GHUNfwOW3uc9clgCKktZDlZUJ2052QiG8ZF/VX8IK2lo4nZKe4C5wJOExgj1o+T0d/NKrBpLRS9LqIvDW6Ug==",
       "peer": true,
       "requires": {
         "blakejs": "1.2.1",

--- a/examples/zkapps/08-custom-tokens/package.json
+++ b/examples/zkapps/08-custom-tokens/package.json
@@ -43,6 +43,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "^0.12.1"
+    "o1js": "0.15.0"
   }
 }

--- a/examples/zkapps/08-custom-tokens/package.json
+++ b/examples/zkapps/08-custom-tokens/package.json
@@ -43,6 +43,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "0.15.0"
+    "o1js": "0.15.1"
   }
 }

--- a/examples/zkapps/08-custom-tokens/src/BasicTokenContract.ts
+++ b/examples/zkapps/08-custom-tokens/src/BasicTokenContract.ts
@@ -41,7 +41,7 @@ export class BasicTokenContract extends SmartContract {
     adminSignature: Signature
   ) {
     let totalAmountInCirculation = this.totalAmountInCirculation.get();
-    this.totalAmountInCirculation.assertEquals(totalAmountInCirculation);
+    this.totalAmountInCirculation.requireEquals(totalAmountInCirculation);
 
     let newTotalAmountInCirculation = totalAmountInCirculation.add(amount);
 

--- a/examples/zkapps/08-custom-tokens/src/WhitelistedTokenContract.ts
+++ b/examples/zkapps/08-custom-tokens/src/WhitelistedTokenContract.ts
@@ -51,7 +51,7 @@ export class WhitelistedTokenContract extends SmartContract {
     adminSignature: Signature
   ) {
     let totalAmountInCirculation = this.totalAmountInCirculation.get();
-    this.totalAmountInCirculation.assertEquals(totalAmountInCirculation);
+    this.totalAmountInCirculation.requireEquals(totalAmountInCirculation);
 
     let newTotalAmountInCirculation = totalAmountInCirculation.add(amount);
 
@@ -77,7 +77,7 @@ export class WhitelistedTokenContract extends SmartContract {
     adminSignature: Signature
   ) {
     const whitelistTreeRoot = this.whitelistTreeRoot.get();
-    this.whitelistTreeRoot.assertEquals(whitelistTreeRoot);
+    this.whitelistTreeRoot.requireEquals(whitelistTreeRoot);
 
     adminSignature.verify(this.address, [newWhitelistRoot]).assertTrue();
 
@@ -99,7 +99,7 @@ export class WhitelistedTokenContract extends SmartContract {
     whitelistWitness: MerkleWitness20
   ) {
     const whitelistTreeRoot = this.whitelistTreeRoot.get();
-    this.whitelistTreeRoot.assertEquals(whitelistTreeRoot);
+    this.whitelistTreeRoot.requireEquals(whitelistTreeRoot);
 
     whitelistWitness
       .calculateRoot(Poseidon.hash(receiverAddress.toFields()))

--- a/examples/zkapps/09-recursion/package-lock.json
+++ b/examples/zkapps/09-recursion/package-lock.json
@@ -15,7 +15,7 @@
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "eslint": "^8.7.0",
-        "eslint-plugin-o1js": "^0.1.0",
+        "eslint-plugin-o1js": "^0.4.0",
         "husky": "^7.0.1",
         "jest": "^27.3.1",
         "lint-staged": "^11.0.1",
@@ -24,7 +24,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "^0.12.1"
+        "o1js": "0.15.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3292,6 +3292,15 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -3865,9 +3874,9 @@
       }
     },
     "node_modules/eslint-plugin-o1js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.1.0.tgz",
-      "integrity": "sha512-ir0fK7RLXfAK4GC11PpCPEC1fTFK1R/uK9DCxQH/rmcgDC0j6AncWRdo7ewkwSNiodmXODWLcuYYt4L4U6KA3A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.4.0.tgz",
+      "integrity": "sha512-12qI6OvAMtUIh8x9lB5uVzJbRMSR6tGrbCRM98fcCmll1FNvVSUIaat3CWhH17tkcjoyVSaFy0I/WzZcqPqaUA==",
       "dev": true
     },
     "node_modules/eslint-scope": {
@@ -7205,12 +7214,13 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.12.1.tgz",
-      "integrity": "sha512-1Z7+FUzARe+1pSLpeaWqzb2kXbPRbZBLBp9MgzIkNJTIFYFAijVdSyqnBJulYyidq7BNCd0R91+hX8sVGQlhnw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
+      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",
+        "cachedir": "^2.4.0",
         "detect-gpu": "^5.0.5",
         "isomorphic-fetch": "^3.0.0",
         "js-sha256": "^0.9.0",
@@ -11080,6 +11090,12 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "peer": true
+    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -11675,9 +11691,9 @@
       }
     },
     "eslint-plugin-o1js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.1.0.tgz",
-      "integrity": "sha512-ir0fK7RLXfAK4GC11PpCPEC1fTFK1R/uK9DCxQH/rmcgDC0j6AncWRdo7ewkwSNiodmXODWLcuYYt4L4U6KA3A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.4.0.tgz",
+      "integrity": "sha512-12qI6OvAMtUIh8x9lB5uVzJbRMSR6tGrbCRM98fcCmll1FNvVSUIaat3CWhH17tkcjoyVSaFy0I/WzZcqPqaUA==",
       "dev": true
     },
     "eslint-scope": {
@@ -14041,12 +14057,13 @@
       "dev": true
     },
     "o1js": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.12.1.tgz",
-      "integrity": "sha512-1Z7+FUzARe+1pSLpeaWqzb2kXbPRbZBLBp9MgzIkNJTIFYFAijVdSyqnBJulYyidq7BNCd0R91+hX8sVGQlhnw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
+      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
       "peer": true,
       "requires": {
         "blakejs": "1.2.1",
+        "cachedir": "^2.4.0",
         "detect-gpu": "^5.0.5",
         "isomorphic-fetch": "^3.0.0",
         "js-sha256": "^0.9.0",

--- a/examples/zkapps/09-recursion/package-lock.json
+++ b/examples/zkapps/09-recursion/package-lock.json
@@ -24,7 +24,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "0.15.0"
+        "o1js": "0.15.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7214,9 +7214,9 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
-      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.1.tgz",
+      "integrity": "sha512-B5GHUNfwOW3uc9clgCKktZDlZUJ2052QiG8ZF/VX8IK2lo4nZKe4C5wJOExgj1o+T0d/NKrBpLRS9LqIvDW6Ug==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",
@@ -14057,9 +14057,9 @@
       "dev": true
     },
     "o1js": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
-      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.1.tgz",
+      "integrity": "sha512-B5GHUNfwOW3uc9clgCKktZDlZUJ2052QiG8ZF/VX8IK2lo4nZKe4C5wJOExgj1o+T0d/NKrBpLRS9LqIvDW6Ug==",
       "peer": true,
       "requires": {
         "blakejs": "1.2.1",

--- a/examples/zkapps/09-recursion/package.json
+++ b/examples/zkapps/09-recursion/package.json
@@ -43,6 +43,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "^0.12.1"
+    "o1js": "0.15.0"
   }
 }

--- a/examples/zkapps/09-recursion/package.json
+++ b/examples/zkapps/09-recursion/package.json
@@ -43,6 +43,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "0.15.0"
+    "o1js": "0.15.1"
   }
 }

--- a/examples/zkapps/09-recursion/src/Square.ts
+++ b/examples/zkapps/09-recursion/src/Square.ts
@@ -22,7 +22,7 @@ export class Square extends SmartContract {
 
   @method update(square: Field) {
     const currentState = this.num.get();
-    this.num.assertEquals(currentState);
+    this.num.requireEquals(currentState);
     square.assertEquals(currentState.mul(currentState));
     this.num.set(square);
   }

--- a/examples/zkapps/09-recursion/src/main.ts
+++ b/examples/zkapps/09-recursion/src/main.ts
@@ -30,15 +30,15 @@ async function main() {
 
   const { verificationKey } = await Add.compile();
 
-  console.log('making proof 0')
+  console.log('making proof 0');
 
   const proof0 = await Add.init(Field(0));
 
-  console.log('making proof 1')
+  console.log('making proof 1');
 
   const proof1 = await Add.addNumber(Field(4), proof0, Field(4));
 
-  console.log('making proof 2')
+  console.log('making proof 2');
 
   const proof2 = await Add.add(Field(4), proof1, proof0);
 
@@ -54,6 +54,7 @@ async function main() {
 }
 
 const Add = ZkProgram({
+  name: 'add-example',
   publicInput: Field,
 
   methods: {
@@ -80,7 +81,7 @@ const Add = ZkProgram({
       method(
         newState: Field, 
         earlierProof1: SelfProof<Field, void>,
-        earlierProof2: SelfProof<Field, void>,
+        earlierProof2: SelfProof<Field, void>
       ) {
         earlierProof1.verify();
         earlierProof2.verify();

--- a/examples/zkapps/09-recursion/src/rollup.ts
+++ b/examples/zkapps/09-recursion/src/rollup.ts
@@ -1,7 +1,6 @@
 import {
   Field,
   SelfProof,
-  ZkProgram,
   Struct,
   MerkleMap,
   MerkleWitness,
@@ -14,7 +13,7 @@ import {
   DeployArgs,
   Proof,
   Permissions,
-  ZkProgram
+  ZkProgram,
 } from 'o1js';
 
 class MerkleWitness20 extends MerkleWitness(20) {}
@@ -217,7 +216,7 @@ class RollupContract extends SmartContract {
 
   @method update(rollupStateProof: RollupProof) {
     const currentState = this.state.get();
-    this.state.assertEquals(currentState);
+    this.state.requireEquals(currentState);
 
     rollupStateProof.publicInput.initialRoot.assertEquals(currentState);
 

--- a/examples/zkapps/09-recursion/src/vote.ts
+++ b/examples/zkapps/09-recursion/src/vote.ts
@@ -103,10 +103,10 @@ class VoteState extends Struct({
     voterWitness: MerkleWitness20,
     nullifierWitness: MerkleMapWitness,
   ) {
-    const publicKey = privateKey.toPublicKey()
+    const publicKey = privateKey.toPublicKey();
 
     const voterRoot = voterWitness.calculateRoot(Poseidon.hash(publicKey.toFields()));
-    voterRoot.assertEquals(state.votersTreeRoot)
+    voterRoot.assertEquals(state.votersTreeRoot);
 
     let nullifier = Poseidon.hash(privateKey.toFields());
 
@@ -125,8 +125,8 @@ class VoteState extends Struct({
   }
 
   static assertInitialState(state: VoteState) {
-    state.voteFor.assertEquals(Field(0))
-    state.voteAgainst.assertEquals(Field(0))
+    state.voteFor.assertEquals(Field(0));
+    state.voteAgainst.assertEquals(Field(0));
 
     const emptyMap = new MerkleMap();
     state.nullifierMapRoot.assertEquals(emptyMap.getRoot());
@@ -145,6 +145,7 @@ class VoteState extends Struct({
 // ===============================================================
 
 const Vote = ZkProgram({
+  name: 'vote-example',
   publicInput: VoteState,
 
   methods: {

--- a/examples/zkapps/10-account-updates/package-lock.json
+++ b/examples/zkapps/10-account-updates/package-lock.json
@@ -27,7 +27,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "0.15.0"
+        "o1js": "0.15.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7445,9 +7445,9 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
-      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.1.tgz",
+      "integrity": "sha512-B5GHUNfwOW3uc9clgCKktZDlZUJ2052QiG8ZF/VX8IK2lo4nZKe4C5wJOExgj1o+T0d/NKrBpLRS9LqIvDW6Ug==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",

--- a/examples/zkapps/10-account-updates/package-lock.json
+++ b/examples/zkapps/10-account-updates/package-lock.json
@@ -18,7 +18,7 @@
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "eslint": "^8.7.0",
-        "eslint-plugin-o1js": "^0.1.0",
+        "eslint-plugin-o1js": "^0.4.0",
         "husky": "^7.0.1",
         "jest": "^27.3.1",
         "lint-staged": "^11.0.1",
@@ -27,7 +27,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "^0.12.1"
+        "o1js": "0.15.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3545,6 +3545,15 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -4159,9 +4168,9 @@
       }
     },
     "node_modules/eslint-plugin-o1js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.1.0.tgz",
-      "integrity": "sha512-ir0fK7RLXfAK4GC11PpCPEC1fTFK1R/uK9DCxQH/rmcgDC0j6AncWRdo7ewkwSNiodmXODWLcuYYt4L4U6KA3A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.4.0.tgz",
+      "integrity": "sha512-12qI6OvAMtUIh8x9lB5uVzJbRMSR6tGrbCRM98fcCmll1FNvVSUIaat3CWhH17tkcjoyVSaFy0I/WzZcqPqaUA==",
       "dev": true
     },
     "node_modules/eslint-scope": {
@@ -7436,12 +7445,13 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.12.1.tgz",
-      "integrity": "sha512-1Z7+FUzARe+1pSLpeaWqzb2kXbPRbZBLBp9MgzIkNJTIFYFAijVdSyqnBJulYyidq7BNCd0R91+hX8sVGQlhnw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
+      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",
+        "cachedir": "^2.4.0",
         "detect-gpu": "^5.0.5",
         "isomorphic-fetch": "^3.0.0",
         "js-sha256": "^0.9.0",

--- a/examples/zkapps/10-account-updates/package.json
+++ b/examples/zkapps/10-account-updates/package.json
@@ -44,7 +44,7 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "^0.12.1"
+    "o1js": "0.15.0"
   },
   "dependencies": {
     "mina-transaction-visualizer": "^0.1.0"

--- a/examples/zkapps/10-account-updates/package.json
+++ b/examples/zkapps/10-account-updates/package.json
@@ -44,7 +44,7 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "0.15.0"
+    "o1js": "0.15.1"
   },
   "dependencies": {
     "mina-transaction-visualizer": "^0.1.0"

--- a/examples/zkapps/10-account-updates/src/ProofsOnlyZkApp.ts
+++ b/examples/zkapps/10-account-updates/src/ProofsOnlyZkApp.ts
@@ -31,7 +31,7 @@ export class ProofsOnlyZkApp extends SmartContract {
   }
 
   @method init() {
-    this.account.provedState.assertEquals(this.account.provedState.get());
+    this.account.provedState.requireEquals(this.account.provedState.get());
     this.account.provedState.get().assertFalse();
 
     super.init();
@@ -40,33 +40,33 @@ export class ProofsOnlyZkApp extends SmartContract {
   }
 
   @method add(incrementBy: Field) {
-    this.account.provedState.assertEquals(this.account.provedState.get());
+    this.account.provedState.requireEquals(this.account.provedState.get());
     this.account.provedState.get().assertTrue();
 
     const num = this.num.get();
-    this.num.assertEquals(num);
+    this.num.requireEquals(num);
     this.num.set(num.add(incrementBy));
 
     this.incrementCalls();
   }
 
   @method incrementCalls() {
-    this.account.provedState.assertEquals(this.account.provedState.get());
+    this.account.provedState.requireEquals(this.account.provedState.get());
     this.account.provedState.get().assertTrue();
 
     const calls = this.calls.get();
-    this.calls.assertEquals(calls);
+    this.calls.requireEquals(calls);
     this.calls.set(calls.add(Field(1)));
   }
 
   @method callSecondary(secondaryAddr: PublicKey) {
-    this.account.provedState.assertEquals(this.account.provedState.get());
+    this.account.provedState.requireEquals(this.account.provedState.get());
     this.account.provedState.get().assertTrue();
 
     const secondaryContract = new SecondaryZkApp(secondaryAddr);
 
     const num = this.num.get();
-    this.num.assertEquals(num);
+    this.num.requireEquals(num);
 
     secondaryContract.add(num);
 

--- a/examples/zkapps/10-account-updates/src/SecondaryZkApp.ts
+++ b/examples/zkapps/10-account-updates/src/SecondaryZkApp.ts
@@ -19,7 +19,7 @@ export class SecondaryZkApp extends SmartContract {
   }
 
   @method init() {
-    this.account.provedState.assertEquals(this.account.provedState.get());
+    this.account.provedState.requireEquals(this.account.provedState.get());
     this.account.provedState.get().assertFalse();
 
     super.init();
@@ -27,11 +27,11 @@ export class SecondaryZkApp extends SmartContract {
   }
 
   @method add(incrementBy: Field) {
-    this.account.provedState.assertEquals(this.account.provedState.get());
+    this.account.provedState.requireEquals(this.account.provedState.get());
     this.account.provedState.get().assertTrue();
 
     const num = this.num.get();
-    this.num.assertEquals(num);
+    this.num.requireEquals(num);
     this.num.set(num.add(incrementBy));
   }
 }

--- a/examples/zkapps/11-advanced-account-updates/package-lock.json
+++ b/examples/zkapps/11-advanced-account-updates/package-lock.json
@@ -18,7 +18,7 @@
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "eslint": "^8.7.0",
-        "eslint-plugin-o1js": "^0.1.0",
+        "eslint-plugin-o1js": "^0.4.0",
         "husky": "^7.0.1",
         "jest": "^27.3.1",
         "lint-staged": "^11.0.1",
@@ -27,7 +27,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "^0.12.1"
+        "o1js": "0.15.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3562,6 +3562,15 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -4180,9 +4189,9 @@
       }
     },
     "node_modules/eslint-plugin-o1js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.1.0.tgz",
-      "integrity": "sha512-ir0fK7RLXfAK4GC11PpCPEC1fTFK1R/uK9DCxQH/rmcgDC0j6AncWRdo7ewkwSNiodmXODWLcuYYt4L4U6KA3A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.4.0.tgz",
+      "integrity": "sha512-12qI6OvAMtUIh8x9lB5uVzJbRMSR6tGrbCRM98fcCmll1FNvVSUIaat3CWhH17tkcjoyVSaFy0I/WzZcqPqaUA==",
       "dev": true
     },
     "node_modules/eslint-scope": {
@@ -7460,12 +7469,13 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.12.1.tgz",
-      "integrity": "sha512-1Z7+FUzARe+1pSLpeaWqzb2kXbPRbZBLBp9MgzIkNJTIFYFAijVdSyqnBJulYyidq7BNCd0R91+hX8sVGQlhnw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
+      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",
+        "cachedir": "^2.4.0",
         "detect-gpu": "^5.0.5",
         "isomorphic-fetch": "^3.0.0",
         "js-sha256": "^0.9.0",

--- a/examples/zkapps/11-advanced-account-updates/package-lock.json
+++ b/examples/zkapps/11-advanced-account-updates/package-lock.json
@@ -27,7 +27,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "0.15.0"
+        "o1js": "0.15.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7469,9 +7469,9 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
-      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.1.tgz",
+      "integrity": "sha512-B5GHUNfwOW3uc9clgCKktZDlZUJ2052QiG8ZF/VX8IK2lo4nZKe4C5wJOExgj1o+T0d/NKrBpLRS9LqIvDW6Ug==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",

--- a/examples/zkapps/11-advanced-account-updates/package.json
+++ b/examples/zkapps/11-advanced-account-updates/package.json
@@ -44,7 +44,7 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "^0.12.1"
+    "o1js": "0.15.0"
   },
   "dependencies": {
     "mina-transaction-visualizer": "^0.1.0"

--- a/examples/zkapps/11-advanced-account-updates/package.json
+++ b/examples/zkapps/11-advanced-account-updates/package.json
@@ -44,7 +44,7 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "0.15.0"
+    "o1js": "0.15.1"
   },
   "dependencies": {
     "mina-transaction-visualizer": "^0.1.0"

--- a/examples/zkapps/11-advanced-account-updates/src/ProofsOnlyZkApp.ts
+++ b/examples/zkapps/11-advanced-account-updates/src/ProofsOnlyZkApp.ts
@@ -31,7 +31,7 @@ export class ProofsOnlyZkApp extends SmartContract {
   @method init() {
     super.init();
 
-    this.account.provedState.assertEquals(this.account.provedState.get());
+    this.account.provedState.requireEquals(this.account.provedState.get());
     this.account.provedState.get().assertFalse();
 
     this.num.set(Field(1));
@@ -39,22 +39,22 @@ export class ProofsOnlyZkApp extends SmartContract {
   }
 
   @method add(incrementBy: Field) {
-    this.account.provedState.assertEquals(this.account.provedState.get());
+    this.account.provedState.requireEquals(this.account.provedState.get());
     this.account.provedState.get().assertTrue();
 
     const num = this.num.get();
-    this.num.assertEquals(num);
+    this.num.requireEquals(num);
     this.num.set(num.add(incrementBy));
 
     this.incrementCalls();
   }
 
   @method incrementCalls() {
-    this.account.provedState.assertEquals(this.account.provedState.get());
+    this.account.provedState.requireEquals(this.account.provedState.get());
     this.account.provedState.get().assertTrue();
 
     const calls = this.calls.get();
-    this.calls.assertEquals(calls);
+    this.calls.requireEquals(calls);
     this.calls.set(calls.add(Field(1)));
   }
 

--- a/examples/zkapps/11-advanced-account-updates/src/WrappedMina.ts
+++ b/examples/zkapps/11-advanced-account-updates/src/WrappedMina.ts
@@ -33,8 +33,8 @@ export class WrappedMina extends SmartContract {
       address: this.address,
       amount: UInt64.from(0),
     });
-    // assert that the receiving account is new, so this can be only done once
-    receiver.account.isNew.assertEquals(Bool(true));
+    // required that the receiving account is new, so this can be only done once
+    receiver.account.isNew.requireEquals(Bool(true));
     // pay fees for opened account
     this.balance.subInPlace(Mina.accountCreationFee());
     this.priorMina.set(UInt64.from(0));
@@ -44,12 +44,12 @@ export class WrappedMina extends SmartContract {
 
   @method mintWrappedMina(amount: UInt64, destination: PublicKey) {
     const priorMina = this.priorMina.get();
-    this.priorMina.assertEquals(this.priorMina.get());
+    this.priorMina.requireEquals(this.priorMina.get());
 
     const newMina = amount.add(priorMina);
 
     // TODO is there a way to directly get the balance change for this transaction?
-    this.account.balance.assertBetween(newMina, UInt64.MAXINT());
+    this.account.balance.requireBetween(newMina, UInt64.MAXINT());
 
     this.token.mint({ address: destination, amount });
 
@@ -76,7 +76,7 @@ export class WrappedMina extends SmartContract {
 
     // update priorMina
     const priorMina = this.priorMina.get();
-    this.priorMina.assertEquals(this.priorMina.get());
+    this.priorMina.requireEquals(this.priorMina.get());
     const newMina = priorMina.sub(amount);
     this.priorMina.set(newMina);
   }
@@ -91,7 +91,7 @@ export class WrappedMina extends SmartContract {
     this.token.burn({ address: source, amount });
 
     const priorMina = this.priorMina.get();
-    this.priorMina.assertEquals(this.priorMina.get());
+    this.priorMina.requireEquals(this.priorMina.get());
 
     const newMina = priorMina.sub(amount);
 
@@ -139,7 +139,7 @@ export class WrappedMina extends SmartContract {
   @method getBalance(publicKey: PublicKey): UInt64 {
     let accountUpdate = AccountUpdate.create(publicKey, this.token.id);
     let balance = accountUpdate.account.balance.get();
-    accountUpdate.account.balance.assertEquals(
+    accountUpdate.account.balance.requireEquals(
       accountUpdate.account.balance.get()
     );
     return balance;

--- a/examples/zkapps/11-advanced-account-updates/src/WrappedMina.ts
+++ b/examples/zkapps/11-advanced-account-updates/src/WrappedMina.ts
@@ -33,7 +33,7 @@ export class WrappedMina extends SmartContract {
       address: this.address,
       amount: UInt64.from(0),
     });
-    // required that the receiving account is new, so this can be only done once
+    // require that the receiving account is new, so this can be only done once
     receiver.account.isNew.requireEquals(Bool(true));
     // pay fees for opened account
     this.balance.subInPlace(Mina.accountCreationFee());

--- a/examples/zkapps/anonymous-message-board/package-lock.json
+++ b/examples/zkapps/anonymous-message-board/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "package-name",
+  "name": "message-board",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "package-name",
+      "name": "message-board",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
@@ -22,7 +22,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "0.14.*"
+        "o1js": "0.15.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -7171,9 +7171,9 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.14.2.tgz",
-      "integrity": "sha512-xU0NfbaOeooT5G7sQbVD0uDKpViLKwfVeCk+3U4rJk7HRq2KtHkdc7rlA0/86AtLUSRQpD5OZlJbVGW4daDvfQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
+      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",
@@ -13892,9 +13892,9 @@
       "dev": true
     },
     "o1js": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.14.2.tgz",
-      "integrity": "sha512-xU0NfbaOeooT5G7sQbVD0uDKpViLKwfVeCk+3U4rJk7HRq2KtHkdc7rlA0/86AtLUSRQpD5OZlJbVGW4daDvfQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
+      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
       "peer": true,
       "requires": {
         "blakejs": "1.2.1",

--- a/examples/zkapps/anonymous-message-board/package.json
+++ b/examples/zkapps/anonymous-message-board/package.json
@@ -36,6 +36,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "0.14.*"
+    "o1js": "0.15.1"
   }
 }

--- a/examples/zkapps/interacting-with-zkApps-server-side/package-lock.json
+++ b/examples/zkapps/interacting-with-zkApps-server-side/package-lock.json
@@ -23,7 +23,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "0.15.0"
+        "o1js": "0.15.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7198,9 +7198,9 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
-      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.1.tgz",
+      "integrity": "sha512-B5GHUNfwOW3uc9clgCKktZDlZUJ2052QiG8ZF/VX8IK2lo4nZKe4C5wJOExgj1o+T0d/NKrBpLRS9LqIvDW6Ug==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",
@@ -14035,9 +14035,9 @@
       "dev": true
     },
     "o1js": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
-      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.1.tgz",
+      "integrity": "sha512-B5GHUNfwOW3uc9clgCKktZDlZUJ2052QiG8ZF/VX8IK2lo4nZKe4C5wJOExgj1o+T0d/NKrBpLRS9LqIvDW6Ug==",
       "peer": true,
       "requires": {
         "blakejs": "1.2.1",

--- a/examples/zkapps/interacting-with-zkApps-server-side/package-lock.json
+++ b/examples/zkapps/interacting-with-zkApps-server-side/package-lock.json
@@ -15,7 +15,7 @@
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "eslint": "^8.7.0",
-        "eslint-plugin-o1js": "^0.1.0",
+        "eslint-plugin-o1js": "^0.4.0",
         "jest": "^27.3.1",
         "lint-staged": "^11.0.1",
         "prettier": "^2.3.2",
@@ -23,7 +23,7 @@
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
-        "o1js": "^0.12.1"
+        "o1js": "0.15.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3291,6 +3291,15 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -3864,9 +3873,9 @@
       }
     },
     "node_modules/eslint-plugin-o1js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.1.0.tgz",
-      "integrity": "sha512-ir0fK7RLXfAK4GC11PpCPEC1fTFK1R/uK9DCxQH/rmcgDC0j6AncWRdo7ewkwSNiodmXODWLcuYYt4L4U6KA3A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.4.0.tgz",
+      "integrity": "sha512-12qI6OvAMtUIh8x9lB5uVzJbRMSR6tGrbCRM98fcCmll1FNvVSUIaat3CWhH17tkcjoyVSaFy0I/WzZcqPqaUA==",
       "dev": true
     },
     "node_modules/eslint-scope": {
@@ -7189,12 +7198,13 @@
       "dev": true
     },
     "node_modules/o1js": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.12.1.tgz",
-      "integrity": "sha512-1Z7+FUzARe+1pSLpeaWqzb2kXbPRbZBLBp9MgzIkNJTIFYFAijVdSyqnBJulYyidq7BNCd0R91+hX8sVGQlhnw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
+      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
       "peer": true,
       "dependencies": {
         "blakejs": "1.2.1",
+        "cachedir": "^2.4.0",
         "detect-gpu": "^5.0.5",
         "isomorphic-fetch": "^3.0.0",
         "js-sha256": "^0.9.0",
@@ -11064,6 +11074,12 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "peer": true
+    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -11659,9 +11675,9 @@
       }
     },
     "eslint-plugin-o1js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.1.0.tgz",
-      "integrity": "sha512-ir0fK7RLXfAK4GC11PpCPEC1fTFK1R/uK9DCxQH/rmcgDC0j6AncWRdo7ewkwSNiodmXODWLcuYYt4L4U6KA3A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-o1js/-/eslint-plugin-o1js-0.4.0.tgz",
+      "integrity": "sha512-12qI6OvAMtUIh8x9lB5uVzJbRMSR6tGrbCRM98fcCmll1FNvVSUIaat3CWhH17tkcjoyVSaFy0I/WzZcqPqaUA==",
       "dev": true
     },
     "eslint-scope": {
@@ -14019,12 +14035,13 @@
       "dev": true
     },
     "o1js": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.12.1.tgz",
-      "integrity": "sha512-1Z7+FUzARe+1pSLpeaWqzb2kXbPRbZBLBp9MgzIkNJTIFYFAijVdSyqnBJulYyidq7BNCd0R91+hX8sVGQlhnw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/o1js/-/o1js-0.15.0.tgz",
+      "integrity": "sha512-KJSVD+sbrsq1O7jD2apOAa8P/BEBYhoYqGZEdiBtEF/NIw7JJGnUdkLV/E/OSX6X6Eo4fXRNLNAogcFPDhd41A==",
       "peer": true,
       "requires": {
         "blakejs": "1.2.1",
+        "cachedir": "^2.4.0",
         "detect-gpu": "^5.0.5",
         "isomorphic-fetch": "^3.0.0",
         "js-sha256": "^0.9.0",

--- a/examples/zkapps/interacting-with-zkApps-server-side/package.json
+++ b/examples/zkapps/interacting-with-zkApps-server-side/package.json
@@ -42,6 +42,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "0.15.0"
+    "o1js": "0.15.1"
   }
 }

--- a/examples/zkapps/interacting-with-zkApps-server-side/package.json
+++ b/examples/zkapps/interacting-with-zkApps-server-side/package.json
@@ -42,6 +42,6 @@
     "typescript": "^4.7.2"
   },
   "peerDependencies": {
-    "o1js": "^0.12.1"
+    "o1js": "0.15.0"
   }
 }

--- a/examples/zkapps/interacting-with-zkApps-server-side/src/Square.ts
+++ b/examples/zkapps/interacting-with-zkApps-server-side/src/Square.ts
@@ -10,7 +10,7 @@ export class Square extends SmartContract {
 
   @method update(square: Field) {
     const currentState = this.num.get();
-    this.num.assertEquals(currentState);
+    this.num.requireEquals(currentState);
     square.assertEquals(currentState.mul(currentState));
     this.num.set(square);
   }


### PR DESCRIPTION
Hi @mitschabaude , @ymekuria , @barriebyron ,

Please find the below changes that I have made to close the issue number #749 .

**Changes Made:**

- Renamed deprecated assert* with require*
- Updated the tutorials package.json to use latest o1js version

**Files/Tutorials changed:**

- Examples from 01 to 11 and Interacting with zkapps are updated
- Tutorials from 01 to Interacting with zkapps are updated
- Other documentations where also updated

**Files/Tutorials Pending to be updated:**

- Facing issue with example 06-offchain-storage. I have updated it locally but the offchain storage zkApp contract's package.json has peer dependency to version of "experimental-offchain-zkapp-storage". So I think we need to update it so, I will need your guidance over here on what to change and how. cc: @mitschabaude 
- Anonymous message board has not used assert for state so no changes made but, I have locally updated it's package.json to use latest o1js version. My question is should I commit it or not ?
- o1js-reference is the only folder I am yet to go through so will make changes to it soon.


Thank You
Luffy 😃