### PR TITLE
Fix: Remove security footgun example in onchain values docs

### DIFF
--- a/docs/zkapps/o1js/on-chain-values.mdx
+++ b/docs/zkapps/o1js/on-chain-values.mdx
@@ -64,13 +64,6 @@ class VotingApp extends SmartContract {
 
 A more refined example could store the current start date in an on-chain state variable, which can then be reset by some process that is also encoded by the zkApp.
 
-In addition to using a predefined range, you can also construct a range that depends on another variable, such as the current time. For example, a DEX with an order book could support orders that expire after an hour. In this case, the range would be `[now, now + 1h]`:
-
-```ts
-const now = this.network.timestamp.get();
-this.network.timestamp.requireBetween(now, now.add(60 * 60 * 1000));
-```
-
 ### Network reference
 
 For completeness, here is the full list of network states you can use and make assertions about in your zkApp.


### PR DESCRIPTION
The code example deleted here (written by me originally) makes no sense and suggests usage of on-chain values in an insecure way: Using a completely unconstrained value (`now`) to define a range that treats that unconstrained value as the actual value.

A better example for `requireBetween()` with the `.get()` value as input would be to treat it like "`requireEquals()` but allowing for an error"