### PR TITLE
HF audit for high-level zkApp docs

### DIFF
--- a/docs/zkapps/how-zkapps-work.mdx
+++ b/docs/zkapps/how-zkapps-work.mdx
@@ -5,7 +5,7 @@ description: In-depth explanation of how zkApps work. The structure of a zkApp, 
 keywords:
   - zkApps
   - smart contracts
-  - zero-knowledge proofs
+  - zero knowledge proofs
   - prover function
   - verifier function
   - mina network
@@ -24,18 +24,16 @@ zkApp programmability is not yet available on the Mina Mainnet. You can get star
 
 zkApps run in the latest versions of [Chrome](https://www.google.com/chrome/index.html), [Firefox](https://www.mozilla.org/en-US/firefox/new/), [Edge](https://microsoft.com/edge), and [Brave](https://brave.com/) web browsers.
 
-zkApps are written in TypeScript using the Mina zkApp CLI. 
+zkApps are written in TypeScript using the zkApp CLI. 
 
 A zkApp consists of two parts: 
 
 - A smart contract
 
 - A user interface (UI) for users to interact with the zkApp
-
 <figure>
   <img src="/img/3_zkApps_Structure.jpg" width="100%" alt="Diagram showing two parts of a zkApp" />
 </figure>
-
 - The term _smart contract_ refers to the code written with o1js.
 
 - The term _zkApp_ refers to the UI + the smart contract.
@@ -44,9 +42,9 @@ A zkApp consists of two parts:
 
 zkApps are based on zero knowledge proofs (zk-SNARKs). As a zkApp developer, you use the zkApp CLI to scaffold and deploy your project. 
 
-Provable code is written by using o1js and generates a prover function and a corresponding verifier function that are derived during the build process.
+Provable code is written using o1js and generates a prover function and a corresponding verifier function that are derived during the build process.
 
-The prover function is the function that executes a smart contract's custom logic and runs in a user's web browser as part of the zkApp. The prover function generates a proof of the executed code. 
+The prover function is the function that executes a smart contract's custom logic and runs in an end user's web browser as part of the zkApp. The prover function generates a proof of the executed code. 
 
 When interacting with a zkApp UI, users enter any data (for example, buy ABC for y price) that is required as input to the prover function, which then generates a zero knowledge proof.
 
@@ -54,13 +52,13 @@ When interacting with a zkApp UI, users enter any data (for example, buy ABC for
 <img src="/img/4_zkApps_Prover_Function.jpg" width="90%" alt="Diagram showing private and public inputs to prover function to create zero knowledge proof" />
 </figure>
 
-Both private inputs and public inputs represent data that must be provided to the prover function when it runs in the user's web browser.
+Private and public inputs represent data that must be provided to the prover function when it runs in the end user's web browser.
 
 Private inputs are not required again. Because public inputs must also be provided to the verifier function when it runs on the Mina network, public inputs are not used for data that you want to remain private.
 
 The verifier function validates whether a zero knowledge proof successfully passes all the constraints defined in the prover function. The verifier function _always_ runs quickly and efficiently, irrespective of the prover function's complexity.
 
-Within the Mina network, Mina acts as the verifier and runs the verifier function. 
+Within the Mina network, Mina acts as the verifier and runs the verifier function.
 
 <figure>
   <img src="/img/5_zkApps_Verifier_Function.jpg" width="90%" alt="Diagram showing verifier function validation" />
@@ -68,40 +66,38 @@ Within the Mina network, Mina acts as the verifier and runs the verifier functio
 
 ## Prover Function and Verification Key
 
-After you write your smart contract, run the `npm run build` command. The build process compiles the TypeScript code into JavaScript and outputs the `smart_contract.js` file. 
+After you write a smart contract, build it by running the `npm run build` command. The build process compiles the TypeScript code into JavaScript and outputs the `smart_contract.js` file. 
 
 From this file, you can:
 
 - Run a prover function to run your smart contract
 - Generate a verification key to deploy your smart contract
 
-While the prover function runs in a user's web browser, the verification key lives on-chain for a given zkApp account and is used by the Mina network to verify that a zero knowledge proof has met all constraints defined in the prover. A verification key is required to create a zkApp account.
+While the prover function runs in an end user's web browser, the verification key lives on-chain for a given zkApp account and is used by the Mina network to verify that a zero knowledge proof has met all constraints defined in the prover. A verification key is required to create a zkApp account.
 
 You can also use the verifier function or verification key to verify proofs off-chain.
 
 ## Deploy a smart contract
 
-Smart contracts are deployed to the Mina network using the Mina zkApp CLI. The deployment process sends a transaction that contains the verification key, an output of the verifier function, to an address on the Mina blockchain.
-
+zkApp developers use the zkApp CLI to deploy smart contracts to the Mina network. The deployment process sends a transaction that contains the verification key that is an output of the verifier function to an address on the Mina blockchain.
 <figure>
   <img src="/img/6_zkApps_DeploySmartContract.jpg" width="75%" alt="Diagram showing deployment of a Mina zkApp smart contract" />
 </figure>
-
 When a Mina address contains a verification key, it acts as a zkApp account.
 
 A regular Mina account can receive any transactions. 
 
-You can specify [permissions](/zkapps/o1js/permissions) so a zkApp account can successfully receive only transactions that satisfy the verifier function. 
+You can specify [permissions](/zkapps/o1js/permissions) so a zkApp account can successfully receive only the transactions that satisfy the verifier function. 
 
-Any transactions that do not pass the verifier function are rejected by the Mina network.
+The Mina network rejects any transactions that do not pass the verifier function.
 
-When you deploy to a new Mina address, the Mina Protocol charges a 1 MINA fee for account creation. This fee is unrelated to zkApps and helps to prevent Sybil or denial of service attacks.
+When you deploy a zkApp to a new Mina address, the Mina Protocol charges a 1 MINA fee for account creation. This fee is unrelated to zkApps and helps to prevent Sybil or denial of service attacks.
 
 ## Deploy a zkApp UI
 
 A zkApp consists of a smart contract and a UI to interact with it. 
 
-To enable users to interact with your smart contract in a web browser, you build a website UI and then deploy this interactive UI as a static website. Choosing a host that offers a global content delivery network (CDN) ensures the best experience for all of your users.
+To enable users to interact with your smart contract in a web browser, you build a website UI and then deploy this interactive UI as a static website. Choosing a host that offers a global content delivery network (CDN) ensures the best experience for all users.
 
 <img src="/img/7_zkApps_DeploySmartContract.jpg" width="95%" alt="Diagram of a zkApp that includes JavaScript and the UI" />
 
@@ -109,29 +105,29 @@ Your website must contain the JavaScript `smart_contract.js` file that you gener
 
 ## How users interact with a zkApp
 
-To use a zkApp, users must [Install a Wallet](../using-mina/install-a-wallet) that supports interactions with zkApps.
+To use a zkApp, end users must [Install a Wallet](../using-mina/install-a-wallet) that supports interactions with zkApps.
 
-After a zkApp is deployed to a host (for example, mycoolzkapp.com), users can interact with it:
+After a zkApp is deployed to a host (for example, mycoolzkapp.com), end users can interact with it:
 
-1. User visits mycoolzkapp.com.
-1. User interacts with the zkApp and enters any data as required. (For example, if this were an automated market maker, the user might specify to buy x amount of ABC at y price.)
+1. The user visits mycoolzkapp.com.
+1. The user interacts with the zkApp and enters the required data. For example, if this were an automated market maker, the user might specify to buy x amount of ABC at y price.
 1. The prover function in the zkApp generates a zero knowledge proof locally using the data entered by the user. This data can be either:
 
-    - Private, the data is never seen by the blockchain
+    - Private, the data is never seen by the blockchain.
     - Public, the data is stored on-chain or off-chain, depending on what the zkApp specified as required for a given use case.
 
- Additionally, a list of state updates (called account updates) to be created by the transaction is generated. The account updates are associated with this proof. 
-1. User selects “submit to chain” in the zkApp UI.
-  - The user confirms the transaction on their wallet, such as a browser extension wallet. 
-  - The wallet signs the transaction that contains the proof and the associated description of state to update.
+ A list of state updates (called account updates) to be created by the transaction is generated. The account updates are associated with this proof. 
+1. The user selects **Submit to chain** in the zkApp UI.
+  - The user confirms the transaction on their wallet. 
+  - The wallet signs the transaction containing the proof and the associated description of state to update.
   - The wallet sends the transaction to the Mina network.
-1. The Mina network receives this transaction and verifies that the proof successfully passes the verifier method listed on the zkApp account. If the network accepts this transaction, then this proof and the requested state changes are valid and are allowed to update the zkApp state.
+1. The Mina network receives this transaction and verifies that the proof successfully passes the verifier method listed on the zkApp account. If the network accepts this transaction, this proof and the requested state changes are valid and are allowed to update the zkApp state.
 
-The user's privacy is maintained because their interaction occurs locally in a web browser using JavaScript on the client.
+The end user's privacy is maintained because their interaction occurs locally in a web browser using JavaScript on the client.
 
-### How state is updated on chain
+### How state is updated on-chain
 
-The zkApp account gets updated on chain. 
+The zkApp account gets updated on-chain. 
 
 When the prover function runs in a web browser, the smart contract outputs a proof and some associated data called "account updates" that are sent to a zkApp address as part of the transaction. The account updates are a JSON plain text description that describes how to update the state on a zkApp account.
 
@@ -159,4 +155,4 @@ When the zkApp runs in a user's web browser, it can insert state to an external 
 
 ### Keep going
 
-On the next page, learn [How to write a zkApp](how-to-write-a-zkapp).
+See [zkApps Getting Started](/zkapps/getting-started-zkapps).

--- a/docs/zkapps/index.mdx
+++ b/docs/zkapps/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: zkApps Overview
-sidebar_label: Overview
+sidebar_label: zkApps Overview
 hide_title: true
 description: zkApps (zero knowledge apps) are Mina Protocol smart contracts powered by zero knowledge proofs, specifically using zk-SNARKs. Use this quickstart guide to deploy zkApps and resources for learning TypeScript.
 keywords:
@@ -26,7 +26,7 @@ zkApp programmability is not yet available on the Mina Mainnet. You can get star
 <figure>
   <img
     src="/img/zk-cli.png"
-    alt="Terminal screenshot of Mina’s zkApp CLI command-line interface."
+    alt="Terminal screenshot of zkApp CLI command line interface."
     width="70%"
   />
 </figure>
@@ -37,9 +37,9 @@ zkApp programmability is not yet available on the Mina Mainnet. You can get star
 
 zkApps (zero knowledge apps) are Mina Protocol smart contracts powered by zero knowledge proofs, specifically using zk-SNARKs.
 
-zkApps use an **off-chain execution** and mostly **off-chain state** model. This allows for private computation and state that can be either private or public.
+zkApps use an **off-chain execution** and mostly **off-chain state** model. This architecture allows for private computation and state that can be either private or public.
 
-zkApps can perform arbitrarily-complex computations off chain while incurring only a flat fee to send the resulting zero-knowledge proof to the chain for verification of this computation, as opposed to other blockchains that run computations on chain and use a variable gas-fee based model.
+zkApps can perform arbitrarily-complex computations off-chain while incurring only a flat fee to send the resulting zero knowledge proof to the chain for verification of this computation. This cost saving benefit is in contrast to other blockchains that run computations on-chain and use a variable gas-fee based model.
 
 <figure>
   <img
@@ -51,7 +51,7 @@ zkApps can perform arbitrarily-complex computations off chain while incurring on
 
 <br />
 
-Learn more on [How zkApps Work](./zkapps/how-zkapps-work).
+To learn more, see [How zkApps Work](./zkapps/how-zkapps-work).
 
 ### TypeScript
 

--- a/docs/zkapps/zkapps-for-ethereum-developers.mdx
+++ b/docs/zkapps/zkapps-for-ethereum-developers.mdx
@@ -31,8 +31,8 @@ on privacy and scalability.
 
 The Mina Protocol works differently. It verifies transactions (and previous
 blocks) cryptographically using recursive zero-knowledge proofs. Smart contract
-code is written in TypeScript and executes off chain. Mina nodes only need to
-verify a small proof in order to validate the associated execution. Better
+code is written in TypeScript and executes off chain. Mina nodes need to
+verify only a small proof in order to validate the associated execution. Better
 still, the proof does not reveal any information about the underlying
 computation, meaning developers can choose whether their inputs and outputs
 should be public or private, depending on the requirements of their application.
@@ -71,7 +71,7 @@ should be public or private, depending on the requirements of their application.
   <tr>
     <td style={{borderColor: 'black', borderWidth: '1px', borderStyle: 'solid', padding: '10px', fontSize: 'larger'}}>Developer Tooling</td>
     <td style={{borderColor: 'black', borderWidth: '1px', borderStyle: 'solid', padding: '10px'}}>New developer tools with unusual patterns like <span style={{color: '#7d4bbd'}}>Hardhat</span>, and <span style={{color: '#7d4bbd'}}>Truffle</span> are needed in order to manage the deployment of Ethereum smart contracts.</td>
-    <td style={{borderColor: 'black', borderWidth: '1px', borderStyle: 'solid', padding: '10px'}}><span style={{color: '#7d4bbd'}}>The Mina zkApp CLI</span> manages scaffolding, linting, testing, and deployment using common JavaScript/TypeScript tools you are already familiar with.</td>
+    <td style={{borderColor: 'black', borderWidth: '1px', borderStyle: 'solid', padding: '10px'}}><span style={{color: '#7d4bbd'}}>The zkApp CLI</span> manages scaffolding, linting, testing, and deployment using common JavaScript/TypeScript tools you are already familiar with.</td>
   </tr>
   <tr>
     <td style={{borderColor: 'black', borderWidth: '1px', borderStyle: 'solid', padding: '10px', fontSize: 'larger'}}>Scaling</td>
@@ -121,9 +121,7 @@ export class Add extends SmartContract {
 }
 ```
 
-## FAQ
-
-### How does Mina bridge to Ethereum?
+## How does Mina bridge to Ethereum?
 
 Mina proofs are small and easy to verify; this means that any Turing complete
 blockchain (like Ethereum) can validate the entire Mina state in a single


### PR DESCRIPTION
This PR achieves some of [Audit non-tutorial zkApps docs before HF](https://app.zenhub.com/workspaces/o1js-docs-6565f4667e7d97084bc9895d/issues/gh/o1-labs/docs2/744) epic:

- https://app.zenhub.com/workspaces/o1js-docs-6565f4667e7d97084bc9895d/issues/gh/o1-labs/docs2/463 
- https://app.zenhub.com/workspaces/o1js-docs-6565f4667e7d97084bc9895d/issues/gh/o1-labs/docs2/466
- https://app.zenhub.com/workspaces/o1js-docs-6565f4667e7d97084bc9895d/issues/gh/o1-labs/docs2/467
- https://app.zenhub.com/workspaces/o1js-docs-6565f4667e7d97084bc9895d/issues/gh/o1-labs/docs2/469

Handy preview links for the docs in this PR

- zkApps Overview https://docs2-git-hf-audit-zkapps-minadocs.vercel.app/zkapps << we need a new code window, what is the best way to produce this high-quality image asset? 
- How zkApps Work https://docs2-git-hf-audit-zkapps-minadocs.vercel.app/zkapps/how-zkapps-work
- zkApps and o1js FAQ https://docs2-git-hf-audit-zkapps-minadocs.vercel.app/zkapps/faq
- zkApps for Ethereum Developers https://docs2-git-hf-audit-zkapps-minadocs.vercel.app/zkapps/zkapps-for-ethereum-developers

High-level docs that include Lightnet are excluded from this PR. Find those topics in https://github.com/o1-labs/docs2/pull/780 