### PR TITLE
Update Mina Security page to remove Testworld Mission 2.0

### DIFF
--- a/docs/about-mina/security.mdx
+++ b/docs/about-mina/security.mdx
@@ -29,7 +29,7 @@ However, it doesn't stop there. Check out these resources to see what measures a
 - [August 9, 2021 Auro Wallet](https://minaprotocol.com/blog/least-authority-concludes-security-audit-on-auro-wallet)  | LeastAuthority
 - [July 16, 2021  Clor.io Wallet](https://minaprotocol.com/blog/clorio-wallet-audit)  | LeastAuthority
 
-## Current Community Security Programs:
+## Community Security Programs:
 - [Bug Bounty Program](https://minaprotocol.com/blog/re-launching-the-mina-ecosystem-bug-bounty-program)
 
 ## Learn:

--- a/docs/about-mina/security.mdx
+++ b/docs/about-mina/security.mdx
@@ -30,8 +30,7 @@ However, it doesn't stop there. Check out these resources to see what measures a
 - [July 16, 2021  Clor.io Wallet](https://minaprotocol.com/blog/clorio-wallet-audit)  | LeastAuthority
 
 ## Current Community Security Programs:
-[Bug Bounty Program](https://minaprotocol.com/blog/re-launching-the-mina-ecosystem-bug-bounty-program)
-[Testworld Mission 2.0](https://minaprotocol.com/blog/testworld-2-protocol-performance-testing-program)
+- [Bug Bounty Program](https://minaprotocol.com/blog/re-launching-the-mina-ecosystem-bug-bounty-program)
 
 ## Learn:
 [Solving for Blockchain’s Security Flaw — Accessible Nodes](https://minaprotocol.com/blog/solving-for-blockchains-security-flaw?utm_medium=gitHub&utm_source=social&utm_campaign=evergreen)


### PR DESCRIPTION
Removing Testworld Mission 2.0 because it just closed.