### PR TITLE
Tutorial 5: Common Types and Functions Import statement changed from 'snarky' to 'o1js'

### DIFF
--- a/docs/zkapps/tutorials/05-common-types-and-functions.mdx
+++ b/docs/zkapps/tutorials/05-common-types-and-functions.mdx
@@ -301,7 +301,7 @@ import {
   ...
   MerkleTree,
   ...
-} from 'snarkyjs'
+} from 'o1js'
 ```
 
 To create Merkle trees in your application:


### PR DESCRIPTION
Import statement changed from 'snarky' to 'o1js' on a code block in "Tutorial 5: Common Types and Functions" page