### PR TITLE
HF doc audit for o1js docs: Time-Locked Accounts and intro to o1js

### DIFF
--- a/docs/zkapps/o1js/basic-concepts.md
+++ b/docs/zkapps/o1js/basic-concepts.md
@@ -27,15 +27,15 @@ zkApp programmability is not yet available on the Mina Mainnet, but zkApps can n
 
 # o1js Basic Concepts
 
-o1js is a TypeScript (TS) library for writing general-purpose zk programs and writing zk smart contracts for Mina.
+o1js is a TypeScript (TS) library for writing general-purpose zero knowledge (zk) programs and writing zk smart contracts for Mina.
 
 ## Field
 
-Field elements are the basic unit of data in zero knowledge proof programming. Each field element can store a number up to almost 256 bits in size. You can think of a field element as a uint256 in Solidity.
+Field elements are the basic unit of data in zero knowledge proof programming. Each field element can store a number up to almost 256 bits in size. You can think of a field element as a `uint256` in Solidity.
 
 :::note
 
-For the cryptography inclined, the exact max value that a field can store is: 28,948,022,309,329,048,855,892,746,252,171,976,963,363,056,481,941,560,715,954,676,764,349,967,630,336
+For the cryptography inclined, the exact max value that a field can store is: 28,948,022,309,329,048,855,892,746,252,171,976,963,363,056,481,941,560,715,954,676,764,349,967,630,336.
 
 :::
 
@@ -51,7 +51,7 @@ This can be simplified as:
 
 `const sum = new Field(1).add(3)`
 
-Note that the 3 is auto-promoted to a field type to make this cleaner.
+Note that the `3` is auto-promoted to a field type to make this cleaner.
 
 ## Built-in data types
 

--- a/docs/zkapps/o1js/index.md
+++ b/docs/zkapps/o1js/index.md
@@ -25,12 +25,12 @@ zkApp programmability is not yet available on the Mina Mainnet, but zkApps can n
 
 # Introduction to o1js
 
-o1js, fka. SnarkyJS, is a TypeScript (TS) library for:
+o1js is a TypeScript library for:
 
-- Writing general-purpose zk programs
+- Writing general-purpose zero knowledge (zk) programs
 - Writing zk smart contracts for Mina
 
-This is TS code that you might write when using o1js:
+This is TypeScript code that you might write when using o1js:
 
 ```ts
 import { Field, Poseidon } from 'o1js';
@@ -45,14 +45,14 @@ const expectedHash =
 ```
 
 In a zkApp, this code can be used to prove that you know a secret value whose hash is publicly known without revealing the secret.
-The code is plain TypeScript (TS) and is executed as normal TS. You might call o1js an _embedded domain-specific language (DSL)_.
+The code is plain TypeScript and is executed as normal TypeScript. You might call o1js an _embedded domain-specific language (DSL)_.
 
 o1js provides data types and methods that are _provable_: You can prove their execution. 
 
-In the previous example code, `Poseidon.hash()` and `Field.assertEquals()` are examples of provable method. Proofs are _zero-knowledge_, because they can be verified without learning their inputs and execution trace. Selected parts of the proof can be made public, if it suits your application.
+In the example code, `Poseidon.hash()` and `Field.assertEquals()` are examples of provable methods. Proofs are _zero knowledge_, because they can be verified without learning their inputs and execution trace. Selected parts of the proof can be made public, if it suits your application.
 
 o1js is a general-purpose zk framework that gives you the tools to create zk proofs. It lets you write arbitrary zk programs leveraging a rich set of built-in provable operations, like basic arithmetic, hashing, signatures, boolean operations, comparisons, and more. Use the o1js framework to write zkApps on Mina, smart contracts that execute client-side and have private inputs.
 
-All of the o1js framework is packaged as a single TS library that can be used in major web browsers and Node.js. The best way to get started with o1js is [using the zkApp CLI](./how-to-write-a-zkapp). You can also install o1js from npm with `npm i o1js`. 
+All of the o1js framework is packaged as a single TypeScript library that can be used in major web browsers and Node.js. The best way to get started with o1js is [using the zkApp CLI](./how-to-write-a-zkapp). You can also install o1js from npm with `npm i o1js`. 
 
 Start your o1js journey by learning about [basic zk programming concepts](./o1js/basic-concepts).

--- a/docs/zkapps/o1js/time-locked-accounts.mdx
+++ b/docs/zkapps/o1js/time-locked-accounts.mdx
@@ -20,7 +20,7 @@ zkApp programmability is not yet available on the Mina Mainnet, but zkApps can n
 
 # Time-Locked Accounts
 
-Time-locking allows you to pay someone in MINA or custom other tokens subject to a vesting schedule. Tokens are initially locked and become available for withdrawal only after a certain time or gradually according to a specific schedule.
+Time-locking allows you to pay someone in MINA or other custom tokens subject to a vesting schedule. Tokens are initially locked and become available for withdrawal only after a certain time or gradually according to a specific schedule.
 
 By default, accounts are not time-locked.
 

--- a/docs/zkapps/o1js/time-locked-accounts.mdx
+++ b/docs/zkapps/o1js/time-locked-accounts.mdx
@@ -1,7 +1,7 @@
 ---
 title: Time-Locked Accounts
 hide_title: true
-description: This guide dives into the feature of time-locking in Mina to implement vesting schedules and practical examples of setting up a time-lock for MINA tokens using o1js.
+description: Use time-locking in Mina to implement vesting schedules. Practical examples of setting up a time-lock for MINA tokens using o1js.
 keywords:
   - time-locked accounts
   - mina blockchain
@@ -22,7 +22,9 @@ zkApp programmability is not yet available on the Mina Mainnet, but zkApps can n
 
 Time-locking allows you to pay someone in MINA or custom other tokens subject to a vesting schedule. Tokens are initially locked and become available for withdrawal only after a certain time or gradually according to a specific schedule.
 
-The zkApp feature that enables time-locking is the `timing` field that is present on every account. It look like this:
+By default, accounts are not time-locked.
+
+The zkApp feature that enables time-locking is the `timing` field that is present on every account:
 
 ```ts
 type Account = {
@@ -38,7 +40,8 @@ type Account = {
 };
 ```
 
-`isTimed` indicates whether this account is time locked. The other fields are parameters that allow you to define a vesting schedule in a very flexible manner. By default, accounts are not time locked. The default value of `isTimed` is `false`, and all other properties contain default values.
+- The `isTimed` field indicates whether this account is time-locked. The default value of `isTimed` is `false`.
+- The other fields are parameters with default values that allow you to define a vesting schedule in a very flexible manner. 
 
 This graph shows how each of the timing properties affect the vesting schedule:
 
@@ -50,9 +53,12 @@ This graph shows how each of the timing properties affect the vesting schedule:
   />
 </figure>
 
-The red cross on the left marks the point in time where the `timing` field is set and `isTimed` switches from `false` to `true`. The orange line shows how the amount of unlocked tokens increases over time until it finally reaches its maximum value and stays flat. At this point, `isTimed` flips from `true` back to `false` because no tokens remain locked.
+- The red cross on the left marks the point in time where the `timing` field is set.
+- `isTimed` switches from `false` to `true`. 
+- The orange line shows how the amount of unlocked tokens increases over time until it finally reaches its maximum value and stays flat. 
+- At this point, `isTimed` flips from `true` back to `false` because no tokens remain locked.
 
-As shown, the maximum amount of unlocked tokens is defined by the `initialMinimumBalance`. The property is called "initialMinimumBalance" because, even though the tokens show up in the balance, they can't be withdrawn. The account has a a non-zero _minimum balance_. Initially, that minimum balance is equal to the amount of tokens locked -- so, that amount is the "initial minimum balance". Over time, the minimum balance decreases until it hits zero, which is the condition that makes `isTimed` false again.
+As shown, the maximum amount of unlocked tokens is defined by the `initialMinimumBalance`. The property is called `initialMinimumBalance` because, even though the tokens show up in the balance, they can't be withdrawn. The account has a a non-zero _minimum balance_. Initially, that minimum balance is equal to the amount of tokens locked -- so, that amount is the "initial minimum balance". Over time, the minimum balance decreases until it hits zero, which is the condition that makes `isTimed` false again.
 
 The other timing-related properties are:
 
@@ -84,7 +90,10 @@ These examples show how to correctly implement several example use cases.
 
 #### Example 1: All tokens unlock after 1 week
 
-If you want all tokens to unlock after a certain time, then the only properties you need to consider are `initialMinimumBalance`, `cliffTime`, and `cliffAmount`. Set `cliffAmount` equal to the `initialMinimumBalance` to ensure all tokens are unlocked when the cliff elapses. Both `vestingPeriod` and `vestingIncrement` are unused so set them to their default values, 1 and 0:
+If you want all tokens to unlock after a certain time, then the only properties you need to consider are `initialMinimumBalance`, `cliffTime`, and `cliffAmount`. 
+
+- Set `cliffAmount` equal to the `initialMinimumBalance` to ensure all tokens are unlocked when the cliff elapses. 
+- Both `vestingPeriod` and `vestingIncrement` are unused, so set them to their default values, `1` and `0`:
 
 ```ts
 // example: 10 MINA to lock
@@ -106,7 +115,11 @@ this.send({ to: accountUpdate, amount: tokensToLock });
 
 #### Example 2: Linear vesting over 1 year
 
-This example does not use a cliff but vests a certain number of tokens linearly over 1 year. To do this, set the `vestingPeriod` to equivalent to 1 month defined in slots, so that new tokens are unlocked every month. The `vestingIncrement` is set to the total amount divided by 12, so that the total amount is unlocked after 12 months. Both `cliffTime` and `cliffAmount` can just be set to 0.
+This example does not use a cliff, but vests a certain number of tokens linearly over 1 year. 
+
+- Set the `vestingPeriod` to equivalent to 1 month defined in slots, so that new tokens are unlocked every month. 
+- Set the `vestingIncrement` to the total amount divided by 12, so that the total amount is unlocked after 12 months. 
+- Set both `cliffTime` and `cliffAmount` to 0.
 
 ```ts
 // example: 100000 MINA to lock


### PR DESCRIPTION
This PR introduces non-substantive grammar, style, clarity edits and continues work for the  [Audit non-tutorial zkApps docs before HF](https://app.zenhub.com/workspaces/o1js-docs-6565f4667e7d97084bc9895d/issues/gh/o1-labs/docs2/744) epic:

- #482 

Handy preview link [Time-Locked Accounts](https://docs2-git-hf5-doc-audit-minadocs.vercel.app/zkapps/o1js/time-locked-accounts)
a few typo fixes and edits for already-approved o1js docs