### PR TITLE
fix: update to o1js in experimental doc

### DIFF
--- a/docs/zkapps/experimental.mdx
+++ b/docs/zkapps/experimental.mdx
@@ -26,10 +26,10 @@ We appreciate any and all feedback you want to provide.
 
 The best place to provide feedback and ask questions is on [Mina Protocol Discord](https://bit.ly/MinaDiscord). 
 
-To ask zkApps questions and engage with other developers building zkApps with SnarkyJS, use the [#zkapps-developers](https://discord.com/channels/484437221055922177/915745847692636181) channel.
+To ask zkApps questions and engage with other developers building zkApps with o1js, use the [#zkapps-developers](https://discord.com/channels/484437221055922177/915745847692636181) channel.
 
 Experimental features are in active development and your feedback is especially appreciated.
 
 - The feature may have bugs
 - The feature may be changed, deprecated, or removed
-- All documentation for the feature explicitly notes the feature is experimental
+- All documentation for the feature explicitly states that the feature is experimental


### PR DESCRIPTION
This doc is not in the sidebar, so earlier updates missed this instance