### PR TITLE
Fixes for archive migration documentation.

### DIFF
--- a/docs/berkeley-upgrade/migrating-archive-database-to-berkeley.mdx
+++ b/docs/berkeley-upgrade/migrating-archive-database-to-berkeley.mdx
@@ -29,9 +29,8 @@ The following commands help you install Debian packages or Docker images.
 
 ```
 CODENAME=bullseye
-CHANNEL=unstable
-# Berkeley nightly version
-VERSION=2.0.0berkeley-rc1-berkeley-c308efc
+CHANNEL=umt
+VERSION=1.0.0umt-tooling
 
 echo "deb [trusted=yes] http://packages.o1test.net $CODENAME $CHANNEL" | tee /etc/apt/sources.list.d/mina.list
 apt-get update

--- a/docs/berkeley-upgrade/migrating-archive-database-to-berkeley.mdx
+++ b/docs/berkeley-upgrade/migrating-archive-database-to-berkeley.mdx
@@ -29,7 +29,7 @@ You can choose packages as you wish. The following commands help you install Deb
 CODENAME=bullseye
 CHANNEL=unstable
 # Berkeley nightly version
-VERSION=2.0.0berkeley-rc1-berkeley-c308efc-bullseye
+VERSION=2.0.0berkeley-rc1-berkeley-c308efc
 
 echo "deb [trusted=yes] http://packages.o1test.net $CODENAME $CHANNEL" | tee /etc/apt/sources.list.d/mina.list
 apt-get update
@@ -39,7 +39,7 @@ apt-get install --allow-downgrades -y "mina-archive-berkeley-archive-migration=$
 ### Docker image
 
 ```
-docker pull gcr.io/o1labs-192920/gcr.io/o1labs-192920/mina-archive-berkeley-archive-migration:2.0.0berkeley-rc1-berkeley-c308efc-bullseyey
+docker pull gcr.io/o1labs-192920/mina-archive-berkeley-archive-migration:1.0.0umt-tooling
 ```
 
 ## Mainnet Genesis Ledger

--- a/docs/berkeley-upgrade/migrating-archive-database-to-berkeley.mdx
+++ b/docs/berkeley-upgrade/migrating-archive-database-to-berkeley.mdx
@@ -15,11 +15,11 @@ keywords:
 
 # Mainnet to Berkeley Archive Migration
 
-Before you start the migration, complete the steps in [How to prepare for archive migration](/berkeley-upgrade/planning-archive-migration).
+Before you start the migration, please read [How to prepare for archive migration](/berkeley-upgrade/planning-archive-migration).
 
 ## Download migration applications
 
-Migration applications are distributed as part of the Docker archive, daemon Dockers, or Debian packages.
+Migration applications are distributed as part of the archive migration Docker and Debian packages.
 
 You can choose packages as you wish. The following commands help you install Debian packages or Docker images.
 
@@ -29,67 +29,181 @@ You can choose packages as you wish. The following commands help you install Deb
 CODENAME=bullseye
 CHANNEL=unstable
 # Berkeley nightly version
-VERSION=2.0.0rampup8-berkeley-b9e1116
+VERSION=2.0.0berkeley-rc1-berkeley-c308efc-bullseye
 
 echo "deb [trusted=yes] http://packages.o1test.net $CODENAME $CHANNEL" | tee /etc/apt/sources.list.d/mina.list
 apt-get update
-apt-get install --allow-downgrades -y "mina-berkeley=$VERSION" "mina-replayer=$VERSION"
+apt-get install --allow-downgrades -y "mina-archive-berkeley-archive-migration=$VERSION"
 ```
 
-### Docker images
-
-The Berkeley migration app:
+### Docker image
 
 ```
-docker pull gcr.io/o1labs-192920/mina-berkeley:2.0.0rampup8-berkeley-b9e1116-bullseye-berkeley
-```
-
-Replayer:
-
-```
-docker pull gcr.io/o1labs-192920/mina-archive:2.0.0rampup8-berkeley-b9e1116-bullseye
+docker pull gcr.io/o1labs-192920/gcr.io/o1labs-192920/mina-archive-berkeley-archive-migration:2.0.0berkeley-rc1-berkeley-c308efc-bullseyey
 ```
 
 ## Mainnet Genesis Ledger
 
+Mainnet genesis ledger is stored in github in mina repository under `genesis_ledgers` subfolder. However if you are already running daemon connected
+to mainnet network you should already have it locally.
+
 ## Berkeley database schema files
 
-### Schema sources files
+Berkeley schema files can also be obtained from different locations:
+
+- Github repository under berkeley branch. Please note, that berkeley branch can contain new updates regarding schema files 
+so it is recommended not to use already downloaded schema but try to get always newest one. 
+- Archive/Rosetta docker from berkeley version
+
+### Example: Downloading schema sources from Github
+
    ```sh
-   docker cp $id:/etc/mina/rosetta/archive/create_schema.sql - > create_schema.sql
+   wget https://raw.githubusercontent.com/MinaProtocol/mina/berkeley/src/app/archive/zkapp_tables.sql
 
-   docker cp $id:/etc/mina/rosetta/archive/zkapp_tables.sql - > zkapp_tables.sql
+   wget https://raw.githubusercontent.com/MinaProtocol/mina/berkeley/src/app/archive/create_schema.sql
 
-   docker rm -v $id
    ```
 
-### Migration Phase 1: Berkeley migration app run
+### Migration process
 
-Run the provided Berkeley migration application:
+As mentioned in section regarding migration preparation mainnet migration can take up to couple of days. 
+Therefore it is recommended to spit migration into 3 stages:
+
+- **Stage1:** Initial migration
+
+- **Stage2:** Incremental migration
+
+- **Stage3:** Remainder migration
+
+Each stage has two migration phases:
+
+- **Phase 1:** Copying data from mainnet database and precomputed blocks (berkeley_migration app)
+
+- **Phase 2:** Populating new berkeley tables (replayer in migration mode)
+
+Below we will describe each phase and stage
+
+#### Stage 1: Initial migration
+
+This stage is a very first one which requires initial berkeley schema and is a foundation for next migrations
+as it populates migrated database and initial checkpoint for further incremental migration
+
+- Inputs
+   - Unmigrated mainnet database
+   - Mainnet genesis ledger 
+   - Empty berkeley schema 
+
+- Outputs
+   - Migrated mainnet database to berkeley from genesis up to last canonical block
+   - Replayer checkpoint which can be use for incremental migration
+
+##### Phase 1: Berkeley migration app run
 
 ```
-mina-berkeley-migration --batch-size 100 --config-file genesis_ledgers/mainnet.json
+mina-berkeley-migration --batch-size 1000 --config-file genesis_ledgers/mainnet.json
 --mainnet-archive-uri {mainnet_connection_string} --migrated-archive-uri {migrated_connection_string} --mainnet-blocks-bucket 
-{bucket name}
+{bucket name} --network "mainnet"
+```
+where: 
+`--network` - precomputed blocks prefix 
+
+
+##### Phase 2: Replayer in migration mode run
+
+Replayer config must contain the Mainnet ledger as starting point. So first we need to prepare replayer config file:
+
+```
+ jq '.ledger.accounts' mainnet.json | jq  '{genesis_ledger: {accounts: .}}' > replayer_input_config.json"
 ```
 
-### Migration Phase 2: Replayer in migration mode runs
+Then:
+```
+ mina-replayer --migration-mode --archive-uri {migrated_connection_string}  --input-file replayer_input_config.json --checkpoint-interval 10000
+```
 
-Run the provided replayer app in migration mode:
+#### Stage 2: Incremental migration
 
-1. Prepare replayer config file.
+After initial migration we have migrated data till last canonical block. However mainnet data is progressing with new blocks 
+which we need to migrate again and again until fork block is announced 
 
-   Replayer config must contain the Mainnet ledger as starting point:
 
-   ```
-   jq '.ledger.accounts' mainnet.json | jq  '{genesis_ledger: {accounts: .}}' > replayer_input_config.json"
-   ```
+- Inputs
+   - Newest mainnet database
+   - Mainnet genesis ledger
+   - Replayer checkpoint from last run 
+   - Migrated berkeley schema from initial migration 
 
-2. Run the import in migration mode:
+- Outputs
+   - Migrated mainnet database to berkeley from up to last canonical block
+   - Replayer checkpoint which can be used for next incremental migration
 
-   ```
-   mina-replayer --migration-mode --archive-uri {migrated_connection_string}  --input-file replayer_input_config.json --checkpoint-interval 100 --output-file  replayer_output.json 
-   ```
+##### Phase 1: Berkeley migration app run
+
+```
+mina-berkeley-migration --batch-size 1000 --config-file genesis_ledgers/mainnet.json
+--mainnet-archive-uri {mainnet_connection_string} --migrated-archive-uri {migrated_connection_string} --mainnet-blocks-bucket 
+{bucket name} --network "mainnet"
+```
+where: 
+`--network` - precomputed blocks prefix 
+
+
+##### Phase 2: Replayer in migration mode run
+
+```
+ mina-replayer --migration-mode --archive-uri {migrated_connection_string}  --input-file replayer-checkpoint-XXXXX.json --checkpoint-interval 10000
+```
+
+where `replayer-checkpoint-XXXXX.json` - is last checkpoint generated from previous migration
+
+
+Incremental migration can be run continuously on top initial migration or last incremental until fork block is anounced 
+
+#### Stage 3: Remainder migration
+
+When fork block is announced we can tackle the remainder migration this is the last migration run 
+we would want to perform.
+
+- Inputs
+   - Newest mainnet database
+   - Mainnet genesis ledger
+   - Replayer checkpoint from last run 
+   - Migrated berkeley schema from last run
+   - Fork block state hash
+
+- Outputs
+   - Migrated mainnet database to berkeley from up fork point
+   - Replayer checkpoint which can be used for replayer run on berkeley schema
+
+
+##### Phase 1: Berkeley migration app run
+
+Noticed decrease in `batch-size` for precomputed blocks as tool may hit missing precomputed blocks problem if we would like 
+to fetch too many of them in single batch while trying to migrate newest blocks in the chain
+
+```
+mina-berkeley-migration --batch-size 2 --config-file genesis_ledgers/mainnet.json
+--mainnet-archive-uri {mainnet_connection_string} --migrated-archive-uri {migrated_connection_string} --mainnet-blocks-bucket 
+{bucket name} --network "mainnet" **--fork-state-hash {fork-state-hash}**
+```
+where: 
+`--network` - precomputed blocks prefix 
+`--fork-state-hash` last migrated block which will be used for as a fork point 
+
+:info: When running berkeley migration app with fork-state-hash, there is no requirement for fork state block to be canonical.
+Tool will automatically converts all pending blocks in subchain including fork block to canonical
+
+##### Phase 2: Replayer in migration mode run
+
+```
+ mina-replayer --migration-mode --archive-uri {migrated_connection_string}  --input-file replayer-checkpoint-XXXXX.json --checkpoint-interval 10000 --output-file replayer_output.json 
+```
+
+where:
+`replayer-checkpoint-XXXXX.json` - is last checkpoint generated from previous migration
+`replayer-output.json` - will contain a very last checkpoint which can be used for berkeley replayer validation
+
+It is important to save checkpoint which was dumped from replayer run, as it will be use in next migrations
 
 ### Example steps using Mina Foundation data
 
@@ -109,42 +223,77 @@ Run the provided replayer app in migration mode:
    CODENAME=bullseye
    CHANNEL=unstable
    # Berkeley nightly version
-   VERSION=2.0.0rampup8-berkeley-b9e1116
+   VERSION=2.0.0berkeley-rc1-berkeley-c308efc-bullseye
 
    echo "deb [trusted=yes] http://packages.o1test.net $CODENAME $CHANNEL" | tee /etc/apt/sources.list.d/mina.list
    apt-get update
-   apt-get install --allow-downgrades -y "mina-berkeley=$VERSION" "mina-replayer=$VERSION"
+   apt-get install --allow-downgrades -y "mina-archive-berkeley-archive-migration=$VERSION"
    ```
 
 3. Create migrated schema:
 
    ```sh
-   cd /etc/mina/rosetta/archive
+   wget https://raw.githubusercontent.com/MinaProtocol/mina/berkeley/src/app/archive/zkapp_tables.sql
+
+   wget https://raw.githubusercontent.com/MinaProtocol/mina/berkeley/src/app/archive/create_schema.sql
 
    psql  -U postgres -c "CREATE DATABASE berkeley_migrated;"
 
    psql -U postgres -d berkeley_migrated -a -f create_schema.sql"
    ```
 
-4. Phase 1:
+4. Stage 1: Initial migration
+
+   4.a) Phase 1:
 
    ```sh
-   mina-berkeley_migration.exe -- --batch-size 2 --config-file /etc/mina/genesis_ledgers/mainnet.json --mainnet-archive-uri postgres://postgres:postgres@localhost/archive_balances_migrated --migrated-archive-uri postgres://postgres:postgres@localhost/berkeley_migrated--mainnet-blocks-bucket mina_network_block_data 
+   mina-berkeley-migration.exe --batch-size 2000 --config-file /etc/mina/genesis_ledgers/mainnet.json --mainnet-archive-uri postgres://postgres:postgres@localhost/archive_balances_migrated --migrated-archive-uri postgres://postgres:postgres@localhost/berkeley_migrated --mainnet-blocks-bucket mina_network_block_data --network mainnet
    ```
 
-4. Phase 2:
+   4.b) Phase 2:
 
    ```sh
    jq '.ledger.accounts' mainnet.json | jq  '{genesis_ledger: {accounts: .}}' > replayer_input_config.json"
 
-   mina-replayer -- --migration-mode --archive-uri postgres://postgres:postgres@localhost/ --input-file replayer_config_input.json --checkpoint-interval 100  --checkpoint-file-prefix migration
+   mina-replayer --migration-mode --archive-uri postgres://postgres:postgres@localhost/ --input-file replayer_config_input.json --checkpoint-interval 100  --checkpoint-file-prefix migration
    ```
+
+5. Stage 2: Initial migration
+
+   5.a) Phase 1:
+
+   ```sh
+   mina-berkeley-migration.exe --batch-size 2000 --config-file /etc/mina/genesis_ledgers/mainnet.json --mainnet-archive-uri postgres://postgres:postgres@localhost/archive_balances_migrated --migrated-archive-uri postgres://postgres:postgres@localhost/berkeley_migrated --mainnet-blocks-bucket mina_network_block_data --network mainnet
+   ```
+
+   5.b) Phase 2:
+
+   ```sh
+   mina-replayer --migration-mode --archive-uri postgres://postgres:postgres@localhost/ --input-file checkpoint-XXXX.json --checkpoint-interval 100  --checkpoint-file-prefix migration
+   ```
+
+5. Stage 2: Remainder migration
+
+   5.a) Phase 1:
+
+   ```sh
+   mina-berkeley-migration.exe --batch-size 2000 --config-file /etc/mina/genesis_ledgers/mainnet.json --mainnet-archive-uri postgres://postgres:postgres@localhost/archive_balances_migrated --migrated-archive-uri postgres://postgres:postgres@localhost/berkeley_migrated --mainnet-blocks-bucket mina_network_block_data --network mainnet --fork-state-hash "3NLdCBNrDseiDKvVj8rZ15k2oAUvx4XuCc8mzf6fL2CmqTJVVceM" 
+   ```
+
+   :warning: 3NLdCBNrDseiDKvVj8rZ15k2oAUvx4XuCc8mzf6fL2CmqTJVVceM - is some random hash, please do not user it on actual migration but learn from MF what is the fork point
+
+   5.b) Phase 2:
+
+   ```sh
+   mina-replayer --migration-mode --archive-uri postgres://postgres:postgres@localhost/ --input-file checkpoint-XXXX.json --checkpoint-interval 100  --checkpoint-file-prefix migration --output-file migrated-checkpoint-at-fork-block.json
+   ```
+
 
 ## How to verify a successful migration
 
 o1Labs and the Mina Foundation make every effort to provide reliable tools of high quality. However, it is not possible to eliminate all errors and test all possible Mainnet archives variations. 
 
-Follow this checklist to perform major verifications after migration to ensure data correctness. 
+Follow this checklist to perform major versification's after migration to ensure data correctness. 
 
 1. #### The Replayer from the Mainnet version generates the same ledger hash as the migrated
 
@@ -257,20 +406,14 @@ In the second phase of migration, add property `target_epoch_ledgers_state_hash`
 }
 ```
 
+#### I am receiving errors from gsutil regarding missing precomputed blocks
+
+When migrating last chunk of blocks from mainnet, there can be an issue for runs with
+large `batch-size` argument inputs. As an optimization gsutil is trying to fetch as `block-size` amount of precomputed blocks.
+However, when precomputed blocks bucket has not contain enough (= `block-size` amount) precomputed blocks gsutil may panic stopping migration process.
+Our recommendation is to restart process with smaller number of `batch-size`. If you are running migration just after fork block is announced it is best
+to have `--block-size` argument set up to 5.
+
 #### How to start replayer migration from latest checkpoint
 
 Instead of using Mainnet ledger as input config, provide the checkpoint for the `--input-config` parameter.
-
-### Migration app parameters reference
-
-For more advanced users and operators, all the parameters that can influence the migration process are listed here:
-
-##### Berkeley migration app
-
-- **batch-size NN**  - is used when downloading precomputed blocks. The bigger the buffer, the more precomputed blocks are downloaded in a single fetch.
-- **end-global-slot NN (Optional)** - Last global slot since genesis to include in the migration (if omitted, the default is to migrate only canonical blocks).
-
-##### Replayer in migration mode
-
-- **checkpoint-interval NN** - Write a checkpoint file for every NN slot.
-- **continue-on-error** - Continue processing after errors

--- a/docs/berkeley-upgrade/planning-archive-migration.mdx
+++ b/docs/berkeley-upgrade/planning-archive-migration.mdx
@@ -45,7 +45,7 @@ To successfully migrate the Mainnet database into the Berkeley version of the Mi
 
 #### Database server
 
-PostgreSQL database in version 15.0 or later.
+PostgreSQL database
 
 #### Migration host
 
@@ -69,7 +69,7 @@ If you don't have an existing database with Mainnet archive data, you can always
 
    You can filter the dumps by date. Replace `{date}` using the required `yyyy-dd-mm` format. For example, for January 15, 2024 you can provide `2024-01-15`
 
-   :warning: In some cases, the 0000 suffix in the date might be different (0001).
+   :warning: Majority of backups are suffixed with 0000, in case download with that name is not available, try incrementing it once or twice(0001, 0002)..
 
 - gsutil:
    
@@ -107,9 +107,9 @@ The daemon node unavailability can cause the archive node to miss some of the bl
 
 If you are uploading the missing blocks to Google Cloud, the missing blocks can be reapplied from precomputed blocks () and preserve chain continuity. 
 
-To automatically verify and patch missing blocks, use the [download_missing_blocks.sh](https://raw.githubusercontent.com/MinaProtocol/mina/rampup/src/app/rosetta/download-missing-blocks.sh) script. Because the `download-missing-blocks` script uses localhost as the database host, you must run it from within the database host.
+To automatically verify and patch missing blocks, use the [download_missing_blocks.sh](https://raw.githubusercontent.com/MinaProtocol/mina/rampup/src/app/rosetta/download-missing-blocks.sh) script. Because the `download-missing-blocks` script uses localhost as the database host, unless you modify PG_CONN in `download_missing_block.sh`, script assumes that psql is running on localhost on 5432 port.
 
-1. Install the required `mina-archive-blocks` and `mina-missing-blocks-auditor` scripts that are packed in the `minaprotocol/mina-rosetta:1.4.0-c980ba8-bullseye` Docker image.
+1. Install the required `mina-archive-blocks` and `mina-missing-blocks-auditor` scripts that are packed in the `minaprotocol/mina-archive:1.4.0-c980ba8-bullseye` Docker image.
 
 2. Export the `BLOCKS_BUCKET`:
 
@@ -129,8 +129,17 @@ To verify Mainnet archive data, the replayer application was developed. You must
 To run replayer:
 
 ```sh
-mina-replayer --archive-uri {db_connection_string} --input-file reference_replayer_input.json --output-file reference_replayer_output.json --checkpoint-interval 100
+mina-replayer --archive-uri {db_connection_string} --input-file reference_replayer_input.json --output-file reference_replayer_output.json --checkpoint-interval 10000
 ```
+
+where:
+ - `reference_replayer_input.json` is a file constructed our of mainnet genesis ledger:
+  
+   ```
+   echo '{ "genesis_ledger": { "accounts": [ ], "add_genesis_winner" : true } }' > input-file.json
+
+   jq --argfile genesis ./genesis_ledger_mainnet.json '.genesis_ledger.accounts += $genesis.ledger.accounts' ./input-file.json > replayer-reference-input.json
+   ```
 
 :warning: Running a replayer from scratch on a Mainnet database can take up to a couple of days. The recommended best practice is to break the replayer into smaller parts by using the checkpoint capabilities of the replayer.
 
@@ -140,7 +149,10 @@ mina-replayer --archive-uri {db_connection_string} --input-file reference_replay
 
 The Mainnet to Berkeley archive data migration requires access to precomputed blocks that are uploaded by daemons connected to the Mainnet network. The Berkeley migration app uses the gsutil app to download blocks. If you didn't store precomputed blocks during first phase of migration, you can use the precomputed blocks provided by Mina Foundation:
 
-`gs://mina_network_block_data`
+`gsutil cp gs://mina_network_block_data/mainnet-*.json .`
+
+:warning: Precomputed blocks for 'mainnet' network takes ~800Gb. Downloading them make take some time 
+
 
 The best practice is to collect precomputed blocks by yourself or by other third parties to preserve idea of decentralization. 
 


### PR DESCRIPTION
Split migration into 3 stages. Fixed wording and Example.

here's your handy preview link https://docs2-git-archivemigration-minadocs.vercel.app/berkeley-upgrade 