### PR TITLE
fix: email syntax and bounty program ownership link in Reporting Issues, Bugs, & Feature Requests

### DIFF
--- a/docs/participate/bugs-and-feature-requests.mdx
+++ b/docs/participate/bugs-and-feature-requests.mdx
@@ -15,15 +15,17 @@ Before making a report, first search through [existing issues](https://github.co
 
 ### 2. Found a bug?
 
-If your issue is a bug, related to the Mina website, or you have feedback about user experience, you can report it on the [Mina Protocol repo on GitHub](https://github.com/MinaProtocol/mina/issues/new/choose).
+If your issue is a bug, related to the Mina website or you have feedback about user experience, you can report it on the [Mina Protocol repo on GitHub](https://github.com/MinaProtocol/mina/issues/new/choose).
 
 ### 3. Found a vulnerability?
 
-If your issue is a vulnerability that may be putting other people’s funds at risk or related to the protocol infrastructure, please report the issue via Mina’s Bounty Program at [hackerone.com/o1-labs](https://hackerone.com/o1-labs).
+If your issue is a vulnerability that may be putting other people's funds at risk or related to the protocol infrastructure, the first step is to report the issue on the [Mina Protocol repo on GitHub](https://github.com/MinaProtocol/mina/issues/new/choose). 
+
+You can participate in the private Mina Foundation Bounty Program on [https://hackerone.com/mina-foundation](https://hackerone.com/mina-foundation). You can request an invitation in the [#security](https://discord.com/channels/484437221055922177/799979001585336331) channel on Mina Protocol Discord. 
 
 ### 4. Found an urgent issue?
 
-If your issue is time-sensitive that needs immediate attention, please send more details and your contact information to <security@o1labs.org>. A member of the engineering team will reach out promptly.
+If your issue is time-sensitive and needs immediate attention, please send more details and your contact information to <security@o1labs.org>. A member of the engineering team will reach out promptly.
 
 :::note
 

--- a/docs/participate/bugs-and-feature-requests.mdx
+++ b/docs/participate/bugs-and-feature-requests.mdx
@@ -19,7 +19,7 @@ If your issue is a bug, related to the Mina website or you have feedback about u
 
 ### 3. Found a vulnerability?
 
-If your issue is a vulnerability that may be putting other people's funds at risk or related to the protocol infrastructure, the first step is to report the issue on the [Mina Protocol repo on GitHub](https://github.com/MinaProtocol/mina/issues/new/choose). 
+If your issue is a vulnerability that may be putting other people's funds at risk or is related to the protocol infrastructure, the first step is to report the issue on the [Mina Protocol repo on GitHub](https://github.com/MinaProtocol/mina/issues/new/choose). 
 
 You can participate in the private Mina Foundation Bounty Program on [https://hackerone.com/mina-foundation](https://hackerone.com/mina-foundation). You can request an invitation in the [#security](https://discord.com/channels/484437221055922177/799979001585336331) channel on Mina Protocol Discord. 
 

--- a/docs/participate/bugs-and-feature-requests.mdx
+++ b/docs/participate/bugs-and-feature-requests.mdx
@@ -15,7 +15,7 @@ Before making a report, first search through [existing issues](https://github.co
 
 ### 2. Found a bug?
 
-If your issue is a bug, related to the Mina website, or you have feedback about user experience, you can report it on the [Mina Protocol repo on Github](https://github.com/MinaProtocol/mina/issues/new/choose).
+If your issue is a bug, related to the Mina website, or you have feedback about user experience, you can report it on the [Mina Protocol repo on GitHub](https://github.com/MinaProtocol/mina/issues/new/choose).
 
 ### 3. Found a vulnerability?
 
@@ -23,7 +23,7 @@ If your issue is a vulnerability that may be putting other people’s funds at r
 
 ### 4. Found an urgent issue?
 
-If your issue is time-sensitive that needs immediate attention, please send more details and your contact information to security@o1labs.org. A member of Mina’s engineering team will reach out promptly.
+If your issue is time-sensitive that needs immediate attention, please send more details and your contact information to <security@o1labs.org>. A member of Mina’s engineering team will reach out promptly.
 
 :::note
 

--- a/docs/participate/bugs-and-feature-requests.mdx
+++ b/docs/participate/bugs-and-feature-requests.mdx
@@ -23,7 +23,7 @@ If your issue is a vulnerability that may be putting other people’s funds at r
 
 ### 4. Found an urgent issue?
 
-If your issue is time-sensitive that needs immediate attention, please send more details and your contact information to <security@o1labs.org>. A member of Mina’s engineering team will reach out promptly.
+If your issue is time-sensitive that needs immediate attention, please send more details and your contact information to <security@o1labs.org>. A member of the engineering team will reach out promptly.
 
 :::note
 


### PR DESCRIPTION
This PR fixes the Markdown syntax for the security@o1labs.org email address in the [Reporting Issues, Bugs, & Feature Requests](https://docs.minaprotocol.com/participate/bugs-and-feature-requests#4-found-an-urgent-issue) doc.

The docs are updated for a more general engineering team response. 

The security@o1labs.org email alias resolves to several people at o1Labs, including PMs, EMs, and architects. When security issues are received at this email address, the issue is discussed internally before a response is sent.

The bounty program link fixed in this PR.
[Tagged Salah and Thomas Kever](https://o1-labs.slack.com/archives/C055RH9MSJZ/p1712071491394529?thread_ts=1711550892.500999&cid=C055RH9MSJZ) in Slack

Preview of updated doc https://docs2-git-barriebyron-patch-1-minadocs.vercel.app/participate/bugs-and-feature-requests 