### PR TITLE
Update instructions for running Rosetta node

### DIFF
--- a/docs/exchange-operators/rosetta/build-from-sources.mdx
+++ b/docs/exchange-operators/rosetta/build-from-sources.mdx
@@ -59,7 +59,7 @@ The easiest way to build Rosetta natively is to use the Nix development environm
 
     You can run it with following command:
     ```shell
-    MINA_ROSETTA_MAX_DB_POOL_SIZE=64 MINA_ROSETTA_NETWORK=mainnet \
+    MINA_ROSETTA_MAX_DB_POOL_SIZE=64 \
         _build/default/src/app/rosetta/rosetta.exe --port 3087 \
         --graphql-uri <URL to Mina GraphQL instance> 
         --archive-uri postgres://<username>:<password>@<host>:<port>/<db_name>

--- a/docs/exchange-operators/rosetta/run-with-docker.mdx
+++ b/docs/exchange-operators/rosetta/run-with-docker.mdx
@@ -26,7 +26,7 @@ To run Mina Rosetta on Apple silicon, you can use the steps in [Building and run
 
 1. Check the latest release for Mainnet on the official [Mina GitHub releases](https://github.com/MinaProtocol/mina/releases) page. 
 
-1. Go to [minaprotocol/mina-rosetta](https://hub.docker.com/r/minaprotocol/mina-rosetta) ` page on the Docker Hub repository. Pull the image with the commit hash matching to the latest Mainnet release.
+1. Go to [minaprotocol/mina-rosetta](https://hub.docker.com/r/minaprotocol/mina-rosetta) page on the Docker Hub repository. Pull the image with the commit hash matching to the latest Mainnet release.
 
 1. Use this image:
 
@@ -37,26 +37,48 @@ If you want to build your own docker image, you can find more details in [Minaâ€
 
 :::
 
-The container in `/rosetta` includes four entrypoints, which each run a different set of services connected to a particular network.
+The container in `/rosetta` includes three entrypoints, which each run a different set of services and has different configurations.
 
-- **docker-start.sh** (default) - connects the mina node to our Mainnet network and initializes the archive database from publicly-available nightly O(1) Labs backups. This script runs a mina node, mina-archive, a postgresql DB, and mina-rosetta. The script also periodically checks for blocks that may be missing between the nightly backup and the tip of the chain and will fill in those gaps by walking back the linked list of blocks in the canonical chain and importing them one at a time. Take a look at the source for more information about what and how you can configure.
-- **docker-standalone-start.sh** - starts only the mina-rosetta API endpoint and any flags passed into the script go to mina-rosetta. Use this for the "offline" part of the Construction API.
+- **docker-start.sh** (default) - connects the mina node to a network (defaults to Mainnet) and initializes the archive database from publicly-available nightly O(1) Labs backups. This script runs a mina node, mina-archive, a postgresql DB, and mina-rosetta. The script also periodically checks for blocks that may be missing between the nightly backup and the tip of the chain and will fill in those gaps by walking back the linked list of blocks in the canonical chain and importing them one at a time. The script is configurable through environment variables. Take a look at the source for more information about what and how you can configure.
+- **docker-standalone-start.sh** - starts only the mina-rosetta API endpoint and any flags passed into the script go to mina-rosetta. You may use this for the "offline" part of the Construction API or if you want a setup with each service in its own container.
 - **docker-demo-start.sh** launches a mina node with a very simple 1-address genesis ledger as a sandbox for developing and playing around in. This script starts the full suite of tools (a mina node, mina-archive, a postgresql DB, and mina-rosetta), but for a demo network with all operations occurring inside this container and no external network activity.
-- **docker-devnet-start.sh** - connects the mina node to our Devnet network with the archive database initialized in a similar way to `docker-start.sh`. As with `docker-start.sh`, this script runs a mina node, mina-archive, a postgresql DB, and mina-rosetta. `docker-devnet-start.sh` is now just a special case of `docker-start.sh` so inspect the source there for more detailed configuration.
 
-Run the container with following command (replace the image tag with the latest one from dockerhub, also replace `--entrypoint` if needed):
+Run the container with following command (replace the image tag with one from dockerhub that's compatible with the network you are trying to connect to, also replace `--entrypoint` and any environment variable if needed):
 
     docker run -it --rm --name rosetta \
         --entrypoint=./docker-start.sh \
-        -p 10101:10101 -p 3085:3085 -p 3086:3086 -p 3087:3087 \
+        -p 8302:8302 -p 3085:3085 -p 3086:3086 -p 3087:3087 \
+        -e MINA_NETWORK=mainnet \
+        -e PEER_LIST_URL=https://storage.googleapis.com/seed-lists/mainnet_seeds.txt \
+        -e MINA_ARCHIVE_DUMP_URL=https://storage.googleapis.com/mina-archive-dumps \
+        -e MINA_GENESIS_LEDGER_URL=http://673156464838-mina-genesis-ledgers.s3-website-us-west-2.amazonaws.com/mainnet/genesis_ledger.json \
+        -e BLOCKS_BUCKET=https://storage.googleapis.com/mina_network_block_data \
         minaprotocol/mina-rosetta:<tag>
+
+You can also create a file with the environment variables and pass it to the docker run command with `--env-file` flag. For example, create a file named `mainnet.env` with the following content:
+
+    MINA_NETWORK=mainnet
+    PEER_LIST_URL=https://storage.googleapis.com/seed-lists/mainnet_seeds.txt
+    MINA_ARCHIVE_DUMP_URL=https://storage.googleapis.com/mina-archive-dumps
+    MINA_GENESIS_LEDGER_URL=http://673156464838-mina-genesis-ledgers.s3-website-us-west-2.amazonaws.com/mainnet/genesis_ledger.json
+    BLOCKS_BUCKET=https://storage.googleapis.com/mina_network_block_data
+
+Then run the container with the following command:
+
+    docker run -it --rm --name rosetta \
+        --entrypoint=./docker-start.sh \
+        -p 8302:8302 -p 3085:3085 -p 3086:3086 -p 3087:3087 \
+        --env-file mainnet.env \
+        minaprotocol/mina-rosetta:<tag>
+
+Example environment files for public networks can be found in [this](https://github.com/MinaProtocol/mina/blob/develop/src/app/rosetta/scripts) directory of Mina's Rosetta repository.
 
 :::note
 
 - It can take 20 min to 1 hour for your node to sync
-- Port 10101 is the default P2P port and must be exposed to the open internet
+- Port 8302 is the default P2P port and must be exposed to the open internet
 - The GraphQL API runs on port 3085 (accessible via localhost:3085/graphql)
-- PostgreSQL runs on port 3086
+- Archive node runs on port 3086
 - Rosetta runs on port 3087
 
 :::

--- a/docs/node-operators/rosetta.mdx
+++ b/docs/node-operators/rosetta.mdx
@@ -45,7 +45,7 @@ The container in `/rosetta` includes 4 scripts, which each run a different set o
 :::note
 
 - It can take 20 min to 1 hour for your node to sync
-- Port 10101 is the default P2P port and must be exposed to the open internet
+- Port 8302 is the default P2P port and must be exposed to the open internet
 - The GraphQL API runs on port 3085 (accessible via localhost:3085/graphql)
 - PostgreSQL runs on port 3086
 - Rosetta runs on port 3087
@@ -56,9 +56,12 @@ The container in `/rosetta` includes 4 scripts, which each run a different set o
 
 **docker-start.sh** (default) - connects the mina node to our Mainnet network and initializes the archive database from publicly-available nightly O(1) Labs backups. As with docker-demo-start.sh, this script runs a mina node, mina-archive, a postgresql DB, and mina-rosetta. The script also periodically checks for blocks that may be missing between the nightly backup and the tip of the chain and will fill in those gaps by walking back the linked list of blocks in the canonical chain and importing them one at a time. Take a look at the source for more information about what and how you can configure.
 
-To run docker-devnet-start.sh and connect to the live Mainnet:
+To run docker-start.sh and connect to the live Mainnet:
 
-    docker run -it --rm --name rosetta --entrypoint=./docker-start.sh -p 10101:10101 -p 3085:3085 -p 3086:3086 -p 3087:3087 minaprotocol/mina-rosetta:latest
+    docker run -it --rm --name rosetta \
+        --entrypoint=./docker-start.sh \
+        -p 8302:8302 -p 3085:3085 -p 3086:3086 -p 3087:3087 \
+        minaprotocol/mina-rosetta:latest
 
 
 #### Mainnet:Offline
@@ -67,7 +70,10 @@ To run docker-devnet-start.sh and connect to the live Mainnet:
 
 To run docker-standalone-start.sh and connect to the offline Mainnet:
 
-    docker run -it --rm --name rosetta --entrypoint=./docker-standalone-start.sh -p 10101:10101 -p 3085:3085 -p 3086:3086 -p 3087:3087 minaprotocol/mina-rosetta:latest
+    docker run -it --rm --name rosetta \
+        --entrypoint=./docker-standalone-start.sh \
+        -p 8302:8302 -p 3085:3085 -p 3086:3086 -p 3087:3087 \
+        minaprotocol/mina-rosetta:latest
 
 #### Demo:Offline
 
@@ -75,15 +81,26 @@ To run docker-standalone-start.sh and connect to the offline Mainnet:
 
 To run the docker-demo-start.sh and connect to the demo network:
 
-    docker run -it --rm --name rosetta --entrypoint=./docker-demo-start.sh -p 10101:10101 -p 3085:3085 -p 3086:3086 -p 3087:3087 minaprotocol/mina-rosetta:latest
+    docker run -it --rm --name rosetta \
+        --entrypoint=./docker-demo-start.sh \
+        -p 8302:8302 -p 3085:3085 -p 3086:3086 -p 3087:3087 \
+        minaprotocol/mina-rosetta:latest
 
 #### Devnet:Online
 
-**docker-devnet-start.sh** - connects the mina node to our Devnet network with the archive database initialized in a similar way to docker-start.sh. As with docker-demo-start.sh, this script runs a mina node, mina-archive, a postgresql DB, and mina-rosetta. docker-devnet-start.sh is now just a special case of docker-start.sh so inspect the source there for more detailed configuration.
+To run docker-start.sh and connect to the live Devnet:
 
-To run the docker-devnet-start.sh and connect to the live Devnet:
+    docker run -it --rm --name rosetta \
+        --entrypoint=./docker-start.sh \
+        -p 8302:8302 -p 3085:3085 -p 3086:3086 -p 3087:3087 \
+        -e MINA_NETWORK=devnet \
+        -e PEER_LIST_URL=https://storage.googleapis.com/o1labs-gitops-infrastructure/devnet/seed-list-devnet.txt \
+        -e MINA_ARCHIVE_DUMP_URL=https://storage.googleapis.com/mina-archive-dumps \
+        -e MINA_GENESIS_LEDGER_URL=http://673156464838-mina-genesis-ledgers.s3-website-us-west-2.amazonaws.com/devnet/genesis_ledger.json \
+        -e BLOCKS_BUCKET=https://storage.googleapis.com/mina_network_block_data \
+        minaprotocol/mina-rosetta:<TAG>
 
-    docker run -it --rm --name rosetta --entrypoint=./docker-devnet-start.sh -p 10101:10101 -p 3085:3085 -p 3086:3086 -p 3087:3087 minaprotocol/mina-rosetta:latest
+Please replace `<TAG>` with the latest release tag compatible with the network you are trying to connect to.
 
 ### Questions?
 


### PR DESCRIPTION
This pull request updates the instructions for running a Rosetta node. It includes changes to the docker run command, environment variables, and port numbers. The instructions now provide more details and examples for running the node on different networks.