### PR TITLE
Node operators section audit

### DIFF
--- a/docs/node-operators/archive-node/getting-started.mdx
+++ b/docs/node-operators/archive-node/getting-started.mdx
@@ -87,7 +87,7 @@ To run a local archive node to run it in the foreground for testing:
 1. Create a local postgres database called `archive`:
 
   ```sh
-  createdb -h localhost -p 5432 -e archive
+  psql -p 5432 --h localhost -c "create database archive"
   ```
 
 1. Load the mina archive schema into the archive database, (create_schema.sql and zkapp_tables.sql):
@@ -174,6 +174,18 @@ To get started with installing and running the archive node using Docker, follow
    --server-port 3086
 
    ```
+
+:::warning
+
+Please be careful when using `--config` argument at archive node bootstrap. 
+
+It should be provided only when archive node is connected to  
+short lived network created mainly for testing, local development or experimental networks.
+
+*Never* use it on long lived network such as mainnet or devnet
+
+
+:::
 
 9. Start the mina daemon and connect it to the archive process that you started on port 3086:
 

--- a/docs/node-operators/block-producer-node/connecting-to-devnet.mdx
+++ b/docs/node-operators/block-producer-node/connecting-to-devnet.mdx
@@ -31,9 +31,9 @@ Connecting to Devnet requires a specific build of the Mina client and a specific
 
 Follow the steps for your operating system.
 
-### Ubuntu 18.04 and Debian 9
+### Ubuntu 20.04 and Debian 11
 
-Install the latest **Stable** [Mina Release 3.0.0](https://github.com/MinaProtocol/mina/releases/tag/3.0.0devnet) or visit the [GitHub Releases Page](https://github.com/MinaProtocol/mina/discussions/15491).
+Install the latest **Stable** [Mina Release 3.0.0](https://github.com/MinaProtocol/mina/releases/tag/3.0.0) or visit the [GitHub Releases Page](https://github.com/MinaProtocol/mina/releases) to install pre-release (Alpha/Beta) builds.
 
 To set up the new debian `stable` repository and install the latest version:
 
@@ -42,7 +42,7 @@ sudo rm /etc/apt/sources.list.d/mina*.list
 sudo echo "deb [trusted=yes] http://packages.o1test.net $(lsb_release -cs) devnet" | sudo tee /etc/apt/sources.list.d/mina-devnet.list
 sudo apt-get install --yes apt-transport-https
 sudo apt-get update
-sudo apt-get install --yes curl unzip mina-devnet-hardfork=3.0.0
+sudo apt-get install --yes curl unzip mina-devnet=3.0.0
 ```
 
 To check that daemon installed correctly:

--- a/docs/node-operators/delegation-program/bp-sidecar.mdx
+++ b/docs/node-operators/delegation-program/bp-sidecar.mdx
@@ -46,7 +46,7 @@ The sidecar is a separate package that can be installed on Debian/Ubuntu or run 
 Install the sidecar package using the apt package manager.
 
 ```
-sudo apt-get install -y mina-bp-stats-sidecar=TBD
+sudo apt-get install -y mina-bp-stats-sidecar=1.3.0-9b0369c
 ```
 
 This will install the following files:

--- a/docs/node-operators/delegation-program/bp-sidecar.mdx
+++ b/docs/node-operators/delegation-program/bp-sidecar.mdx
@@ -46,7 +46,7 @@ The sidecar is a separate package that can be installed on Debian/Ubuntu or run 
 Install the sidecar package using the apt package manager.
 
 ```
-sudo apt-get install -y mina-bp-stats-sidecar=1.3.0-9b0369c
+sudo apt-get install -y mina-bp-stats-sidecar=TBD
 ```
 
 This will install the following files:

--- a/docs/node-operators/delegation-program/uptime-tracking-system.mdx
+++ b/docs/node-operators/delegation-program/uptime-tracking-system.mdx
@@ -45,7 +45,7 @@ If you are required to keep your node online for a grant or specific program, yo
 
 ### Pre-requisites
 
-Make sure you updated your node to at least release (1.3.1+):
+Make sure you updated your node to at least release (3.0.0+):
 
 ## How to set up the uptime system
 

--- a/docs/node-operators/index.mdx
+++ b/docs/node-operators/index.mdx
@@ -20,7 +20,7 @@ There are three public Mina Protocol networks:
 
 1. `mainnet`  - the production network
 2. `devnet`   - the test network based on the same software versions as the mainnet
-3. `berkeley` - a development network where new features are trialed
+3. `izmir`    - a development network where new features are trialed
 
 You check the identity of the network with this graphQL query:
 
@@ -56,15 +56,15 @@ This section describes operations on Mina and how node operators can run Mina no
 
 A node is a machine running the Mina daemon. Different nodes fulfill different roles within the Mina network:
 
-1. Block Producer - A node that participates in a process to determine what blocks it is allowed to produce and then produces blocks containing transactions that can be broadcast to the network. People who run [block producer](https://docs.minaprotocol.com/mina-protocol/block-producers) nodes are also called block producers.
+1. [Block Producer](https://docs.minaprotocol.com/glossary#block-producer) - A node that participates in a process to determine what blocks it is allowed to produce and then produces blocks containing transactions that can be broadcast to the network. People who run [block producer](https://docs.minaprotocol.com/mina-protocol/block-producers) nodes are also called block producers.
 
 2. [SNARK Coordinators](https://docs.minaprotocol.com/glossary#snark-coordinator) - A role on a Mina node in the Mina network that distributes work to a series of SNARK workers in parallel to block production.
 
-3. SNARK Workers -  SNARK workers create [zk-SNARKs](https://minaprotocol.com/blog/what-are-zk-snarks) for each transaction. These zk-SNARKs are used to create recursive zk-SNARKs that prove the correctness of a block, and in turn, these zk-SNARKs are used to create recursive zk-SNARKs that prove the correctness of the network. These zk-SNARKs help provide the Mina Protocol with succinctness. 
+3. [SNARK Workers](https://docs.minaprotocol.com/glossary#snark-worker) -  SNARK workers create [zk-SNARKs](https://minaprotocol.com/blog/what-are-zk-snarks) for each transaction. These zk-SNARKs are used to create recursive zk-SNARKs that prove the correctness of a block, and in turn, these zk-SNARKs are used to create recursive zk-SNARKs that prove the correctness of the network. These zk-SNARKs help provide the Mina Protocol with succinctness. 
 
 4. [Archive Nodes](/node-operators/archive-node) - A regular mina daemon that is connected to a running `mina-archive` process. The daemon regularly sends blockchain data to the archive process that stores it in a [PostgreSQL](https://www.postgresql.org/) database.
 
-5. Seed Nodes - Keep a record of nodes in the network and enable nodes joining the network to connect to peer nodes.
+5. [Seed Nodes](https://docs.minaprotocol.com/glossary#seed-nodes) - Keep a record of nodes in the network and enable nodes joining the network to connect to peer nodes.
 
 
 ## Mina Protocol

--- a/docs/node-operators/staking-and-snarking.mdx
+++ b/docs/node-operators/staking-and-snarking.mdx
@@ -17,7 +17,7 @@ keywords:
 
 # Staking and Snarking
 
-You can interact with the Mina network by participating in consensus to produce a cryptographic proof for the data by generating zk-SNARKs. By operating a node that helps secure the network, you can receive MINA for your efforts. See [Staking Rewards on Mina](https://minaprotocol.com/blog/staking-rewards-on-mina).
+You can interact with the Mina network by participating in consensus to produce a cryptographic proof for the data by generating [zk-SNARKs](https://docs.minaprotocol.com/glossary#zk-snark). By operating a node that helps secure the network, you can receive MINA for your efforts. See [Staking Rewards on Mina](https://minaprotocol.com/blog/staking-rewards-on-mina).
 
 ## Participating in Consensus
 


### PR DESCRIPTION
This Pr consolidates my audit of node-operator section for docs. I mainly fixed versions from 1.4XXX or 1.3XXX to TBD. Removed obsolete app as well . Finally added info about using `--config` parameter when starting archive