### PR TITLE
Update versions (stop-slot) on major-upgrade

### DIFF
--- a/docs/berkeley-upgrade/archive-migration/mainnet-database-maintenance.mdx
+++ b/docs/berkeley-upgrade/archive-migration/mainnet-database-maintenance.mdx
@@ -143,7 +143,7 @@ where:
 
 :warning: Running a replayer from scratch on a Devnet/Mainnet database can take up to a couple of days. The recommended best practice is to break the replayer into smaller parts by using the checkpoint capabilities of the replayer.
 
-:warning: You must run the replayer using the Mainnet version. You can run it from the Docker image at `minaprotocol/mina-archive:1.4.0-c980ba8-bullseye`.
+:warning: You must run the replayer using the Mainnet version. You can run it from the Docker image at `gcr.io/o1labs-192920/mina-archive:2.0.0-039296a-bullseye`.
 
 ## Missing blocks
 
@@ -155,7 +155,7 @@ If you uploaded the missing blocks to Google Cloud, the missing blocks can be re
 
    The `download-missing-blocks` script uses `localhost` as the database host so the script assumes that psql is running on localhost on port 5432. Modify `PG_CONN` in `download_missing_block.sh` for your environment.
 
-1. Install the required `mina-archive-blocks` and `mina-missing-blocks-auditor` scripts that are packed in the `minaprotocol/mina-archive:1.4.0-c980ba8-bullseye` Docker image.
+1. Install the required `mina-archive-blocks` and `mina-missing-blocks-auditor` scripts that are packed in the `gcr.io/o1labs-192920/mina-archive:2.0.0-039296a-bullseye` Docker image.
 
 1. Export the `BLOCKS_BUCKET`:
 
@@ -183,7 +183,7 @@ O1labs maintains a Google bucket containing precomputed blocks from Devnet and M
 Note: It's important to highlight that precomputed blocks for **Devnet** between heights `2` and `1582` have missing fields or incorrect transaction data. Utilizing these blocks to patch your Devnet archive database will result in failure. For those who rely on precomputed blocks from this bucket, please follow the outlined steps:
 
 1. Download additional blocks from `gs://mina_network_block_data/devnet-extensional-bundle.tar.gz`.
-2. Install the necessary `mina-archive-blocks` script contained within the `minaprotocol/mina-archive:1.4.1-e76fc1c-bullseye` Docker image.
+2. Install the necessary `mina-archive-blocks` script contained within the `gcr.io/o1labs-192920/mina-archive:2.0.0-039296a-bullseye` Docker image.
 3. Execute mina-archive-blocks to import the extracted blocks from step 1 using the provided command:
 
       ```sh

--- a/docs/berkeley-upgrade/flags-configs.mdx
+++ b/docs/berkeley-upgrade/flags-configs.mdx
@@ -12,23 +12,22 @@ keywords:
 
 # Post-Upgrade Flags and Configurations for Mainnet
 
-Please refer to the Berkeley node release notes [here](https://github.com/MinaProtocol/mina/releases/tag/3.0.0devnet) **_[NEEDS-UPDATE]_**.
+Please refer to the Berkeley node release notes [here](https://github.com/MinaProtocol/mina/releases/tag/2.0.0).
 
 ### Network details
-**_[NEEDS-UPDATE]_**
 
 ```
 Chain ID
-29936104443aaf264a7f0192ac64b1c7173198c1ed404c1bcff5e562e05eb7f6
+5f704cc0c82e0ed70e873f0893d7e06f148524e3f0bdae2afb02e7819a0c24d1
 
 Git SHA-1
-dc6bf78b8ddbbca3a1a248971b76af1514bf05aa
+039296a260080ed02d0d0750d185921f030b6c9c
 
 Seed List
 https://bootnodes.minaprotocol.com/networks/mainnet.txt
 
 Node build
-https://github.com/MinaProtocol/mina/releases/tag/3.0.0devnet
+https://github.com/MinaProtocol/mina/releases/tag/2.0.0
 ```
 
 ### Block Producer​s
@@ -88,8 +87,8 @@ Running an Archive Node involves setting up a non-block-producing node and a Pos
 For more information about running archive nodes, see [Archive Node](/node-operators/archive-node).
 
 The PostgreSQL database requires two schemas:
-1. The PostgreSQL schema used by the Mina archive database: in the [release notes](https://github.com/MinaProtocol/mina/releases/tag/3.0.0devnet) **_[NEEDS-UPDATE]_**
-2. The PostgreSQL schema extensions to support zkApp commands: in the [release notes](https://github.com/MinaProtocol/mina/releases/tag/3.0.0devnet) **_[NEEDS-UPDATE]_**
+1. The PostgreSQL schema used by the Mina archive database: in the [release notes](https://github.com/MinaProtocol/mina/releases/tag/2.0.0)
+2. The PostgreSQL schema extensions to support zkApp commands: in the [release notes](https://github.com/MinaProtocol/mina/releases/tag/2.0.0)
 
 The non-block-producing node must be configured with the following flags:
 ```

--- a/docs/berkeley-upgrade/upgrade-steps.mdx
+++ b/docs/berkeley-upgrade/upgrade-steps.mdx
@@ -25,15 +25,15 @@ Below it's the description in detail of all the upgrade steps and what which nod
   - Review the [upgrade readiness checklist](https://docs.google.com/document/d/1rTmJvyaK33dWjJXMOSiUIGgf8z7turxolGHUpVHNxEU/edit#heading=h.2hqz0ixwjk3f) to confirm they have covered the required steps.
   - Upgrade their nodes to the 1.4.1 stable version
   - Ensure servers are provisioned to run Berkeley nodes, meeting the new hardware requirements
-  - Upgrade their nodes to the node version 2.0.0, with stop-slots, when this version becomes available
+  - Upgrade their nodes to the node version [2.0.0](https://github.com/MinaProtocol/mina/releases/tag/2.0.0), with stop-slots, when this version becomes available
   - Start the archive node initial migration if they run archive nodes and wish to perform the migration in a decentralized manner
 
-**Please note:** a simplified Node Status service will be part of the upgrade tooling and enabled by default in Pre-Upgrade release with the stop-slots (2.0.0) **_[NEEDS-UPDATE]_**. This feature will allow for a safe upgrade by monitoring the amount of upgraded active stake. Only non-sensitive data will be reported. If operators are not comfortable sharing their node version, they will have the option to disable the node version reports by using the appropriate node flag `--node-stats-type none`
+**Please note:** a simplified Node Status service will be part of the upgrade tooling and enabled by default in Pre-Upgrade release with the stop-slots ([2.0.0](https://github.com/MinaProtocol/mina/releases/tag/2.0.0)). This feature will allow for a safe upgrade by monitoring the amount of upgraded active stake. Only non-sensitive data will be reported. If operators are not comfortable sharing their node version, they will have the option to disable the node version reports by using the appropriate node flag `--node-stats-type none`
 
 ### Block Producers and SNARK Workers
 1. Review the [upgrade readiness checklist](https://docs.google.com/document/d/1rTmJvyaK33dWjJXMOSiUIGgf8z7turxolGHUpVHNxEU).
 1. Provision servers that meet the minimum hardware requirements, including the new 32GB RAM requirement and support for _AVX_ and _BMI2_ CPU instructions.
-1. Upgrade nodes to node version 2.0.0 **_[NEEDS-UPDATE]_** when available (2.0.0 **_[NEEDS-UPDATE]_** has built-in stop slots).
+1. Upgrade nodes to node version [2.0.0](https://github.com/MinaProtocol/mina/releases/tag/2.0.0) ([2.0.0](https://github.com/MinaProtocol/mina/releases/tag/2.0.0) has built-in stop slots).
 
 ### Archive Node Operators and Rosetta Operators
 - Two migration processes will be available to archive node operators: _trustless_ and _trustful_. If the archive node operator wants to perform the _trustless_ migration, they should follow these steps; otherwise, proceed to the Upgrade phase. The _trustful_ migration will rely on o1Labs database exports and Docker images to migrate the archive node database and doesn’t require any actions at this stage.
@@ -42,7 +42,7 @@ Below it's the description in detail of all the upgrade steps and what which nod
   - Perform the initial archive node migration. Since Mainnet is a long-lived network, the initial migration process can take up to 48 hours, depending on your server specification and infrastructure.
   - If your Mina Daemon, archive node, or PostgreSQL database runs on different machines, the migration performance will be greatly impacted.
   - For more information on the archive node migration process, please refer to the [Archive Migration](/berkeley-upgrade/archive-migration) section.
-2. Upgrade all nodes to the latest stable version [1.4.1](https://github.com/MinaProtocol/mina/releases/tag/1.4.1).
+2. Upgrade all nodes to the latest stable version [2.0.0](https://github.com/MinaProtocol/mina/releases/tag/2.0.0).
 3. Provision servers that meet the minimum hardware requirements, primarily the new 32GB RAM requirement.
 4. Upgrade their nodes to the version that includes built-in stop slots before the pre-defined _stop-transaction-slot_.
 
@@ -50,7 +50,7 @@ Below it's the description in detail of all the upgrade steps and what which nod
 1. Make sure to test your system integration with Berkeley's new features. Pay special attention to:
   - If you use the **o1labs/client-sdk** library to sign transactions, you should switch to **mina-signer** https://www.npmjs.com/package/mina-signer. **o1labs/client-sdk was deprecated some time ago and will be unusable** once the network has been upgraded. Please review the migration instructions in [Appendix](/berkeley-upgrade/appendix)
   - If you rely on the archive node SQL database tables, please review the schema changes in Appendix 1 of this document.
-2. Upgrade all nodes to the latest stable version [1.4.1](https://github.com/MinaProtocol/mina/releases/tag/1.4.1).
+2. Upgrade all nodes to the latest stable version [2.0.0](https://github.com/MinaProtocol/mina/releases/tag/2.0.0).
 3. Provision servers that meet the minimum hardware requirements, particularly the new 32GB RAM requirement.
 4. Upgrade your nodes to the version that includes built-in stop slots before the pre-defined _stop-transaction-slot_.
 

--- a/docs/exchange-operators/rosetta/run-with-docker.mdx
+++ b/docs/exchange-operators/rosetta/run-with-docker.mdx
@@ -26,9 +26,7 @@ To run Mina Rosetta on Apple silicon, you can use the steps in [Building and run
 
 1. Check the latest release for Mainnet on the official [Mina GitHub releases](https://github.com/MinaProtocol/mina/releases) page.
 
-1. Go to [minaprotocol/mina-rosetta](https://hub.docker.com/r/minaprotocol/mina-rosetta) ` page on the Docker Hub repository. Pull the image with the commit hash matching to the latest Mainnet release.
-
-1. Use this image:
+1. Use the Mina Rosetta Docker image:
 
 
 :::note
@@ -37,19 +35,18 @@ If you want to build your own docker image, you can find more details in [Minaâ€
 
 :::
 
-The container in `/rosetta` includes four entrypoints, which each run a different set of services connected to a particular network.
+The container in `/rosetta` includes three entrypoints, which each run a different set of services connected to a particular network.
 
 - **docker-start.sh** (default) - connects the mina node to our Mainnet network and initializes the archive database from publicly-available nightly o1Labs backups. This script runs a mina node, mina-archive, a postgresql DB, and mina-rosetta. The script also periodically checks for blocks that may be missing between the nightly backup and the tip of the chain and will fill in those gaps by walking back the linked list of blocks in the canonical chain and importing them one at a time. Take a look at the source for more information about what and how you can configure.
 - **docker-standalone-start.sh** - starts only the mina-rosetta API endpoint and any flags passed into the script go to mina-rosetta. Use this for the "offline" part of the Construction API.
 - **docker-demo-start.sh** launches a mina node with a very simple 1-address genesis ledger as a sandbox for developing and playing around in. This script starts the full suite of tools (a mina node, mina-archive, a postgresql DB, and mina-rosetta), but for a demo network with all operations occurring inside this container and no external network activity.
-- **docker-devnet-start.sh** - connects the mina node to our Devnet network with the archive database initialized in a similar way to `docker-start.sh`. As with `docker-start.sh`, this script runs a mina node, mina-archive, a postgresql DB, and mina-rosetta. `docker-devnet-start.sh` is now just a special case of `docker-start.sh` so inspect the source there for more detailed configuration.
 
 Run the container with following command (replace the image tag with the latest one from dockerhub, also replace `--entrypoint` if needed):
 
     docker run -it --rm --name rosetta \
         --entrypoint=./docker-start.sh \
         -p 10101:10101 -p 3085:3085 -p 3086:3086 -p 3087:3087 \
-        minaprotocol/mina-rosetta:<tag>
+        gcr.io/o1labs-192920/mina-rosetta:2.0.0-039296a-focal
 
 :::note
 

--- a/docs/node-operators/archive-node/getting-started.mdx
+++ b/docs/node-operators/archive-node/getting-started.mdx
@@ -55,13 +55,13 @@ Running an archive node requires some knowledge of managing a PostgreSQL databas
    - Ubuntu/Debian:
 
      ```
-     sudo apt-get install mina-archive=1.4.0-c980ba8
+     sudo apt-get install mina-archive=2.0.0-039296a
      ```
 
    - Docker:
 
      ```
-     minaprotocol/mina-archive:1.4.0-c980ba8-bullseye
+     gcr.io/o1labs-192920/mina-archive:2.0.0-039296a-bullseye
      ```
 
 ## Set up the archive node
@@ -93,9 +93,7 @@ To run a local archive node to run it in the foreground for testing:
 1. Load the mina archive schema into the archive database, (create_schema.sql and zkapp_tables.sql):
 
   ```sh
-  psql -h localhost -p 5432 -d archive -f <(curl -Ls https://raw.githubusercontent.com/MinaProtocol/mina/1551e2faaa246c01636908aabe5f7981715a10f4/src/app/archive/create_schema.sql)
-
-  psql -h localhost -p 5432 -d archive -f <(curl -Ls https://raw.githubusercontent.com/MinaProtocol/mina/1551e2faaa246c01636908aabe5f7981715a10f4/src/app/archive/zkapp_tables.sql)
+  psql -h localhost -p 5432 -d archive -f <(curl -Ls https://raw.githubusercontent.com/MinaProtocol/mina/release/2.0.0/src/app/archive/create_schema.sql)
 
   ```
 
@@ -127,7 +125,7 @@ To get started with installing and running the archive node using Docker, follow
 2. Pull the archive node image from Docker Hub.
 
    ```sh
-   docker pull minaprotocol/mina-archive:1.4.0-c980ba8-bullseye
+   docker pull gcr.io/o1labs-192920/mina-archive:2.0.0-bullseye
    ```
 
 3. Pull and install the postgres image from Docker Hub.
@@ -170,7 +168,7 @@ To get started with installing and running the archive node using Docker, follow
    --name archive \
    -p 3086:3086 \
    -v /tmp/archive:/data \
-   minaprotocol/mina-archive:1.4.0-c980ba8-bullseye \
+   gcr.io/o1labs-192920/mina-archive:2.0.0-bullseye \
    mina-archive run \
    --postgres-uri postgres://postgres:postgres@postgres:5432/archive \
    --server-port 3086
@@ -202,7 +200,7 @@ To run the archive node using Docker Compose:
 3. Pull the archive node image from Docker Hub.
 
    ```sh
-   docker pull minaprotocol/mina-archive:1.4.0-c980ba8-bullseye
+   docker pull gcr.io/o1labs-192920/mina-archive:2.0.0-bullseye
    ```
 
 4. Pull and install the postgres image from Docker Hub.
@@ -230,7 +228,7 @@ To run the archive node using Docker Compose:
        ports:
          - '5432:5432'
      archive:
-       image: 'minaprotocol/mina-archive:1.4.0-c980ba8-bullseye'
+       image: 'gcr.io/o1labs-192920/mina-archive:2.0.0-bullseye'
        command: >-
          mina-archive run --postgres-uri
          postgres://postgres:postgres@postgres:5432/archive --server-port 3086

--- a/docs/node-operators/block-producer-node/connecting-to-devnet.mdx
+++ b/docs/node-operators/block-producer-node/connecting-to-devnet.mdx
@@ -13,7 +13,7 @@ keywords:
 
 # Connect to Devnet
 
-The Devnet network is designed for testing and experimentation. Devnet is a dedicated network for developers who are building on top of the Mina protocol. 
+The Devnet network is designed for testing and experimentation. Devnet is a dedicated network for developers who are building on top of the Mina protocol.
 
 On the Devnet network, MINA holds no real value. To request a prefunded account, reach out on [Mina Protocol Discord](https://discord.gg/minaprotocol).
 
@@ -27,21 +27,22 @@ If you are interested in running a node, connect to [Mainnet network](connecting
 
 ## Update your software
 
-Connecting to Devnet requires a specific build of the Mina client and a specific version of a peers list. 
+Connecting to Devnet requires a specific build of the Mina client and a specific version of a peers list.
 
 Follow the steps for your operating system.
 
 ### Ubuntu 18.04 and Debian 9
 
-Install the latest **Stable** [Mina Release 1.3.1.2](https://github.com/MinaProtocol/mina/releases/tag/1.3.1.2) or visit the [GitHub Releases Page](https://github.com/MinaProtocol/mina/releases) to install pre-release (Alpha/Beta) builds.
+Install the latest **Stable** [Mina Release 3.0.0](https://github.com/MinaProtocol/mina/releases/tag/3.0.0devnet) or visit the [GitHub Releases Page](https://github.com/MinaProtocol/mina/discussions/15491).
 
 To set up the new debian `stable` repository and install the latest version:
 
 ```sh
-echo "deb [trusted=yes] http://packages.o1test.net $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/mina.list
+sudo rm /etc/apt/sources.list.d/mina*.list
+sudo echo "deb [trusted=yes] http://packages.o1test.net $(lsb_release -cs) devnet" | sudo tee /etc/apt/sources.list.d/mina-devnet.list
 sudo apt-get install --yes apt-transport-https
 sudo apt-get update
-sudo apt-get install --yes curl unzip mina-devnet=1.3.0-9b0369c
+sudo apt-get install --yes curl unzip mina-devnet-hardfork=3.0.0
 ```
 
 To check that daemon installed correctly:
@@ -97,7 +98,7 @@ docker run --name mina -d \
 --restart=always \
 --mount "type=bind,source=$(pwd)/.mina-env,dst=/entrypoint.d/mina-env,readonly" \
 --mount "type=bind,source=$(pwd)/.mina-config,dst=/root/.mina-config" \
-minaprotocol/mina-daemon:1.3.1.2-25388a0-bullseye-devnet \
+gcr.io/o1labs-192920/mina-daemon:3.0.0-dc6bf78-bullseye-devnet \
 daemon \
 ```
 

--- a/docs/node-operators/block-producer-node/connecting-to-the-network.mdx
+++ b/docs/node-operators/block-producer-node/connecting-to-the-network.mdx
@@ -9,7 +9,7 @@ keywords:
   - install mina
   - start a mina node
   - .mina-env
-  - connectivity 
+  - connectivity
   - how to monitor a mina node
   - standalone mina node
 ---
@@ -30,7 +30,7 @@ Steps to install mina, connect to the Mina Mainnet network, and test connectivit
 
 ## Update your mina daemon
 
-The first step to connecting to Mainnet is to install the latest daemon version. 
+The first step to connecting to Mainnet is to install the latest daemon version.
 
 ### Ubuntu 20.04 and Debian 10, 11, 12
 
@@ -40,7 +40,7 @@ To install the latest [Mainnet **Stable** Release 1.4.0](https://github.com/Mina
 
 **Note:** A known issue exists with the Hetzner hosting provider. If you are using Hetzner, follow the [Networking troubleshooting](/node-operators/troubleshooting#my-hosting-provider-is-warning-me-abuse-message-netscan-detected) guidance before you start a node.
 
-Auto-restart flows are in place to ensure your nodes perform optimally.  
+Auto-restart flows are in place to ensure your nodes perform optimally.
 
 1. Start a standalone mina node to make sure everything works.
 
@@ -179,7 +179,7 @@ docker run --name mina -d \
 --mount "type=bind,source=$(pwd)/.mina-env,dst=/entrypoint.d/mina-env,readonly" \
 --mount "type=bind,source=$(pwd)/keys,dst=/keys,readonly" \
 --mount "type=bind,source=$(pwd)/.mina-config,dst=/root/.mina-config" \
-minaprotocol/mina-daemon:1.4.0-c980ba8-bullseye-mainnet \
+gcr.io/o1labs-192920/mina-daemon:2.0.0-039296a-mainnet \
 daemon
 ```
 
@@ -242,6 +242,6 @@ The expected response includes these fields:
 
 ## Step up your game
 
-Now that you have a fully synced node, learn about some of the more advanced features of the daemon, such as [Sending a payment](/mina-protocol/sending-a-payment) and [Staking & Delegating](/node-operators/staking-and-snarking). 
+Now that you have a fully synced node, learn about some of the more advanced features of the daemon, such as [Sending a payment](/mina-protocol/sending-a-payment) and [Staking & Delegating](/node-operators/staking-and-snarking).
 
 To earn MINA tokens, check out the [Mina Foundation Delegation Program](/node-operators/delegation-program/foundation-delegation-program).

--- a/docs/node-operators/block-producer-node/getting-started.mdx
+++ b/docs/node-operators/block-producer-node/getting-started.mdx
@@ -79,7 +79,7 @@ sudo apt-get update
 Now install the node package.
 
 ```
-sudo apt-get install -y curl unzip mina-mainnet=1.4.0-c980ba8
+sudo apt-get install -y curl unzip mina-mainnet=2.0.0-039296a
 ```
 
 
@@ -87,7 +87,7 @@ To verify the mina daemon installation, run:
 
 - `mina version`
 
-The expected output is `Commit c980ba87c3417f40a7081225dfe7478c5ee70fd7 on branch master`.
+The expected output is `Commit 039296a260080ed02d0d0750d185921f030b6c9c on branch master`.
 
 ### If you are using Ufw, allow these permissions
 

--- a/docs/node-operators/generating-a-keypair.mdx
+++ b/docs/node-operators/generating-a-keypair.mdx
@@ -18,7 +18,7 @@ keywords:
 
 ## About Key Pairs
 
-Two different key pairs are relevant to node operators: 
+Two different key pairs are relevant to node operators:
 
 - Wallet keypairs you generate with the steps provided here
 - libp2p keypairs that are gossip network identities
@@ -34,7 +34,7 @@ The supported tools for generating public/private key pairs are:
 - [Mina Signer](/node-operators/mina-signer)
 - [Mina command line wallet package](https://github.com/jspada/ledger-app-mina/blob/v1.0.0-beta.2/README.md#command-line-wallet) that interfaces with your Ledger device and Mina blockchain to generate addresses on the Ledger hardware wallet
 
-Always give out your public keys. Mina will never ask you for your private keys. Be sure that your private keys are stored safely. 
+Always give out your public keys. Mina will never ask you for your private keys. Be sure that your private keys are stored safely.
 
 
 :::caution
@@ -43,7 +43,7 @@ Never give out your private key.
 
 :::
 
-If you lose your private key or if a malicious actor gains access to your private key, you will lose access to your account and lose your account funds. 
+If you lose your private key or if a malicious actor gains access to your private key, you will lose access to your account and lose your account funds.
 
 ## Mina Generate Keypair
 
@@ -52,7 +52,7 @@ The `mina-generate-keypair` command line utility is the simplest method to creat
 ```
 Generate a new public, private keypair
 
-  mina-generate-keypair 
+  mina-generate-keypair
 
 === flags ===
 
@@ -74,7 +74,7 @@ Generate a new public, private keypair
     ```sh
     echo "deb [trusted=yes] http://packages.o1test.net $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/mina.list
     sudo apt-get update
-    sudo apt-get install mina-generate-keypair=1.4.0-c980ba8
+    sudo apt-get install mina-generate-keypair=2.0.0-039296a
     ```
 
 1. Verify that the key generation tool installed correctly:
@@ -86,10 +86,10 @@ Generate a new public, private keypair
     The expected output is:
 
     ```
-    Commit c980ba87c3417f40a7081225dfe7478c5ee70fd7 on branch master
+    Commit 039296a260080ed02d0d0750d185921f030b6c9c on branch master
     ```
 
-### macOS, Windows, and platforms other than Ubuntu and Debian 
+### macOS, Windows, and platforms other than Ubuntu and Debian
 
 Install Docker. Follow the Docker-based instructions to generate key pairs.
 
@@ -113,27 +113,30 @@ Install Docker. Follow the Docker-based instructions to generate key pairs.
 Make sure to set a new and secure password for the following commands. Mina will never ask you for this password. Do not share this password with anyone.
 :::
 
-1. Run the `mina-generate-keypair` command: 
-    
+1. Run the `mina-generate-keypair` command:
+
     ```
     mina-generate-keypair --privkey-path ~/keys/my-wallet
     ```
 
-1. When prompted, type in the password you intend to use to secure this key. <em>Do NOT forget this password.</em> If already set, the tool uses the password from the `MINA_PRIVKEY_PASS` environment variable instead of prompting you. 
+1. When prompted, type in the password you intend to use to secure this key. <em>Do NOT forget this password.</em> If already set, the tool uses the password from the `MINA_PRIVKEY_PASS` environment variable instead of prompting you.
 
 ## Generate keys on Docker for Windows, macOS, and Linux
-    
+
 1. Use the `minaprotocol/generate-keypair` Docker image:
-    
+
     ```
     cd ~
-    docker run --interactive --tty --rm --volume $(pwd)/keys:/keys minaprotocol/mina-generate-keypair:1.3.1-3e3abec --privkey-path /keys/my-wallet
+    docker run -it --rm --entrypoint "" \
+           --volume $(pwd)/keys:/keys \
+           gcr.io/o1labs-192920/mina-daemon:2.0.0beta1-039296a-bullseye-mainnet \
+           mina advanced generate-keypair --privkey-path /keys/my-wallet
     ```
-    
+
 1. When prompted, type in the password you intend to use to secure this key. <em>Do NOT forget this password.</em>
 
     Two files are created for your public/private key pair:
-    
+
     - `~/keys/my-wallet`: the encrypted private key
     - `~/keys/my-wallet.pub`: the public key in plain text
 
@@ -158,7 +161,10 @@ mina-validate-keypair --privkey-path <path-to-the-private-key-file>
 On Docker:
 
 ```
-docker run --interactive --tty --rm --entrypoint=mina-validate-keypair --volume $(pwd)/keys:/keys minaprotocol/mina-generate-keypair:1.3.1-3e3abec --privkey-path /keys/my-wallet
+docker run -it --rm --entrypoint "" \
+        --volume $(pwd)/keys:/keys \
+        gcr.io/o1labs-192920/mina-daemon:2.0.0beta1-039296a-bullseye-mainnet \
+        mina advanced validate-keypair --privkey-path /keys/my-wallet
 ```
 
 ## mina libp2p generate-keypair
@@ -193,7 +199,7 @@ Mina
   ```
   Generate a new libp2p keypair and print out the peer ID
 
-  mina libp2p generate-keypair 
+  mina libp2p generate-keypair
 
 === flags ===
 
@@ -202,7 +208,7 @@ Mina
                        (alias: -privkey-path)
   [-help]              print this help text and exit
                        (alias: -?)
-  ``` 
+  ```
 ### Installation Instructions
 
 See [Getting Started](./block-producer-node/getting-started)

--- a/docs/welcome.mdx
+++ b/docs/welcome.mdx
@@ -11,9 +11,9 @@ import HomepageFeatures from "@site/src/components/features/HomepageFeatures";
 
 :::caution May 21st 2024
 
-Please make sure to upgrade your mina nodes to **2.0.0** **_[NEEDS-UPDATE]_**
+Please make sure to upgrade your mina nodes to **2.0.0**
 
-=> [Release notes](https://github.com/MinaProtocol/mina/discussions/15333) <= **_[NEEDS-UPDATE]_**
+=> [Release notes](https://github.com/MinaProtocol/mina/discussions/15662)
 
 :::
 
@@ -28,6 +28,6 @@ This [Berkeley Upgrade section](/berkeley-upgrade/requirements) describes the up
 ### Feedback and Questions​
 Thank you for participating in the Berkeley upgrade.
 
-If you have any questions or feedback related to the Berkeley upgrade, please use the dedicated Discord #mainnet channel. **_[NEEDS-UPDATE]_**
+If you have any questions or feedback related to the Berkeley upgrade, please use the dedicated Discord [#mainnet-updates](https://discord.com/channels/484437221055922177/816099272859844638) channel.
 
 ### Next: [How to upgrade your Mina node](/berkeley-upgrade/requirements)


### PR DESCRIPTION
Content

- Mainnet Version updated to 2.0.0-039296a
- Devnet versions updated to 3.0.0
- Updated some "generate-keypair" blocks with the latest release