### PR TITLE
Fix PEER_LIST_URL typo + update Seed List URL

### DIFF
--- a/docs/exchange-operators/rosetta/run-with-docker.mdx
+++ b/docs/exchange-operators/rosetta/run-with-docker.mdx
@@ -51,7 +51,7 @@ Run the container with following command (replace the image tag with one from do
 You can also create a file with the environment variables and pass it to the docker run command with `--env-file` flag. For example, create a file named `mainnet.env` with the following content:
 
     MINA_NETWORK=mainnet
-    PEER_LIST_URL=https://storage.googleapis.com/seed-lists/mainnet_seeds.txt
+    PEERS_LIST_URL=https://bootnodes.minaprotocol.com/networks/mainnet.txt
     MINA_ARCHIVE_DUMP_URL=https://storage.googleapis.com/mina-archive-dumps
     MINA_GENESIS_LEDGER_URL=http://673156464838-mina-genesis-ledgers.s3-website-us-west-2.amazonaws.com/mainnet/genesis_ledger.json
     BLOCKS_BUCKET=https://storage.googleapis.com/mina_network_block_data

--- a/docs/node-operators/block-producer-node/connecting-to-devnet.mdx
+++ b/docs/node-operators/block-producer-node/connecting-to-devnet.mdx
@@ -62,7 +62,7 @@ Commit 9b0369c27bb85c8ab2f8725c6e977eb27b53b826 on branch master
 To start a Mina node instance and connect to the Devnet network:
 
 ```
-mina daemon --peer-list-url https://storage.googleapis.com/seed-lists/devnet_seeds.txt
+mina daemon --peer-list-url https://bootnodes.minaprotocol.com/networks/devnet.txt
 ```
 
 The `--peer-list` argument specifies the the source file of seed peer addresses for the initial peer to connect to on the network. Mina is a [peer-to-peer](/glossary#peer-to-peer) protocol, so there is no dependence on a single centralized server.
@@ -83,12 +83,12 @@ export MINA_PRIVKEY_PASS="My_V3ry_S3cure_Password"
 LOG_LEVEL=Info
 FILE_LOG_LEVEL=Debug
 EXTRA_FLAGS=" --block-producer-key <BLOCK_PRODUCER_KEY_PATH>"
-PEER_LIST_URL=https://storage.googleapis.com/seed-lists/devnet_seeds.txt
+PEERS_LIST_URL=https://bootnodes.minaprotocol.com/networks/devnet.txt
 ```
 
 Replace `<BLOCK_PRODUCER_KEY_PATH>` with the full path to your block producer private key. For example, `/home/ubuntu/keys/my-wallet`.
 
-If you do not want to produce blocks, then provide only the `PEER_LIST_URL`.
+If you do not want to produce blocks, then provide only the `PEERS_LIST_URL`.
 
 Now, run the image with your `~/.mina-config` and `~/.mina-env` files mounted into the container:
 

--- a/docs/node-operators/block-producer-node/connecting-to-the-network.mdx
+++ b/docs/node-operators/block-producer-node/connecting-to-the-network.mdx
@@ -47,7 +47,7 @@ Auto-restart flows are in place to ensure your nodes perform optimally.
    To start a mina node instance and connect to the live network:
 
    ```sh
-   mina daemon --peer-list-url https://storage.googleapis.com/seed-lists/mainnet_seeds.txt
+   mina daemon --peer-list-url https://bootnodes.minaprotocol.com/networks/mainnet.txt
    ```
 
    The `--peer-list` argument specifies the source file of seed peer addresses for the initial peer to connect to on the network. Mina is a [peer-to-peer](/glossary#peer-to-peer) protocol, so there is no dependence on a single centralized server.
@@ -55,7 +55,7 @@ Auto-restart flows are in place to ensure your nodes perform optimally.
    If you have a key with MINA stake and want to produce blocks:
 
    ```sh
-   mina daemon --peer-list-url https://storage.googleapis.com/seed-lists/mainnet_seeds.txt \
+   mina daemon --peer-list-url https://bootnodes.minaprotocol.com/networks/mainnet.txt \
                --block-producer-key ~/keys/my-wallet
    ```
 
@@ -97,7 +97,7 @@ To produce blocks or otherwise customize the configuration for the mina daemon:
 
    - External port 8302
      - Change with `-external-port`
-   - Mainnet package [https://storage.googleapis.com/seed-lists/mainnet_seeds.txt](https://storage.googleapis.com/seed-lists/mainnet_seeds.txt)
+   - Mainnet package [https://bootnodes.minaprotocol.com/networks/mainnet.txt](https://bootnodes.minaprotocol.com/networks/mainnet.txt)
      - Change with `--peer-list-url`
 
 1. After your `.mina-env` file is ready, start a mina node instance and connect to the live network using systemctl to control systemd:
@@ -163,12 +163,12 @@ export MINA_PRIVKEY_PASS="My_V3ry_S3cure_Password"
 LOG_LEVEL=Info
 FILE_LOG_LEVEL=Debug
 EXTRA_FLAGS=" --block-producer-key <BLOCK_PRODUCER_KEY_PATH>"
-PEER_LIST_URL=https://storage.googleapis.com/seed-lists/mainnet_seeds.txt
+PEERS_LIST_URL=https://bootnodes.minaprotocol.com/networks/mainnet.txt
 ```
 
 Replace `<BLOCK_PRODUCER_KEY_PATH>` with the full path to your block producer private key. For example, `/home/ubuntu/keys/my-wallet`.
 
-If you do not want to produce blocks, provide only the `PEER_LIST_URL`.
+If you do not want to produce blocks, provide only the `PEERS_LIST_URL`.
 
 Now, run the image with your `~/.mina-config` and `~/.mina-env` files mounted into the container:
 

--- a/docs/node-operators/seed-peers/getting-started.mdx
+++ b/docs/node-operators/seed-peers/getting-started.mdx
@@ -69,7 +69,7 @@ MINA_LIBP2P_PASS="My_V3ry_S3cure_Password"
 LOG_LEVEL=Info
 FILE_LOG_LEVEL=Debug
 EXTRA_FLAGS=" --libp2p-keypair <path-to-the-key-file> --seed --max-connection 100"
-PEER_LIST_URL=https://storage.googleapis.com/seed-lists/mainnet_seeds.txt
+PEERS_LIST_URL=https://bootnodes.minaprotocol.com/networks/mainnet.txt
 ```
 
 Please note that `<path-to-the-key-file>` could change in value depending on where you stored your libp2p keypair from the previous steps. In docker, the keypath will always be `/keys/filename` due to where volumes are mounted.

--- a/docs/node-operators/troubleshooting.mdx
+++ b/docs/node-operators/troubleshooting.mdx
@@ -148,7 +148,7 @@ We only need the last `k` (290) blocks of the blockchain to produce blocks. So o
 
 ### My sync status is offline?
 
-This status indicates that you have not received any messages from peers for the last ~24 minutes. Ensure that you use the `--peer-list` argument that points to `https://storage.googleapis.com/mina-seed-lists/mainnet_seeds.txt`
+This status indicates that you have not received any messages from peers for the last ~24 minutes. Ensure that you use the `--peer-list` argument that points to `https://bootnodes.minaprotocol.com/networks/mainnet.txt`
 
 See [Connect to Mainnet](./block-producer-node/connecting-to-the-network).
 
@@ -191,7 +191,7 @@ The client port `8301` should **never** be exposed to the internet. There may be
 
 ### Node fails with "Failed to find any peers, crashing as this is not a seed node"?
 
-Ensure that you use the `--peer-list` argument that points to `https://storage.googleapis.com/mina-seed-lists/mainnet_seeds.txt`
+Ensure that you use the `--peer-list` argument that points to `https://bootnodes.minaprotocol.com/networks/mainnet.txt`
 
 See [Connect to Mainnet](./block-producer-node/connecting-to-the-network).
 


### PR DESCRIPTION
Another small PR to fix a bug raised by the community
The documentation refers to `PEER_LIST_URL` but the systemd `mina.service` file refers to `PEERS_LIST_URL`
![image](https://github.com/o1-labs/docs2/assets/12220897/a900b39e-0044-4d4f-8ba2-9893b712eca1)

I am updating on as well the Seed List URL to the official ones
- https://bootnodes.minaprotocol.com/networks/mainnet.txt
- https://bootnodes.minaprotocol.com/networks/devnet.txt