### PR TITLE
Update docker references - repos + port

### DIFF
--- a/docs/exchange-operators/rosetta/run-with-docker.mdx
+++ b/docs/exchange-operators/rosetta/run-with-docker.mdx
@@ -46,7 +46,7 @@ Run the container with following command (replace the image tag with one from do
     docker run -it --rm --name rosetta \
         --entrypoint=./docker-start.sh \
         -p 10101:10101 -p 3085:3085 -p 3086:3086 -p 3087:3087 \
-        gcr.io/o1labs-192920/mina-rosetta:2.0.0-039296a-focal
+        minaprotocol/mina-rosetta:2.0.0-039296a-focal
 
 You can also create a file with the environment variables and pass it to the docker run command with `--env-file` flag. For example, create a file named `mainnet.env` with the following content:
 

--- a/docs/node-operators/archive-node/docker-compose.mdx
+++ b/docs/node-operators/archive-node/docker-compose.mdx
@@ -88,6 +88,7 @@ services:
       - './node/mina-config:/data/.mina-config'
     ports:
       - '3085:3085'
+      - '8302:8302'
     depends_on:
       generate_libp2p_key:
         condition: service_completed_successfully

--- a/docs/node-operators/archive-node/getting-started.mdx
+++ b/docs/node-operators/archive-node/getting-started.mdx
@@ -61,7 +61,7 @@ Running an archive node requires some knowledge of managing a PostgreSQL databas
    - Docker:
 
      ```
-     gcr.io/o1labs-192920/mina-archive:2.0.0-039296a-bullseye
+     minaprotocol/mina-archive:2.0.0-039296a-bullseye
      ```
 
 ## Set up the archive node
@@ -125,7 +125,7 @@ To get started with installing and running the archive node using Docker, follow
 2. Pull the archive node image from Docker Hub.
 
    ```sh
-   docker pull gcr.io/o1labs-192920/mina-archive:2.0.0-bullseye
+   docker pull minaprotocol/mina-archive:2.0.0-039296a-bullseye
    ```
 
 3. Pull and install the postgres image from Docker Hub.
@@ -168,7 +168,7 @@ To get started with installing and running the archive node using Docker, follow
    --name archive \
    -p 3086:3086 \
    -v /tmp/archive:/data \
-   gcr.io/o1labs-192920/mina-archive:2.0.0-bullseye \
+   minaprotocol/mina-archive:2.0.0-039296a-bullseye \
    mina-archive run \
    --postgres-uri postgres://postgres:postgres@postgres:5432/archive \
    --server-port 3086
@@ -200,7 +200,7 @@ To run the archive node using Docker Compose:
 3. Pull the archive node image from Docker Hub.
 
    ```sh
-   docker pull gcr.io/o1labs-192920/mina-archive:2.0.0-bullseye
+   docker pull minaprotocol/mina-archive:2.0.0-039296a-bullseye
    ```
 
 4. Pull and install the postgres image from Docker Hub.
@@ -228,7 +228,7 @@ To run the archive node using Docker Compose:
        ports:
          - '5432:5432'
      archive:
-       image: 'gcr.io/o1labs-192920/mina-archive:2.0.0-bullseye'
+       image: 'minaprotocol/mina-archive:2.0.0-039296a-bullseye'
        command: >-
          mina-archive run --postgres-uri
          postgres://postgres:postgres@postgres:5432/archive --server-port 3086

--- a/docs/node-operators/block-producer-node/connecting-to-the-network.mdx
+++ b/docs/node-operators/block-producer-node/connecting-to-the-network.mdx
@@ -179,7 +179,7 @@ docker run --name mina -d \
 --mount "type=bind,source=$(pwd)/.mina-env,dst=/entrypoint.d/mina-env,readonly" \
 --mount "type=bind,source=$(pwd)/keys,dst=/keys,readonly" \
 --mount "type=bind,source=$(pwd)/.mina-config,dst=/root/.mina-config" \
-gcr.io/o1labs-192920/mina-daemon:2.0.0-039296a-mainnet \
+minaprotocol/mina-daemon:2.0.0-039296a-mainnet \
 daemon
 ```
 

--- a/docs/node-operators/block-producer-node/docker-compose.mdx
+++ b/docs/node-operators/block-producer-node/docker-compose.mdx
@@ -58,6 +58,8 @@ services:
       '
     volumes:
       - './node/mina-config:/data/.mina-config'
+    ports:
+      - '8302:8302'
     depends_on:
       generate_libp2p_key:
         condition: service_completed_successfully

--- a/docs/node-operators/generating-a-keypair.mdx
+++ b/docs/node-operators/generating-a-keypair.mdx
@@ -129,7 +129,7 @@ Make sure to set a new and secure password for the following commands. Mina will
     cd ~
     docker run -it --rm --entrypoint "" \
            --volume $(pwd)/keys:/keys \
-           gcr.io/o1labs-192920/mina-daemon:2.0.0beta1-039296a-bullseye-mainnet \
+           minaprotocol/mina-daemon:2.0.0-039296a-bullseye-mainnet \
            mina advanced generate-keypair --privkey-path /keys/my-wallet
     ```
 
@@ -163,7 +163,7 @@ On Docker:
 ```
 docker run -it --rm --entrypoint "" \
         --volume $(pwd)/keys:/keys \
-        gcr.io/o1labs-192920/mina-daemon:2.0.0beta1-039296a-bullseye-mainnet \
+        minaprotocol/mina-daemon:2.0.0-039296a-bullseye-mainnet \
         mina advanced validate-keypair --privkey-path /keys/my-wallet
 ```
 

--- a/docs/node-operators/seed-peers/docker-compose.mdx
+++ b/docs/node-operators/seed-peers/docker-compose.mdx
@@ -43,6 +43,8 @@ services:
       '
     volumes:
       - './node/mina-config:/data/.mina-config'
+    ports:
+      - '8302:8302'
     depends_on:
       generate_libp2p_key:
         condition: service_completed_successfully

--- a/docs/node-operators/snark-workers/docker-compose.mdx
+++ b/docs/node-operators/snark-workers/docker-compose.mdx
@@ -66,6 +66,8 @@ services:
       '
     volumes:
       - './node/mina-config:/data/.mina-config'
+    ports:
+      - '8302:8302'
     depends_on:
       generate_libp2p_key:
         condition: service_completed_successfully


### PR DESCRIPTION
In this PR:

- Update `gcr.io/o1labs-192920/mina-xxx` to `minaprotocol/mina-xxx` where possible
- Open libp2p port in docker-compose examples