### PR TITLE
Update docker references, fix typo and remove outdated commands

### DIFF
--- a/docs/mina-protocol/sending-a-payment.mdx
+++ b/docs/mina-protocol/sending-a-payment.mdx
@@ -167,19 +167,19 @@ Once you feel comfortable with the basics of creating an address, and sending & 
 
 Sometimes you may wish to send many transactions: for example, to payout rewards to those delegating to you if you're running a staking pool.
 
-All information here is relevant as of the 1.3.0 build:
+All information here is relevant as of the 2.0.0 build:
 
 ### Rate limiting
 
-Currently, nodes on the network will rate limit receiving messages from a given node. As of the 1.3.0 build, your node will also follow this rate limit when sending transactions. Specifically, the limit is currently set at 10 transactions every 15 seconds computed over a 5 minute window. If you attempt to send transactions faster than this rate, your node will queue them up and flush them as older transactions expire from the window upon which the rate limit is computed. You do not need to throttle sending these transactions yourself.
+Currently, nodes on the network will rate limit receiving messages from a given node. As of the 2.0.0 build, your node will also follow this rate limit when sending transactions. Specifically, the limit is currently set at 10 transactions every 15 seconds computed over a 5 minute window. If you attempt to send transactions faster than this rate, your node will queue them up and flush them as older transactions expire from the window upon which the rate limit is computed. You do not need to throttle sending these transactions yourself.
 
 Note that older releases of the mina daemon do not perform this rate limiting; if you are running an older version, you should manually limit the number of transactions. Due to overheads from rebroadcasting transactions, we do not recommend sending more than 50 transactions every 5 minutes if you need to manually rate limit.
 
 ### My node crashed or disconnected before I could finish sending transactions
 
-The Mina daemon does _not_ currently persist the transaction pool. This means that the transactions that your node will be unaware of any transactions that you've sent so far if your node crashes in the middle of this process. As of the 1.3.0 build, you can resend all transactions (exactly in the same manner as before) and they will be rebroadcasted on the network.
+The Mina daemon does _not_ currently persist the transaction pool. This means that the transactions that your node will be unaware of any transactions that you've sent so far if your node crashes in the middle of this process. As of the 2.0.0 build, you can resend all transactions (exactly in the same manner as before) and they will be rebroadcasted on the network.
 
-If you believe you were temporarily disconnected from the network, but your node stayed online (i.e. the gossip network may have missed one or more of your transactions), as of the 1.3.0 build, you can resend any of the transactions locally and they will be broadcasted again to the network even if your node thinks they've already been shared.
+If you believe you were temporarily disconnected from the network, but your node stayed online (i.e. the gossip network may have missed one or more of your transactions), as of the 2.0.0 build, you can resend any of the transactions locally and they will be broadcasted again to the network even if your node thinks they've already been shared.
 
 ### Cancelling a transaction and setting a new fee
 

--- a/docs/node-developers/sandbox-node.mdx
+++ b/docs/node-developers/sandbox-node.mdx
@@ -26,7 +26,7 @@ docker run \
   --name mina \
   -e RUN_DEMO=true \
   -e MINA_PRIVKEY_PASS='' \
-  minaprotocol/mina-daemon:1.3.0-9b0369c-bullseye-devnet
+  minaprotocol/mina-daemon:2.0.0-039296a-bullseye-mainnet
 
 ```
 

--- a/docs/node-operators/block-producer-node/connecting-to-devnet.mdx
+++ b/docs/node-operators/block-producer-node/connecting-to-devnet.mdx
@@ -54,7 +54,37 @@ mina version
 The expected output is:
 
 ```text
-Commit 9b0369c27bb85c8ab2f8725c6e977eb27b53b826 on branch master
+Commit dc6bf78b8ddbbca3a1a248971b76af1514bf05aa on branch berkeley
+```
+
+## Generate keypairs
+
+```sh
+mkdir -p .mina-config/keys
+```
+
+As described in the [Generate keypairs](/node-operators/generating-a-keypair) guide, each node in the Mina network must possess its own distinct libp2p key pair to comminicate with other nodes.
+
+```sh
+export MINA_LIBP2P_PASS="My_V3ry_S3cure_Password"
+mina libp2p generate-keypair -privkey-path .mina-config/keys/libp2p-key
+```
+
+If you wish to participate in the network as a block producer or a snark-coordinator, you will also need a wallet key pair.
+
+```sh
+export MINA_PRIVKEY_PASS="My_V3ry_S3cure_Password"
+mina-generate-keypair --privkey-path .mina-config/keys/my-wallet
+```
+
+## Set the correct permissions
+
+When running your daemon using Docker, ensure your private keys have the correct permissions.
+
+```sh
+chmod 700 .mina-config/keys
+chmod 600 .mina-config/keys/libp2p-key
+chmod 600 .mina-config/keys/my-wallet
 ```
 
 ## Start and connect a node to Devnet
@@ -62,44 +92,42 @@ Commit 9b0369c27bb85c8ab2f8725c6e977eb27b53b826 on branch master
 To start a Mina node instance and connect to the Devnet network:
 
 ```
-mina daemon --peer-list-url https://bootnodes.minaprotocol.com/networks/devnet.txt
+mina daemon --peer-list-url https://bootnodes.minaprotocol.com/networks/devnet.txt \
+            --libp2p-keypair .mina-config/keys/libp2p-key
 ```
 
 The `--peer-list` argument specifies the the source file of seed peer addresses for the initial peer to connect to on the network. Mina is a [peer-to-peer](/glossary#peer-to-peer) protocol, so there is no dependence on a single centralized server.
 
 ### Docker
 
-To run your daemon using Docker, create a directory on the host machine to mount as a volume:
-
-```sh
-cd ~
-mkdir ~/.mina-config
-```
-
-To produce blocks or customize the configuration for the mina daemon, create the `~/.mina-env` file:
+To produce blocks or otherwise customize the configuration for the mina daemon, create a `.mina-env` files with the following:
 
 ```sh
 export MINA_PRIVKEY_PASS="My_V3ry_S3cure_Password"
+export MINA_LIBP2P_PASS="My_V3ry_S3cure_Password"
 LOG_LEVEL=Info
 FILE_LOG_LEVEL=Debug
-EXTRA_FLAGS=" --block-producer-key <BLOCK_PRODUCER_KEY_PATH>"
-PEERS_LIST_URL=https://bootnodes.minaprotocol.com/networks/devnet.txt
+EXTRA_FLAGS=" --block-producer-key /data/.mina-config/keys/my-wallet --libp2p-keypair /data/.mina-config/keys/libp2p-key"
+PEER_LIST_URL=https://bootnodes.minaprotocol.com/networks/devnet.txt
 ```
 
-Replace `<BLOCK_PRODUCER_KEY_PATH>` with the full path to your block producer private key. For example, `/home/ubuntu/keys/my-wallet`.
+In the example above, `/data/.mina-config/keys/my-wallet` is the absolute path of your block producer private key mounted in the container.
 
-If you do not want to produce blocks, then provide only the `PEERS_LIST_URL`.
+If you do not want to produce blocks, provide only the `PEER_LIST_URL` and the `--libp2p-keypair` flag.
+```sh
+EXTRA_FLAGS="--libp2p-keypair /data/.mina-config/keys/libp2p-key"
+```
 
-Now, run the image with your `~/.mina-config` and `~/.mina-env` files mounted into the container:
+Now, run the image with your `.mina-config` and `.mina-env` and `keys` files mounted into the container:
 
 ```sh
 docker run --name mina -d \
--p 8302:8302 \
---restart=always \
---mount "type=bind,source=$(pwd)/.mina-env,dst=/entrypoint.d/mina-env,readonly" \
---mount "type=bind,source=$(pwd)/.mina-config,dst=/root/.mina-config" \
-gcr.io/o1labs-192920/mina-daemon:3.0.0-dc6bf78-bullseye-devnet \
-daemon \
+       -p 8302:8302 \
+       --restart=always \
+       -v $(pwd)/.mina-config:/data/.mina-config \
+       -v $(pwd)/.mina-env:/entrypoint.d/mina-env \
+       gcr.io/o1labs-192920/mina-daemon:3.0.0-dc6bf78-bullseye-devnet \
+       daemon
 ```
 
 ## Check your connectivity

--- a/docs/node-operators/block-producer-node/connecting-to-the-network.mdx
+++ b/docs/node-operators/block-producer-node/connecting-to-the-network.mdx
@@ -163,7 +163,7 @@ export MINA_PRIVKEY_PASS="My_V3ry_S3cure_Password"
 LOG_LEVEL=Info
 FILE_LOG_LEVEL=Debug
 EXTRA_FLAGS=" --block-producer-key <BLOCK_PRODUCER_KEY_PATH>"
-PEERS_LIST_URL=https://bootnodes.minaprotocol.com/networks/mainnet.txt
+PEER_LIST_URL=https://bootnodes.minaprotocol.com/networks/mainnet.txt
 ```
 
 Replace `<BLOCK_PRODUCER_KEY_PATH>` with the full path to your block producer private key. For example, `/home/ubuntu/keys/my-wallet`.
@@ -179,7 +179,7 @@ docker run --name mina -d \
 --mount "type=bind,source=$(pwd)/.mina-env,dst=/entrypoint.d/mina-env,readonly" \
 --mount "type=bind,source=$(pwd)/keys,dst=/keys,readonly" \
 --mount "type=bind,source=$(pwd)/.mina-config,dst=/root/.mina-config" \
-minaprotocol/mina-daemon:2.0.0-039296a-mainnet \
+minaprotocol/mina-daemon:2.0.0-039296a-bullseye-mainnet \
 daemon
 ```
 

--- a/docs/node-operators/generating-a-keypair.mdx
+++ b/docs/node-operators/generating-a-keypair.mdx
@@ -74,26 +74,26 @@ Generate a new public, private keypair
     ```sh
     echo "deb [trusted=yes] http://packages.o1test.net $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/mina.list
     sudo apt-get update
-    sudo apt-get install mina-generate-keypair=2.0.0-039296a
+    sudo apt-get install -y mina-mainnet=2.0.0-039296a
     ```
 
 1. Verify that the key generation tool installed correctly:
 
     ```sh
-    mina-generate-keypair -version
+    mina -version
     ```
 
     The expected output is:
 
     ```
-    Commit 039296a260080ed02d0d0750d185921f030b6c9c on branch master
+    Commit 039296a260080ed02d0d0750d185921f030b6c9c on branch compatible
     ```
 
 ### macOS, Windows, and platforms other than Ubuntu and Debian
 
 Install Docker. Follow the Docker-based instructions to generate key pairs.
 
-## Using mina-generate-keypair
+## Using mina advanced generate-keypair
 
 1. Create a folder on your system where you can store the key files. By convention, the `~/keys` folder:
 
@@ -113,10 +113,10 @@ Install Docker. Follow the Docker-based instructions to generate key pairs.
 Make sure to set a new and secure password for the following commands. Mina will never ask you for this password. Do not share this password with anyone.
 :::
 
-1. Run the `mina-generate-keypair` command:
+1. Run the `mina advanced generate-keypair` command:
 
     ```
-    mina-generate-keypair --privkey-path ~/keys/my-wallet
+    mina advanced generate-keypair --privkey-path ~/keys/my-wallet
     ```
 
 1. When prompted, type in the password you intend to use to secure this key. <em>Do NOT forget this password.</em> If already set, the tool uses the password from the `MINA_PRIVKEY_PASS` environment variable instead of prompting you.
@@ -150,12 +150,12 @@ Be sure to store the private key file and password you used in a secure place, s
 
 ## Validate your private key
 
-Now that you've created your key, validate that it works. It's sufficient to use the `mina-validate-keypair` tool to verify that you can sign a transaction.
+Now that you've created your key, validate that it works. It's sufficient to use the `mina advanced validate-keypair` command to verify that you can sign a transaction.
 
 On Linux:
 
 ```
-mina-validate-keypair --privkey-path <path-to-the-private-key-file>
+mina advanced validate-keypair --privkey-path <path-to-the-private-key-file>
 ```
 
 On Docker:

--- a/docs/node-operators/seed-peers/getting-started.mdx
+++ b/docs/node-operators/seed-peers/getting-started.mdx
@@ -88,7 +88,7 @@ docker run --name mina-seed-node -d \
 -v "$(pwd)/keys:/root/keys:ro" \
 -v "$(pwd)/.mina-config:/root/.mina-config" \
 -v "$(pwd)/.mina-env:/entrypoint.d/mina-env:ro" \
-minaprotocol/mina-daemon:1.3.0-9b0369c-bullseye-mainnet \
+minaprotocol/mina-daemon:2.0.0-039296a-bullseye-mainnet \
 daemon
 ```
 


### PR DESCRIPTION
In this PR:
- Update reference from 1.3.0 to 2.0.0
- All libp2p block to "connecting-to-devnet"
- Fix typo `PEERS_LIST_URL` -> `PEER_LIST_URL` (We cannot fix it everywhere as systemd file expects `PEERS_...` but daemon expects `PEER_...`)
- Replace `mina-generate-keypair` and `mina-validate-keypair` command with `mina advanced ...`
- Add missing `codename` in `connecting-to-the-network`