### PR TITLE
Fixes broken link in zkApps overview

### DIFF
--- a/docs/zkapps/writing-a-zkapp/index.mdx
+++ b/docs/zkapps/writing-a-zkapp/index.mdx
@@ -57,7 +57,7 @@ zkApps can perform arbitrarily-complex computations off-chain while incurring on
 
 <br />
 
-To learn more, see [How zkApps Work](./zkapps/writing-a-zkapp/introduction-to-zkapps/how-zkapps-work).
+To learn more, see [How zkApps Work](./writing-a-zkapp/introduction-to-zkapps/how-zkapps-work).
 
 ### TypeScript
 


### PR DESCRIPTION
## Description

I was going through the docs to learn more about zkApps, found a broken link in overview page. 
<img width="1511" alt="Screenshot 2024-06-20 at 12 38 20 PM" src="https://github.com/o1-labs/docs2/assets/34301187/ce0eeeaa-f250-4208-b9dc-4d101c601155">
