### PR TITLE
Fix broken links for zkApps docs

### DIFF
--- a/docs/zkapps/tutorials/01-hello-world.mdx
+++ b/docs/zkapps/tutorials/01-hello-world.mdx
@@ -311,7 +311,7 @@ Using a simulated local blockchain speeds up development and tests the behavior 
 :::info
 
 - The term _simulated local blockchain_ refers to the local testing blockchain you use in the first phase of testing as described here.
-- The term _Lightnet_ is used to describe the lightweight Mina network (Lightnet) that is a more accurate representation of the Mina blockchain. See [Testing zkApps with Lightnet](zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-lightnet).
+- The term _Lightnet_ is used to describe the lightweight Mina network (Lightnet) that is a more accurate representation of the Mina blockchain. See [Testing zkApps with Lightnet](/zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-lightnet).
 
 :::
 

--- a/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
+++ b/docs/zkapps/tutorials/03-deploying-to-a-network.mdx
@@ -297,7 +297,7 @@ You ran the `zk deploy` command to:
 
 Congratulations!
 
-To test, configure, and deploy your zkApp on a local representation of the Mina blockchain, see [Testing zkApps with Lightnet](zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-lightnet).
+To test, configure, and deploy your zkApp on a local representation of the Mina blockchain, see [Testing zkApps with Lightnet](/zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-lightnet).
 
 ## About the Smart Contract Transactions
 

--- a/docs/zkapps/writing-a-zkapp/feature-overview/actions-and-reducer.mdx
+++ b/docs/zkapps/writing-a-zkapp/feature-overview/actions-and-reducer.mdx
@@ -120,7 +120,7 @@ In the near future, we want to add a function to retrieve actions from an archiv
 this.reducer.getActions({ fromActionState?: Field, endActionState?: Field }): A[][];
 ```
 
-Use `getActions` for testing with a simulated `LocalBlockchain`. See [Testing zkApps Locally](zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-locally).
+Use `getActions` for testing with a simulated `LocalBlockchain`. See [Testing zkApps Locally](/zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-locally).
 
 ### Actions for concurrent state updates
 

--- a/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/getting-started-zkapps.mdx
+++ b/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/getting-started-zkapps.mdx
@@ -102,11 +102,11 @@ Add the logic for your smart contract.
 
 ### 6. Test locally
 
-- [Test zkApps locally](zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-locally) with a simulated local blockchain.
+- [Test zkApps locally](/zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-locally) with a simulated local blockchain.
 
 ### 7. Test with Lightnet
 
-- Use [Lightnet](zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-lightnet) to test your zkApp with an accurate representation of Mina blockchain.
+- Use [Lightnet](/zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-lightnet) to test your zkApp with an accurate representation of Mina blockchain.
 
 1. Start Lightnet:
 

--- a/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/how-to-write-a-zkapp.mdx
+++ b/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/how-to-write-a-zkapp.mdx
@@ -257,7 +257,7 @@ zkApps are written in TypeScript using o1js. o1js is a TypeScript library for wr
 
 To get started writing zkApps, begin with these o1js docs:
 
-- [Basic concepts](zkapps/o1js/basic-concepts)
+- [Basic concepts](/zkapps/o1js/basic-concepts)
 - [Interacting with Mina](/zkapps/writing-a-zkapp/introduction-to-zkapps/interact-with-mina)
 
 A basic smart contract example is generated when you created a zk project. The high-level smart contract code workflow is:
@@ -270,10 +270,10 @@ A basic smart contract example is generated when you created a zk project. The h
 
     See the exported `class` in the [Add.ts](https://github.com/o1-labs/zkapp-cli/blob/main/templates/project-ts/src/Add.ts#L12) file.
 
-For guided steps to create your first zkApp, start with [Tutorial 1: Hello World](zkapps/tutorials/hello-world).
+For guided steps to create your first zkApp, start with [Tutorial 1: Hello World](/zkapps/tutorials/hello-world).
 
-For comprehensive details about the o1js API, see the [o1js reference](zkapps/o1js-reference).
+For comprehensive details about the o1js API, see the [o1js reference](/zkapps/o1js-reference).
 
 ## Next Steps
 
-Now that you've learned how to write and operate a basic smart contract, you can learn about [Testing zkApps Locally](zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-locally).
+Now that you've learned how to write and operate a basic smart contract, you can learn about [Testing zkApps Locally](/zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-locally).

--- a/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/interact-with-mina.md
+++ b/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/interact-with-mina.md
@@ -470,4 +470,4 @@ Doing this means setting up a fresh, local ledger that is pre-filled with a coup
 
 Fun fact: The `LocalBlockchain` instance literally uses the same OCaml code for transaction validation and application that the Mina node uses; it's compiled to JavaScript with [js_of_ocaml](https://github.com/ocsigen/js_of_ocaml).
 
-You can learn more about testing in [Test zkApps Locally](zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-locally).
+You can learn more about testing in [Test zkApps Locally](/zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-locally).

--- a/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-lightnet.mdx
+++ b/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-lightnet.mdx
@@ -61,7 +61,7 @@ When you use Lightnet via the [`zkapp-cli`](/zkapps/writing-a-zkapp/introduction
 
 ## High-level workflow for Lightnet
 
-1. [Write tests for your smart contract](zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-locally#writing-tests-for-your-smart-contract) and test locally on a simulated local blockchain
+1. [Write tests for your smart contract](/zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-locally#writing-tests-for-your-smart-contract) and test locally on a simulated local blockchain
 1. Start the `Docker Engine`
 1. [Start the Lightnet](#start-the-single-node-network)
 1. [Configure and deploy your zkApp to Lightnet](#configure-your-zkapp)

--- a/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-locally.mdx
+++ b/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-locally.mdx
@@ -182,4 +182,4 @@ See the [Jest Getting Started](https://jestjs.io/docs/getting-started) documenta
 
 ## Next Steps
 
-Now that you know how to test a smart contract on a simulated local blockchain, you can move on to [Testing zkApps with Lightnet](zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-lightnet) before you learn [how to deploy your zkApp](how-to-deploy-a-zkapp) to public networks.
+Now that you know how to test a smart contract on a simulated local blockchain, you can move on to [Testing zkApps with Lightnet](/zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-lightnet) before you learn [how to deploy your zkApp](how-to-deploy-a-zkapp) to public networks.


### PR DESCRIPTION
## Description

While going through the docs, I saw a few broken links for zkApps docs. Maybe we can use something like [linkspector](https://github.com/UmbrellaDocs/linkspector) to help identify if any PR is breaking the links and also previously broken links. 

We do use it for our docs. Let me know, happy to help and set up. 