### PR TITLE
Add Github Actions Testing to Examples

### DIFF
--- a/.github/workflows/test-tutorials.yml
+++ b/.github/workflows/test-tutorials.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - feat/actions
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/test-tutorials.yml
+++ b/.github/workflows/test-tutorials.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/test-tutorials.yml
+++ b/.github/workflows/test-tutorials.yml
@@ -2,6 +2,8 @@ name: Test-Tutorials
 
 on:
   push:
+    branches:
+      - main
 
 jobs:
   run-tests:

--- a/.github/workflows/test-tutorials.yml
+++ b/.github/workflows/test-tutorials.yml
@@ -34,7 +34,7 @@ jobs:
           git config --global user.email "test@example.com"
           git config --global user.name "Test"
 
-      - name: Install and run build for ${{ matrix.example-path }}
+      - name: Install dependencies, build and run ${{ matrix.example-path }}/build/src/main.js
         run: |
           cd ${{ matrix.example-path }}
           npm ci

--- a/.github/workflows/test-tutorials.yml
+++ b/.github/workflows/test-tutorials.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
       

--- a/.github/workflows/test-tutorials.yml
+++ b/.github/workflows/test-tutorials.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  run-tests:
+  test-tutorials:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/test-tutorials.yml
+++ b/.github/workflows/test-tutorials.yml
@@ -26,9 +26,6 @@ jobs:
         with:
           node-version: '20'
       
-      - name: Install dependencies at root level
-        run: npm ci
-      
       - name: Set Git config (global)
         run: |
           git config --global user.email "test@example.com"

--- a/.github/workflows/test-tutorials.yml
+++ b/.github/workflows/test-tutorials.yml
@@ -1,6 +1,4 @@
 name: Test-Tutorials
-
-name: Tutorials tests
 on:
   push:
     branches:
@@ -13,6 +11,7 @@ jobs:
 
     strategy:
       matrix:
+        node-version: [18, 20, 22]
         example-path:
           - examples/zkapps/01-hello-world
           - examples/zkapps/02-private-inputs-and-hash-functions
@@ -26,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: ${{ matrix.node-version }}
       
       - name: Set Git config (global)
         run: |

--- a/.github/workflows/test-tutorials.yml
+++ b/.github/workflows/test-tutorials.yml
@@ -1,9 +1,11 @@
 name: Test-Tutorials
 
+name: Tutorials tests
 on:
   push:
     branches:
       - main
+  workflow_dispatch: {}
 
 jobs:
   test-tutorials:

--- a/.github/workflows/test-tutorials.yml
+++ b/.github/workflows/test-tutorials.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - feat/actions
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/test-tutorials.yml
+++ b/.github/workflows/test-tutorials.yml
@@ -4,16 +4,37 @@ on:
   push:
 
 jobs:
-  hello-world:
+  run-tests:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        example-path:
+          - examples/zkapps/01-hello-world
+          - examples/zkapps/02-private-inputs-and-hash-functions
+          - examples/zkapps/05-common-types-and-functions
+          - examples/zkapps/10-account-updates
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
         with:
-          # In case of version change, update README.md accordingly
-          node-version: 18
-      - run: |
-          npm ci
+          node-version: '20'
+      
+      - name: Install dependencies at root level
+        run: npm ci
+      
+      - name: Set Git config (global)
+        run: |
           git config --global user.email "test@example.com"
           git config --global user.name "Test"
-          npx ts-node scripts/tutorial-runner.ts docs/zkapps/tutorials/01-hello-world.mdx
+
+      - name: Install and run build for ${{ matrix.example-path }}
+        run: |
+          cd ${{ matrix.example-path }}
+          npm ci
+          npm run build
+          node build/src/main.js


### PR DESCRIPTION
This PR updates the test-tutorials workflow to run examples when a commit is pushed to the main branch.

- Bump node version to 20
- Added automated testing for the following examples:
- `01-hello-world`
- `02-private-inputs-and-hash-functions`
- `05-common-types-and-functions`
- `10-account-updates`