### PR TITLE
Add workflow dispatch to algolia-search.yml

### DIFF
--- a/.github/workflows/algolia-search.yml
+++ b/.github/workflows/algolia-search.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: {}
 jobs:
   wait-for-vercel:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We should be able to run `algolia-search` workflow whenever we want.