### PR TITLE
Small fix: fix a link in glossary.mdx

### DIFF
--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -289,7 +289,7 @@ The Mina CLI is installed when you [install Mina](/node-operators/block-producer
 
 ### Mina nodes
 
-Mina nodes fulfill different roles within the network, including [block producers](#block-producer) and [SNARK coordinators)[#snark-coordinator].
+Mina nodes fulfill different roles within the network, including [block producers](#block-producer) and [SNARK coordinators](#snark-coordinator).
 
 ## N
 


### PR DESCRIPTION
Fixes a typo that breaks a link in glossary.