### PR TITLE
When clicking the sidebar caret, open the category index page if available

### DIFF
--- a/src/theme/DocSidebarItem/Category/index.tsx
+++ b/src/theme/DocSidebarItem/Category/index.tsx
@@ -1,4 +1,4 @@
-import React, {type ComponentProps, useEffect, useMemo} from 'react';
+import React, { type ComponentProps, useEffect, useMemo } from 'react';
 import clsx from 'clsx';
 import {
   ThemeClassNames,
@@ -14,10 +14,11 @@ import {
   isSamePath,
 } from '@docusaurus/theme-common/internal';
 import Link from '@docusaurus/Link';
-import {translate} from '@docusaurus/Translate';
+import { translate } from '@docusaurus/Translate';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 import DocSidebarItems from '@theme/DocSidebarItems';
-import type {Props} from '@theme/DocSidebarItem/Category';
+import type { Props } from '@theme/DocSidebarItem/Category';
+import { useHistory } from '@docusaurus/router';
 
 // If we navigate to a category and it becomes active, it should automatically
 // expand itself
@@ -48,7 +49,7 @@ function useAutoExpandActiveCategory({
  * see https://github.com/facebook/docusaurus/issues/3030
  */
 function useCategoryHrefWithSSRFallback(
-  item: Props['item'],
+  item: Props['item']
 ): string | undefined {
   const isBrowser = useIsBrowser();
   return useMemo(() => {
@@ -80,7 +81,7 @@ function CollapseButton({
           description:
             'The ARIA label to toggle the collapsible sidebar category',
         },
-        {label: categoryLabel},
+        { label: categoryLabel }
       )}
       type="button"
       className="clean-btn menu__caret"
@@ -97,18 +98,19 @@ export default function DocSidebarItemCategory({
   index,
   ...props
 }: Props): JSX.Element {
-  const {items, label, collapsible, className, href} = item;
+  const { items, label, collapsible, className, href } = item;
   const {
     docs: {
-      sidebar: {autoCollapseCategories},
+      sidebar: { autoCollapseCategories },
     },
   } = useThemeConfig();
   const hrefWithSSRFallback = useCategoryHrefWithSSRFallback(item);
 
   const isActive = isActiveSidebarItem(item, activePath);
   const isCurrentPage = isSamePath(href, activePath);
+  const history = useHistory();
 
-  const {collapsed, setCollapsed} = useCollapsible({
+  const { collapsed, setCollapsed } = useCollapsible({
     // Active categories are always initialized as expanded. The default
     // (`item.collapsed`) is only used for non-active categories.
     initialState: () => {
@@ -119,13 +121,13 @@ export default function DocSidebarItemCategory({
     },
   });
 
-  const {expandedItem, setExpandedItem} = useDocSidebarItemsExpandedState();
+  const { expandedItem, setExpandedItem } = useDocSidebarItemsExpandedState();
   // Use this instead of `setCollapsed`, because it is also reactive
   const updateCollapsed = (toCollapsed: boolean = !collapsed) => {
     setExpandedItem(toCollapsed ? null : index);
     setCollapsed(toCollapsed);
   };
-  useAutoExpandActiveCategory({isActive, collapsed, updateCollapsed});
+  useAutoExpandActiveCategory({ isActive, collapsed, updateCollapsed });
   useEffect(() => {
     if (
       collapsible &&
@@ -146,12 +148,14 @@ export default function DocSidebarItemCategory({
         {
           'menu__list-item--collapsed': collapsed,
         },
-        className,
-      )}>
+        className
+      )}
+    >
       <div
         className={clsx('menu__list-item-collapsible', {
           'menu__list-item-collapsible--active': isCurrentPage,
-        })}>
+        })}
+      >
         <Link
           className={clsx('menu__link', {
             'menu__link--sublist': collapsible,
@@ -176,7 +180,8 @@ export default function DocSidebarItemCategory({
           aria-current={isCurrentPage ? 'page' : undefined}
           aria-expanded={collapsible ? !collapsed : undefined}
           href={collapsible ? hrefWithSSRFallback ?? '#' : hrefWithSSRFallback}
-          {...props}>
+          {...props}
+        >
           {label}
         </Link>
         {href && collapsible && (
@@ -185,6 +190,7 @@ export default function DocSidebarItemCategory({
             onClick={(e) => {
               e.preventDefault();
               updateCollapsed();
+              collapsed && history.push(hrefWithSSRFallback);
             }}
           />
         )}


### PR DESCRIPTION
This PR makes the sidebar caret open the category index page, if available. Only applied if the category itself is collapsed.

Implemented by ejecting the `DocSidebarItem/Category` component and adding [this line of code](https://github.com/o1-labs/docs2/compare/main...maht0rz:docs2:feature/caret-open-category?expand=1#diff-5944c9a3cf5ed12b796db434f2525e9d48acc4dd4c4cf298a5f20c90de462ce7R193)