### PR TITLE
Update roadmap.mdx with link to o1Labs blog

### DIFF
--- a/docs/zkapps/roadmap.mdx
+++ b/docs/zkapps/roadmap.mdx
@@ -25,4 +25,4 @@ import Subhead from '@site/src/components/common/Subhead';
   src="/img/banner-o1js.png"
 />
 
-To stay up to date with zkApps and o1js, follow the [What's New in o1js](https://blog.o1labs.org/search?q=o1js) monthly updates.
+To stay up to date with zkApps and o1js, follow the [o1Labs blog posts](https://www.o1labs.org/blog).


### PR DESCRIPTION
The existing link sends readers to a Medium account which we don't use anymore. We are updating this to point to the o1Labs bog content.