### PR TITLE
Check starting value instead of computed value

### DIFF
--- a/examples/zkapps/01-hello-world/src/Square.ts
+++ b/examples/zkapps/01-hello-world/src/Square.ts
@@ -8,10 +8,11 @@ export class Square extends SmartContract {
     this.num.set(Field(3));
   }
 
-  @method async update(square: Field) {
+  @method async update(from: Field) {
     const currentState = this.num.get();
-    this.num.requireEquals(currentState);
-    square.assertEquals(currentState.mul(currentState));
+    this.num.requireEquals(from);
+    from.assertEquals(currentState);
+    const square = from.mul(from);
     this.num.set(square);
   }
 }

--- a/examples/zkapps/01-hello-world/src/main.ts
+++ b/examples/zkapps/01-hello-world/src/main.ts
@@ -33,7 +33,7 @@ console.log('state after init:', num0.toString());
 // ----------------------------------------------------
 
 const txn1 = await Mina.transaction(senderAccount, async () => {
-  await zkAppInstance.update(Field(9));
+  await zkAppInstance.update(Field(3));
 });
 await txn1.prove();
 await txn1.sign([senderKey]).send();
@@ -45,7 +45,7 @@ console.log('state after txn1:', num1.toString());
 
 try {
   const txn2 = await Mina.transaction(senderAccount, async () => {
-    await zkAppInstance.update(Field(75));
+    await zkAppInstance.update(Field(10));
   });
   await txn2.prove();
   await txn2.sign([senderKey]).send();
@@ -58,7 +58,7 @@ console.log('state after txn2:', num2.toString());
 // ----------------------------------------------------
 
 const txn3 = await Mina.transaction(senderAccount, async () => {
-  await zkAppInstance.update(Field(81));
+  await zkAppInstance.update(Field(9));
 });
 await txn3.prove();
 await txn3.sign([senderKey]).send();


### PR DESCRIPTION
I thought the first example was a little counter-intuitive. You have to perform the computation once with the app and once outside the app to check the result. Now, the app will square the value if you supply the current state.