### PR TITLE
Replace inline Rosetta docker-compose with reference to mina repo

### DIFF
--- a/docs/exchange-operators/rosetta/docker-compose.mdx
+++ b/docs/exchange-operators/rosetta/docker-compose.mdx
@@ -21,6 +21,10 @@ The full Docker Compose configuration — including `docker-compose.yml`, exampl
 
 ## Quick start
 
+:::tip
+Before running the commands below, review the [Configuration](#configuration) section to see all available options — including image tags, network selection, ports, and database settings.
+:::
+
 ```bash
 git clone https://github.com/MinaProtocol/mina.git
 cd mina/src/app/rosetta/docker-compose

--- a/docs/exchange-operators/rosetta/docker-compose.mdx
+++ b/docs/exchange-operators/rosetta/docker-compose.mdx
@@ -13,114 +13,139 @@ keywords:
 
 # Docker Compose Rosetta
 
-This example demonstrates how to run the Mina Rosetta bundle using Docker Compose for the Mainnet network. This Docker Compose setup includes a Postgres database, a bootstrap database populated with the latest daily SQL dump available, an archive node, a Mina node, and a Missing Blocks Guardian which will fill in any missing blocks.
+For production deployments, use Docker Compose to run each Rosetta component as a separate container. This gives you control over resource allocation, logging, and restarts.
 
-Copy and paste the provided configuration into a `docker-compose.yaml` file. Then run `docker compose up -d` to start the services, and use `docker compose logs -f` to monitor the logs.
+The full Docker Compose configuration — including `docker-compose.yml`, example environment files for mainnet and devnet, a `Makefile`, and a `README` — is maintained in the Mina repository:
 
-```yaml
-services:
-  postgres:
-    image: postgres:17
-    restart: always
-    environment:
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: archive
-    healthcheck:
-      test: ["CMD-SHELL", "psql -U postgres -d archive -tAc \"SELECT COUNT(*) FROM pg_database WHERE datname='archive';\" | grep -q '^1$'"]
-      interval: 5s
-      timeout: 10s
-      retries: 10
-    volumes:
-      - './archive/postgresql/data:/var/lib/postgresql/data'
-    ports:
-      - '5432:5432'
-  bootstrap_db:
-    image: 'minaprotocol/mina-archive:3.3.0-8c0c2e6-bullseye-mainnet'
-    command: >
-      bash -c '
-      curl -O https://storage.googleapis.com/mina-archive-dumps/mainnet-archive-dump-$(date +%F_0000).sql.tar.gz;
-      tar -zxvf mainnet-archive-dump-$(date +%F_0000).sql.tar.gz;
-      psql postgres://postgres:postgres@postgres:5432/archive -c "
-      ALTER SYSTEM SET max_connections = 500;
-      ALTER SYSTEM SET max_locks_per_transaction = 100;
-      ALTER SYSTEM SET max_pred_locks_per_relation = 100;
-      ALTER SYSTEM SET max_pred_locks_per_transaction = 5000;
-      "
-      psql postgres://postgres:postgres@postgres:5432/archive -f mainnet-archive-dump-$(date +%F_0000).sql;
-      '
-    depends_on:
-      postgres:
-        condition: service_healthy
-  missing_blocks_guardian:
-    image: 'minaprotocol/mina-archive:3.3.0-8c0c2e6-bullseye-mainnet'
-    command: >
-      bash -c '
-      curl -O https://raw.githubusercontent.com/MinaFoundation/helm-charts/main/mina-archive/scripts/missing-blocks-guardian-command.sh;
-      export GUARDIAN_PRECOMPUTED_BLOCKS_URL=https://673156464838-mina-precomputed-blocks.s3.us-west-2.amazonaws.com/mainnet;
-      export MINA_NETWORK=mainnet;
-      export PG_CONN=postgres://postgres:postgres@postgres:5432/archive;
-      while true; do bash missing-blocks-guardian-command.sh; sleep 600; done
-      '
-    depends_on:
-      bootstrap_db:
-        condition: service_completed_successfully
-  mina_archive:
-    image: 'minaprotocol/mina-archive:3.3.0-8c0c2e6-bullseye-mainnet'
-    restart: always
-    command:
-      - mina-archive
-      - run
-      - --postgres-uri
-      - postgres://postgres:postgres@postgres:5432/archive
-      - --server-port
-      - "3086"
-    volumes:
-      - './archive/data:/data'
-    depends_on:
-      bootstrap_db:
-        condition: service_completed_successfully
-  mina_node:
-    image: 'minaprotocol/mina-daemon:3.3.0-8c0c2e6-bullseye-mainnet'
-    restart: always
-    environment:
-      MINA_LIBP2P_PASS: PssW0rD
-      MINA_CLIENT_TRUSTLIST: "0.0.0.0/0"
-    entrypoint: []
-    command: >
-      bash -c '
-        mina daemon --archive-address mina_archive:3086 \
-             --peer-list-url https://bootnodes.minaprotocol.com/networks/mainnet.txt \
-             --insecure-rest-server \
-             --rest-port 3085
-      '
-    ports:
-      - '3085:3085'
-      - '8302:8302'
-    depends_on:
-      bootstrap_db:
-        condition: service_completed_successfully
-  mina_rosetta:
-    image: 'minaprotocol/mina-rosetta:3.3.0-8c0c2e6-bullseye-mainnet'
-    restart: always
-    environment:
-      MINA_ROSETTA_MAX_DB_POOL_SIZE: 80
-      MINA_ROSETTA_PG_DATA_INTERVAL: 30
-    entrypoint: []
-    command: >
-      bash -c '
-        mina-rosetta --port 3087 \
-             --archive-uri postgres://postgres:postgres@postgres:5432/archive \
-             --graphql-uri http://mina_node:3085/graphql \
-             --log-level Info
-      '
-    ports:
-      - '3087:3087'
-    depends_on:
-      bootstrap_db:
-        condition: service_completed_successfully
+**[`mina/src/app/rosetta/docker-compose/`](https://github.com/MinaProtocol/mina/tree/compatible/src/app/rosetta/docker-compose)**
+
+## Quick start
+
+```bash
+git clone https://github.com/MinaProtocol/mina.git
+cd mina/src/app/rosetta/docker-compose
+
+# For mainnet
+cp example.mainnet.env .env
+
+# For devnet
+cp example.devnet.env .env
+
+# Edit .env — set MINA_LIBP2P_PASS and review POSTGRES_PASSWORD
+vi .env
+
+# Start all services
+docker compose up -d
+
+# Or use make shortcuts
+make mainnet   # copies mainnet env and starts services
+make devnet    # copies devnet env and starts services
 ```
 
-Once the services are running, you can access the Mina node graphql endpoint at `http://localhost:3085/graphql` and the postgres database using  `psql postgres://postgres:postgres@localhost:5432/archive`.
-You can also access the Rosetta API at `http://localhost:3087`.
+## Services overview
 
-To retrieve the status of the Mina Node, run `docker compose exec mina_node mina client status`
+The Docker Compose setup includes six services:
+
+| Service | Description | Default Port |
+|---------|-------------|--------------|
+| **postgres** | PostgreSQL 17 with health checks | 5432 (container), configurable host port |
+| **bootstrap_db** | One-shot: downloads and imports the latest daily archive dump | — |
+| **mina_archive** | Archive process, stores block data in PostgreSQL | 3086 |
+| **mina_node** | Mina daemon with GraphQL API | 3085 (GraphQL), 8302 (P2P) |
+| **mina_rosetta** | Rosetta API for exchange integration | 3087 |
+| **missing_blocks_guardian** | Monitors and recovers missing blocks between nightly dumps and chain tip | — |
+
+## Configuration
+
+All configuration is done through a single `.env` file. Key variables:
+
+### Docker images
+
+| Variable | Description |
+|----------|-------------|
+| `MINA_DAEMON_IMAGE` | Mina daemon Docker image |
+| `MINA_ARCHIVE_IMAGE` | Mina archive Docker image |
+| `MINA_ROSETTA_IMAGE` | Mina Rosetta Docker image |
+
+For mainnet, images are pulled from [Docker Hub](https://hub.docker.com/u/minaprotocol) (`minaprotocol/mina-*`).
+For devnet, images are pulled from the o1Labs GCR registry.
+
+### Network
+
+| Variable | Description |
+|----------|-------------|
+| `MINA_NETWORK` | `mainnet` or `devnet` |
+| `MINA_PEERLIST_URL` | Bootstrap peers URL |
+| `MINA_LIBP2P_PASS` | Passphrase for the libp2p key (required) |
+
+### Ports
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `POSTGRES_PORT` | `5433` | Host port mapped to PostgreSQL |
+| `MINA_REST_PORT` | `3085` | GraphQL API port |
+| `MINA_P2P_PORT` | `8302` | P2P networking port |
+| `MINA_ARCHIVE_PORT` | `3086` | Archive server port |
+| `MINA_ROSETTA_PORT` | `3087` | Rosetta API port |
+
+### Archive bootstrap
+
+| Variable | Description |
+|----------|-------------|
+| `ARCHIVE_DUMP_BASE_URL` | Base URL for daily archive dumps |
+| `ARCHIVE_DUMP_PREFIX` | Dump filename prefix (`mainnet-archive-dump` or `devnet-archive-dump`) |
+| `GUARDIAN_PRECOMPUTED_BLOCKS_URL` | S3 bucket URL for precomputed blocks used by the missing blocks guardian |
+
+## Data persistence
+
+Bind mounts preserve data across `docker compose down` / `up`:
+
+| Host path | Container path | Contents |
+|-----------|---------------|----------|
+| `./archive/postgresql/data` | `/var/lib/postgresql/data` | PostgreSQL data |
+| `./archive/data` | `/data` | Archive node data |
+| `./mina_node/.mina-config` | `/root/.mina-config` | Daemon config, keys, peers |
+| `./mina_rosetta/.mina-config` | `/root/.mina-config` | Rosetta config |
+
+## Make targets
+
+| Command | Description |
+|---------|-------------|
+| `make devnet` | Copy devnet env and start services |
+| `make mainnet` | Copy mainnet env and start services |
+| `make stop` | Stop all services |
+| `make clean` | Stop services, remove volumes and all persisted data |
+| `make logs` | Follow logs for all services |
+| `make status` | Show container status |
+| `make health` | Check health of Postgres, GraphQL, and Rosetta endpoints |
+
+## Verifying the deployment
+
+Once services are running and the node is synced:
+
+```bash
+# Check container status
+make status
+
+# Run health checks
+make health
+
+# Check sync status
+docker compose exec mina_node mina client status
+
+# Query Rosetta API
+curl -s http://localhost:3087/network/list \
+  -H 'Content-Type: application/json' -d '{}' | jq .
+
+# Connect to archive database
+psql postgres://postgres:postgres@localhost:5433/archive
+```
+
+## Clean start
+
+To wipe all data and start fresh:
+
+```bash
+make clean
+docker compose up -d
+```


### PR DESCRIPTION
## Summary

- Replace the inline `docker-compose.yml` in the docs with a reference to [`mina/src/app/rosetta/docker-compose/`](https://github.com/MinaProtocol/mina/tree/compatible/src/app/rosetta/docker-compose) as the single source of truth
- Document key configuration variables, services overview, data persistence, Make targets, and verification steps
- Eliminates drift between docs and the actual compose files (the inline version had bugs: ALTER SYSTEM in transaction block, filename mismatch in bootstrap, outdated guardian script, old image tags)

Depends on: https://github.com/MinaProtocol/mina/compare/compatible...dkijania/update-rosetta-docker-compose (mina repo PR with the actual docker-compose)

## Test plan

- [ ] Verify the docs page renders correctly
- [ ] Verify the GitHub link to `mina/src/app/rosetta/docker-compose/` resolves
- [ ] Follow the quick start instructions on a clean machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)