### PR TITLE
Move Mina Signer into Developer Tools category

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -58,7 +58,6 @@ module.exports = {
         'using-mina/Protect-Your-MINA',
       ],
     },
-    'mina-signer',
     {
       type: 'category',
       label: 'zkApp Developers',
@@ -1602,6 +1601,13 @@ module.exports = {
           ],
         },
         'exchange-operators/faq',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Developer Tools',
+      items: [
+        'mina-signer',
       ],
     },
     {


### PR DESCRIPTION
## Summary
- Remove `mina-signer` from top-level sidebar (was between "Using Mina" and "zkApp Developers")
- Create new "Developer Tools" category after Exchange Operators
- Place Mina Signer as first item in Developer Tools

## Motivation
Mina Signer was a standalone top-level sidebar item at the same level as major sections like Node Operators and zkApp Developers. It's a tool, not a section - moving it into a dedicated category gives it a more appropriate home that can grow to include other developer tools.

## Test plan
- [x] `npm run build` passes
- [ ] Verify sidebar renders with new "Developer Tools" category
- [ ] Verify `/mina-signer` URL still works (file not moved, only sidebar changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)