### PR TITLE
Skip x.x.x and TBD placeholder tags in docker image validator

### DIFF
--- a/scripts/validate-docker-images.js
+++ b/scripts/validate-docker-images.js
@@ -66,6 +66,17 @@ function hasTemplatePlaceholders(imageRef) {
     return true;
   }
 
+  // Skip image refs whose tag contains a literal version placeholder
+  // such as "x.x.x", "X.X", or "TBD" (case-insensitive). These are
+  // documentation placeholders the reader must substitute, not real tags.
+  const tag = imageRef.split(':').slice(1).join(':');
+  if (tag && /\b[xX]\.[xX](?:\.[xX])?\b/.test(tag)) {
+    return true;
+  }
+  if (tag && /\bTBD\b/i.test(tag)) {
+    return true;
+  }
+
   return false;
 }
 


### PR DESCRIPTION
## Summary

- The docker image validator (`scripts/validate-docker-images.js`) skips placeholders wrapped in `{}`, `<>`, `$`, or `[]`, but the docs frequently use bare literals like `3.x.x` or `TBD` to mark a version the reader must substitute.
- Today those tags are sent to Docker Hub, return 404, and fail CI for any docs PR that uses the convention (e.g. PR #1133 / Mesa upgrade docs).
- Add two tag-side patterns (case-insensitive) to `hasTemplatePlaceholders`: `x.x[.x]` / `X.X[.X]` and `TBD`. Concrete versions like `3.0.0` are still validated.

## Test plan

- [x] Unit-checked the helper against the failing tags from PR #1133:
  - `minaprotocol/mina-daemon-auto-hardfork:3.x.x-bullseye-mainnet` → SKIP
  - `minaprotocol/mina-daemon-auto-hardfork:3.x.x-noble-mainnet` → SKIP
  - `minaprotocol/mina-daemon:3.x.x-bullseye-mainnet` → SKIP
  - `minaprotocol/mina-daemon:TBD-bullseye-mainnet` → SKIP
  - `minaprotocol/mina-daemon:X.X-bullseye-mainnet` → SKIP
  - `minaprotocol/mina-daemon:3.0.0-bullseye-mainnet` → CHECK (still validated)
- [x] Verify the `validate-docker-images` GitHub Actions check stays green on this PR.
- [ ] Once merged, rebase PR #1133 and confirm the placeholder tags it uses (`3.x.x-*`) no longer fail validation. Concrete `4.0.0-*-mesa` example tags in #1133 will still need to be moved to `4.x.x` (separate change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)