### PR TITLE
Mesa preflight: post-hard-fork banner and bump to 4.0.0-preflight-3f038cb

### DIFF
--- a/docs/network-upgrades/index.mdx
+++ b/docs/network-upgrades/index.mdx
@@ -14,7 +14,15 @@ keywords:
 
 Mina protocol evolves through network upgrades (hard forks) that introduce new features and improvements. Each upgrade requires node operators to update their software to remain compatible with the network.
 
+:::warning Mesa preflight hard fork completed — 2026-04-27 14:00 UTC
+
+The Mesa preflight network has hard-forked. The post-fork chain is now running the Mesa release **`4.0.0-preflight-3f038cb`**, which raises the **transaction protocol version to 5.0.0**.
+
+Operators must run **`4.0.0-preflight-3f038cb`** to remain on the preflight network. Earlier builds — including the stop-slot release `4.0.0-preflight-stop-2967b39` — are no longer compatible with the post-fork chain. See [Preflight Network](/network-upgrades/mesa/preflight-network) for the upgrade path.
+
+:::
+
 | Upgrade | Status | Date | Key Changes |
 |---------|--------|------|-------------|
 | [Berkeley](/network-upgrades/berkeley/requirements) | Completed | June 2024 | zkApp programmability, recursive proofs, new transaction model, archive database migration |
-| [Mesa](/network-upgrades/mesa/preflight-network) | Upcoming | TBD | Expanded zkApp state (8 → 31 fields), automode upgrades, simplified archive migration |
+| [Mesa](/network-upgrades/mesa/preflight-network) | Preflight hard fork completed | 2026-04-27 14:00 UTC (preflight) | Transaction protocol v5.0.0, automode upgrades, simplified archive migration |

--- a/docs/network-upgrades/index.mdx
+++ b/docs/network-upgrades/index.mdx
@@ -14,15 +14,19 @@ keywords:
 
 Mina protocol evolves through network upgrades (hard forks) that introduce new features and improvements. Each upgrade requires node operators to update their software to remain compatible with the network.
 
-:::warning Mesa preflight hard fork completed — 2026-04-27 14:00 UTC
+:::warning Mesa preflight hard fork completed — 2026-04-27 13:00 UTC
 
 The Mesa preflight network has hard-forked. The post-fork chain is now running the Mesa release **`4.0.0-preflight-3f038cb`**, which raises the **transaction protocol version to 5.0.0**.
 
-Operators must run **`4.0.0-preflight-3f038cb`** to remain on the preflight network. Earlier builds — including the stop-slot release `4.0.0-preflight-stop-2967b39` — are no longer compatible with the post-fork chain. See [Preflight Network](/network-upgrades/mesa/preflight-network) for the upgrade path.
+Operators must run **`4.0.0-preflight-3f038cb`** to remain on the preflight network. Earlier builds — including the stop-slot release `4.0.0-preflight-stop-2967b39` — are no longer compatible with the post-fork chain.
+
+zkApp developers must update to **`o1js@3.0.0-mesa.698ca`**, which targets transaction protocol v5.0.0; earlier o1js releases will produce transactions that the post-fork network rejects.
+
+See [Preflight Network](/network-upgrades/mesa/preflight-network) for the full upgrade path.
 
 :::
 
 | Upgrade | Status | Date | Key Changes |
 |---------|--------|------|-------------|
 | [Berkeley](/network-upgrades/berkeley/requirements) | Completed | June 2024 | zkApp programmability, recursive proofs, new transaction model, archive database migration |
-| [Mesa](/network-upgrades/mesa/preflight-network) | Preflight hard fork completed | 2026-04-27 14:00 UTC (preflight) | Transaction protocol v5.0.0, automode upgrades, simplified archive migration |
+| [Mesa](/network-upgrades/mesa/preflight-network) | Preflight hard fork completed | 2026-04-27 13:00 UTC (preflight) | Transaction protocol v5.0.0, automode upgrades, simplified archive migration |

--- a/docs/network-upgrades/mesa/archive-upgrade.mdx
+++ b/docs/network-upgrades/mesa/archive-upgrade.mdx
@@ -15,9 +15,9 @@ keywords:
 
 This guide describes the general procedure for upgrading a Mina archive database from Berkeley to Mesa. The same steps apply to every Mesa deployment (preflight, devnet, mainnet) — only the archive package version differs.
 
-:::warning Hard fork completed — 2026-04-27 14:00 UTC
+:::warning Hard fork completed — 2026-04-27 13:00 UTC
 
-The Mesa preflight network hard-forked at **2026-04-27 14:00 UTC**. The post-fork chain runs **`4.0.0-preflight-3f038cb`**, which raises the **transaction protocol version to 5.0.0**. Pre-fork builds — including the stop-slot release `4.0.0-preflight-stop-2967b39` — are no longer compatible.
+The Mesa preflight network hard-forked at **2026-04-27 13:00 UTC**. The post-fork chain runs **`4.0.0-preflight-3f038cb`**, which raises the **transaction protocol version to 5.0.0**. Pre-fork builds — including the stop-slot release `4.0.0-preflight-stop-2967b39` — are no longer compatible.
 
 When upgrading a preflight archive database, install the matching `mina-archive-mesa=4.0.0-preflight-3f038cb` package so the archive node speaks the new transaction protocol.
 

--- a/docs/network-upgrades/mesa/archive-upgrade.mdx
+++ b/docs/network-upgrades/mesa/archive-upgrade.mdx
@@ -15,14 +15,20 @@ keywords:
 
 This guide describes the general procedure for upgrading a Mina archive database from Berkeley to Mesa. The same steps apply to every Mesa deployment (preflight, devnet, mainnet) — only the archive package version differs.
 
+:::warning Hard fork completed — 2026-04-27 14:00 UTC
+
+The Mesa preflight network hard-forked at **2026-04-27 14:00 UTC**. The post-fork chain runs **`4.0.0-preflight-3f038cb`**, which raises the **transaction protocol version to 5.0.0**. Pre-fork builds — including the stop-slot release `4.0.0-preflight-stop-2967b39` — are no longer compatible.
+
+When upgrading a preflight archive database, install the matching `mina-archive-mesa=4.0.0-preflight-3f038cb` package so the archive node speaks the new transaction protocol.
+
+:::
+
 :::info Choosing the Mesa archive version
 
 The commands below use `<MESA_VERSION>` as a placeholder for the archive build you want to install. Substitute the tag that matches your target network:
 
-- **Preflight network** — see [Preflight Network](./preflight-network) for the current pinned version (e.g. `4.0.0-preflight-stop-2967b39`).
+- **Preflight network** — use `4.0.0-preflight-3f038cb` (post-hard-fork; transaction protocol v5.0.0). See [Preflight Network](./preflight-network) for the full release matrix.
 - **Devnet / mainnet** — use the Mesa release tag published for that network when it is announced.
-
-If you are following the preflight hard-fork timeline (**2026-04-27 14:00 UTC**), see [Preflight Network](./preflight-network) for the build versions and the hard-fork notice. A dedicated upgrade-steps walkthrough will be linked here once it ships.
 
 :::
 

--- a/docs/network-upgrades/mesa/preflight-network.mdx
+++ b/docs/network-upgrades/mesa/preflight-network.mdx
@@ -15,13 +15,13 @@ keywords:
 
 The Mesa preflight network is a testing environment for validating the Mesa upgrade before deployment to devnet and mainnet. This network allows node operators and developers to test their infrastructure and applications with the new Mesa release.
 
-:::warning Network Hard Fork — 2026-04-27 14:00 UTC
+:::warning Hard fork completed — 2026-04-27 14:00 UTC
 
-The Mesa preflight network will hard-fork on **2026-04-27 at 14:00 UTC**. A new stop-slot release, **`4.0.0-preflight-stop-2967b39`**, is now available and is **mandatory** for every operator running a Mesa node.
+The Mesa preflight network hard-forked at **2026-04-27 14:00 UTC**. The post-fork chain is now running the Mesa release **`4.0.0-preflight-3f038cb`**, which bumps the **transaction protocol version to 5.0.0**.
 
-Nodes still on the original preflight build (`4.0.0-preflight1-b649c79`) will fall off the network at the stop transaction slot (2026-04-27 10:00 UTC). Upgrade to `4.0.0-preflight-stop-2967b39` now — the same binary carries your node across the fork automatically.
+The transaction protocol bump is a breaking wire-format change: any node still running a pre-fork build (including the stop-slot release `4.0.0-preflight-stop-2967b39` and the original preflight build `4.0.0-preflight1-b649c79`) will reject the new transaction format and is no longer compatible with the network. Upgrade to **`4.0.0-preflight-3f038cb`** to resume participation.
 
-A dedicated **Upgrade Steps** page covering the full hard-fork timeline and per-role operator checklist will be linked from the Mesa Upgrade sidebar once it ships.
+A dedicated **Upgrade Steps** page covering the post-fork operator checklist will be linked from the Mesa Upgrade sidebar once it ships.
 
 :::
 
@@ -35,19 +35,22 @@ The preflight network is intended for testing purposes only. This network may ex
 
 The Mesa preflight network uses the following build versions:
 
-**Current version (install this):** `4.0.0-preflight-stop-2967b39` — stop-slot / hard-fork release.
+**Current version (install this):** `4.0.0-preflight-3f038cb` — post-hard-fork release. Implements transaction protocol version **5.0.0** and is the only build compatible with the post-fork chain.
 
-**Previous version (historical):** `4.0.0-preflight1-b649c79` — original preflight build. Kept here for reference only; do not install on new nodes.
+**Previous versions (historical, do not install on new nodes):**
+
+- `4.0.0-preflight-stop-2967b39` — stop-slot release used to carry nodes up to the fork. Pre-fork transaction protocol; incompatible with the post-fork chain.
+- `4.0.0-preflight1-b649c79` — original preflight build. Listed for reference only.
 
 ### Docker Images
 
 Docker images are available for both `amd64` and `arm64` architectures, on the `bookworm` and `noble` base distributions:
 
-- **Mina Daemon:** `gcr.io/o1labs-192920/mina-daemon:4.0.0-preflight-stop-2967b39-bookworm-mesa`
-- **Archive Node:** `gcr.io/o1labs-192920/mina-archive:4.0.0-preflight-stop-2967b39-bookworm-mesa`
-- **Rosetta:** `gcr.io/o1labs-192920/mina-rosetta:4.0.0-preflight-stop-2967b39-bookworm-mesa`
+- **Mina Daemon:** `gcr.io/o1labs-192920/mina-daemon:4.0.0-preflight-3f038cb-bookworm-mesa`
+- **Archive Node:** `gcr.io/o1labs-192920/mina-archive:4.0.0-preflight-3f038cb-bookworm-mesa`
+- **Rosetta:** `gcr.io/o1labs-192920/mina-rosetta:4.0.0-preflight-3f038cb-bookworm-mesa`
 
-For `noble`, swap `bookworm` for `noble` in the tag (e.g. `mina-daemon:4.0.0-preflight-stop-2967b39-noble-mesa`).
+For `noble`, swap `bookworm` for `noble` in the tag (e.g. `mina-daemon:4.0.0-preflight-3f038cb-noble-mesa`).
 
 ### Debian Packages
 
@@ -57,7 +60,7 @@ Debian packages are available from the unstable repository:
 **Channel:** `preflight`
 **Codenames:** `bookworm`, `noble`
 
-Available packages (each at version `4.0.0-preflight-stop-2967b39`):
+Available packages (each at version `4.0.0-preflight-3f038cb`):
 
 - `mina-mesa`
 - `mina-archive-mesa`
@@ -85,7 +88,7 @@ To start a Mina daemon node using Docker:
 docker run --name mina-mesa-preflight -d \
   -p 8302:8302 \
   --restart=always \
-  gcr.io/o1labs-192920/mina-daemon:4.0.0-preflight-stop-2967b39-bookworm-mesa \
+  gcr.io/o1labs-192920/mina-daemon:4.0.0-preflight-3f038cb-bookworm-mesa \
   daemon \
   --peer-list-url https://storage.googleapis.com/o1labs-gitops-infrastructure/mina-mesa-network/mina-mesa-network-seeds.txt
 ```
@@ -97,7 +100,7 @@ docker run --name mina-mesa-preflight -d \
   -p 8302:8302 \
   --restart=always \
   -v $(pwd)/.mina-config:/root/.mina-config \
-  gcr.io/o1labs-192920/mina-daemon:4.0.0-preflight-stop-2967b39-bookworm-mesa \
+  gcr.io/o1labs-192920/mina-daemon:4.0.0-preflight-3f038cb-bookworm-mesa \
   daemon \
   --peer-list-url https://storage.googleapis.com/o1labs-gitops-infrastructure/mina-mesa-network/mina-mesa-network-seeds.txt \
   --libp2p-keypair /root/.mina-config/keys/libp2p-key
@@ -121,7 +124,7 @@ echo "deb https://unstable.apt.packages.minaprotocol.com $(lsb_release -cs) pref
 
 # Step 4: Update and install
 sudo apt-get update
-sudo apt-get install -y mina-mesa=4.0.0-preflight-stop-2967b39
+sudo apt-get install -y mina-mesa=4.0.0-preflight-3f038cb
 ```
 
 Then start the daemon:
@@ -165,7 +168,7 @@ echo "deb https://unstable.apt.packages.minaprotocol.com $(lsb_release -cs) pref
 
 # Step 4: Install mina-archive-mesa
 sudo apt-get update
-sudo apt-get install -y mina-archive-mesa=4.0.0-preflight-stop-2967b39
+sudo apt-get install -y mina-archive-mesa=4.0.0-preflight-3f038cb
 
 # Step 5: Create PostgreSQL database
 sudo -u postgres createdb archive
@@ -186,7 +189,7 @@ mina-archive run \
 docker run --name mina-archive-mesa -d \
   -p 3086:3086 \
   --restart=always \
-  gcr.io/o1labs-192920/mina-archive:4.0.0-preflight-stop-2967b39-bookworm-mesa \
+  gcr.io/o1labs-192920/mina-archive:4.0.0-preflight-3f038cb-bookworm-mesa \
   mina-archive run \
   --postgres-uri postgresql://archive_user:your-secure-password@postgres-host:5432/archive \
   --server-port 3086
@@ -222,7 +225,7 @@ echo "deb https://unstable.apt.packages.minaprotocol.com $(lsb_release -cs) pref
 
 # Step 4: Install mina-rosetta-mesa
 sudo apt-get update
-sudo apt-get install -y mina-rosetta-mesa=4.0.0-preflight-stop-2967b39
+sudo apt-get install -y mina-rosetta-mesa=4.0.0-preflight-3f038cb
 
 # Step 5: Start Rosetta
 # Rosetta connects to both the mina daemon and archive node
@@ -238,7 +241,7 @@ mina-rosetta \
 docker run --name mina-rosetta-mesa -d \
   -p 3087:3087 \
   --restart=always \
-  gcr.io/o1labs-192920/mina-rosetta:4.0.0-preflight-stop-2967b39-bookworm-mesa \
+  gcr.io/o1labs-192920/mina-rosetta:4.0.0-preflight-3f038cb-bookworm-mesa \
   --port 3087 \
   --archive-uri http://archive-host:3086/graphql \
   --graphql-uri http://mina-daemon-host:3085/graphql

--- a/docs/network-upgrades/mesa/preflight-network.mdx
+++ b/docs/network-upgrades/mesa/preflight-network.mdx
@@ -15,11 +15,13 @@ keywords:
 
 The Mesa preflight network is a testing environment for validating the Mesa upgrade before deployment to devnet and mainnet. This network allows node operators and developers to test their infrastructure and applications with the new Mesa release.
 
-:::warning Hard fork completed — 2026-04-27 14:00 UTC
+:::warning Hard fork completed — 2026-04-27 13:00 UTC
 
-The Mesa preflight network hard-forked at **2026-04-27 14:00 UTC**. The post-fork chain is now running the Mesa release **`4.0.0-preflight-3f038cb`**, which bumps the **transaction protocol version to 5.0.0**.
+The Mesa preflight network hard-forked at **2026-04-27 13:00 UTC**. The post-fork chain is now running the Mesa release **`4.0.0-preflight-3f038cb`**, which bumps the **transaction protocol version to 5.0.0**.
 
 The transaction protocol bump is a breaking wire-format change: any node still running a pre-fork build (including the stop-slot release `4.0.0-preflight-stop-2967b39` and the original preflight build `4.0.0-preflight1-b649c79`) will reject the new transaction format and is no longer compatible with the network. Upgrade to **`4.0.0-preflight-3f038cb`** to resume participation.
+
+zkApp developers must rebuild and redeploy against **`o1js@3.0.0-mesa.698ca`** — the first o1js release that targets transaction protocol v5.0.0. Transactions produced by earlier o1js versions will be rejected by post-fork nodes.
 
 A dedicated **Upgrade Steps** page covering the post-fork operator checklist will be linked from the Mesa Upgrade sidebar once it ships.
 
@@ -36,6 +38,8 @@ The preflight network is intended for testing purposes only. This network may ex
 The Mesa preflight network uses the following build versions:
 
 **Current version (install this):** `4.0.0-preflight-3f038cb` — post-hard-fork release. Implements transaction protocol version **5.0.0** and is the only build compatible with the post-fork chain.
+
+**Compatible o1js release:** `o1js@3.0.0-mesa.698ca` — the matching SDK for transaction protocol v5.0.0. Install with `npm install o1js@3.0.0-mesa.698ca` (or the equivalent for your package manager) when developing or redeploying zkApps against the post-fork preflight network.
 
 **Previous versions (historical, do not install on new nodes):**
 

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -5397,18 +5397,22 @@ url: /network-upgrades
 
 Mina protocol evolves through network upgrades (hard forks) that introduce new features and improvements. Each upgrade requires node operators to update their software to remain compatible with the network.
 
-:::warning Mesa preflight hard fork completed — 2026-04-27 14:00 UTC
+:::warning Mesa preflight hard fork completed — 2026-04-27 13:00 UTC
 
 The Mesa preflight network has hard-forked. The post-fork chain is now running the Mesa release **`4.0.0-preflight-3f038cb`**, which raises the **transaction protocol version to 5.0.0**.
 
-Operators must run **`4.0.0-preflight-3f038cb`** to remain on the preflight network. Earlier builds — including the stop-slot release `4.0.0-preflight-stop-2967b39` — are no longer compatible with the post-fork chain. See [Preflight Network](/network-upgrades/mesa/preflight-network) for the upgrade path.
+Operators must run **`4.0.0-preflight-3f038cb`** to remain on the preflight network. Earlier builds — including the stop-slot release `4.0.0-preflight-stop-2967b39` — are no longer compatible with the post-fork chain.
+
+zkApp developers must update to **`o1js@3.0.0-mesa.698ca`**, which targets transaction protocol v5.0.0; earlier o1js releases will produce transactions that the post-fork network rejects.
+
+See [Preflight Network](/network-upgrades/mesa/preflight-network) for the full upgrade path.
 
 :::
 
 | Upgrade | Status | Date | Key Changes |
 |---------|--------|------|-------------|
 | [Berkeley](/network-upgrades/berkeley/requirements) | Completed | June 2024 | zkApp programmability, recursive proofs, new transaction model, archive database migration |
-| [Mesa](/network-upgrades/mesa/preflight-network) | Preflight hard fork completed | 2026-04-27 14:00 UTC (preflight) | Transaction protocol v5.0.0, automode upgrades, simplified archive migration |
+| [Mesa](/network-upgrades/mesa/preflight-network) | Preflight hard fork completed | 2026-04-27 13:00 UTC (preflight) | Transaction protocol v5.0.0, automode upgrades, simplified archive migration |
 
 ---
 url: /network-upgrades/mesa/archive-upgrade
@@ -5418,9 +5422,9 @@ url: /network-upgrades/mesa/archive-upgrade
 
 This guide describes the general procedure for upgrading a Mina archive database from Berkeley to Mesa. The same steps apply to every Mesa deployment (preflight, devnet, mainnet) — only the archive package version differs.
 
-:::warning Hard fork completed — 2026-04-27 14:00 UTC
+:::warning Hard fork completed — 2026-04-27 13:00 UTC
 
-The Mesa preflight network hard-forked at **2026-04-27 14:00 UTC**. The post-fork chain runs **`4.0.0-preflight-3f038cb`**, which raises the **transaction protocol version to 5.0.0**. Pre-fork builds — including the stop-slot release `4.0.0-preflight-stop-2967b39` — are no longer compatible.
+The Mesa preflight network hard-forked at **2026-04-27 13:00 UTC**. The post-fork chain runs **`4.0.0-preflight-3f038cb`**, which raises the **transaction protocol version to 5.0.0**. Pre-fork builds — including the stop-slot release `4.0.0-preflight-stop-2967b39` — are no longer compatible.
 
 When upgrading a preflight archive database, install the matching `mina-archive-mesa=4.0.0-preflight-3f038cb` package so the archive node speaks the new transaction protocol.
 
@@ -5588,11 +5592,13 @@ url: /network-upgrades/mesa/preflight-network
 
 The Mesa preflight network is a testing environment for validating the Mesa upgrade before deployment to devnet and mainnet. This network allows node operators and developers to test their infrastructure and applications with the new Mesa release.
 
-:::warning Hard fork completed — 2026-04-27 14:00 UTC
+:::warning Hard fork completed — 2026-04-27 13:00 UTC
 
-The Mesa preflight network hard-forked at **2026-04-27 14:00 UTC**. The post-fork chain is now running the Mesa release **`4.0.0-preflight-3f038cb`**, which bumps the **transaction protocol version to 5.0.0**.
+The Mesa preflight network hard-forked at **2026-04-27 13:00 UTC**. The post-fork chain is now running the Mesa release **`4.0.0-preflight-3f038cb`**, which bumps the **transaction protocol version to 5.0.0**.
 
 The transaction protocol bump is a breaking wire-format change: any node still running a pre-fork build (including the stop-slot release `4.0.0-preflight-stop-2967b39` and the original preflight build `4.0.0-preflight1-b649c79`) will reject the new transaction format and is no longer compatible with the network. Upgrade to **`4.0.0-preflight-3f038cb`** to resume participation.
+
+zkApp developers must rebuild and redeploy against **`o1js@3.0.0-mesa.698ca`** — the first o1js release that targets transaction protocol v5.0.0. Transactions produced by earlier o1js versions will be rejected by post-fork nodes.
 
 A dedicated **Upgrade Steps** page covering the post-fork operator checklist will be linked from the Mesa Upgrade sidebar once it ships.
 
@@ -5609,6 +5615,8 @@ The preflight network is intended for testing purposes only. This network may ex
 The Mesa preflight network uses the following build versions:
 
 **Current version (install this):** `4.0.0-preflight-3f038cb` — post-hard-fork release. Implements transaction protocol version **5.0.0** and is the only build compatible with the post-fork chain.
+
+**Compatible o1js release:** `o1js@3.0.0-mesa.698ca` — the matching SDK for transaction protocol v5.0.0. Install with `npm install o1js@3.0.0-mesa.698ca` (or the equivalent for your package manager) when developing or redeploying zkApps against the post-fork preflight network.
 
 **Previous versions (historical, do not install on new nodes):**
 

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -5397,10 +5397,18 @@ url: /network-upgrades
 
 Mina protocol evolves through network upgrades (hard forks) that introduce new features and improvements. Each upgrade requires node operators to update their software to remain compatible with the network.
 
+:::warning Mesa preflight hard fork completed — 2026-04-27 14:00 UTC
+
+The Mesa preflight network has hard-forked. The post-fork chain is now running the Mesa release **`4.0.0-preflight-3f038cb`**, which raises the **transaction protocol version to 5.0.0**.
+
+Operators must run **`4.0.0-preflight-3f038cb`** to remain on the preflight network. Earlier builds — including the stop-slot release `4.0.0-preflight-stop-2967b39` — are no longer compatible with the post-fork chain. See [Preflight Network](/network-upgrades/mesa/preflight-network) for the upgrade path.
+
+:::
+
 | Upgrade | Status | Date | Key Changes |
 |---------|--------|------|-------------|
 | [Berkeley](/network-upgrades/berkeley/requirements) | Completed | June 2024 | zkApp programmability, recursive proofs, new transaction model, archive database migration |
-| [Mesa](/network-upgrades/mesa/preflight-network) | Upcoming | TBD | Expanded zkApp state (8 → 31 fields), automode upgrades, simplified archive migration |
+| [Mesa](/network-upgrades/mesa/preflight-network) | Preflight hard fork completed | 2026-04-27 14:00 UTC (preflight) | Transaction protocol v5.0.0, automode upgrades, simplified archive migration |
 
 ---
 url: /network-upgrades/mesa/archive-upgrade
@@ -5410,14 +5418,20 @@ url: /network-upgrades/mesa/archive-upgrade
 
 This guide describes the general procedure for upgrading a Mina archive database from Berkeley to Mesa. The same steps apply to every Mesa deployment (preflight, devnet, mainnet) — only the archive package version differs.
 
+:::warning Hard fork completed — 2026-04-27 14:00 UTC
+
+The Mesa preflight network hard-forked at **2026-04-27 14:00 UTC**. The post-fork chain runs **`4.0.0-preflight-3f038cb`**, which raises the **transaction protocol version to 5.0.0**. Pre-fork builds — including the stop-slot release `4.0.0-preflight-stop-2967b39` — are no longer compatible.
+
+When upgrading a preflight archive database, install the matching `mina-archive-mesa=4.0.0-preflight-3f038cb` package so the archive node speaks the new transaction protocol.
+
+:::
+
 :::info Choosing the Mesa archive version
 
 The commands below use `<MESA_VERSION>` as a placeholder for the archive build you want to install. Substitute the tag that matches your target network:
 
-- **Preflight network** — see [Preflight Network](./preflight-network) for the current pinned version (e.g. `4.0.0-preflight-stop-2967b39`).
+- **Preflight network** — use `4.0.0-preflight-3f038cb` (post-hard-fork; transaction protocol v5.0.0). See [Preflight Network](./preflight-network) for the full release matrix.
 - **Devnet / mainnet** — use the Mesa release tag published for that network when it is announced.
-
-If you are following the preflight hard-fork timeline (**2026-04-27 14:00 UTC**), see [Preflight Network](./preflight-network) for the build versions and the hard-fork notice. A dedicated upgrade-steps walkthrough will be linked here once it ships.
 
 :::
 
@@ -5574,13 +5588,13 @@ url: /network-upgrades/mesa/preflight-network
 
 The Mesa preflight network is a testing environment for validating the Mesa upgrade before deployment to devnet and mainnet. This network allows node operators and developers to test their infrastructure and applications with the new Mesa release.
 
-:::warning Network Hard Fork — 2026-04-27 14:00 UTC
+:::warning Hard fork completed — 2026-04-27 14:00 UTC
 
-The Mesa preflight network will hard-fork on **2026-04-27 at 14:00 UTC**. A new stop-slot release, **`4.0.0-preflight-stop-2967b39`**, is now available and is **mandatory** for every operator running a Mesa node.
+The Mesa preflight network hard-forked at **2026-04-27 14:00 UTC**. The post-fork chain is now running the Mesa release **`4.0.0-preflight-3f038cb`**, which bumps the **transaction protocol version to 5.0.0**.
 
-Nodes still on the original preflight build (`4.0.0-preflight1-b649c79`) will fall off the network at the stop transaction slot (2026-04-27 10:00 UTC). Upgrade to `4.0.0-preflight-stop-2967b39` now — the same binary carries your node across the fork automatically.
+The transaction protocol bump is a breaking wire-format change: any node still running a pre-fork build (including the stop-slot release `4.0.0-preflight-stop-2967b39` and the original preflight build `4.0.0-preflight1-b649c79`) will reject the new transaction format and is no longer compatible with the network. Upgrade to **`4.0.0-preflight-3f038cb`** to resume participation.
 
-A dedicated **Upgrade Steps** page covering the full hard-fork timeline and per-role operator checklist will be linked from the Mesa Upgrade sidebar once it ships.
+A dedicated **Upgrade Steps** page covering the post-fork operator checklist will be linked from the Mesa Upgrade sidebar once it ships.
 
 :::
 
@@ -5594,19 +5608,22 @@ The preflight network is intended for testing purposes only. This network may ex
 
 The Mesa preflight network uses the following build versions:
 
-**Current version (install this):** `4.0.0-preflight-stop-2967b39` — stop-slot / hard-fork release.
+**Current version (install this):** `4.0.0-preflight-3f038cb` — post-hard-fork release. Implements transaction protocol version **5.0.0** and is the only build compatible with the post-fork chain.
 
-**Previous version (historical):** `4.0.0-preflight1-b649c79` — original preflight build. Kept here for reference only; do not install on new nodes.
+**Previous versions (historical, do not install on new nodes):**
+
+- `4.0.0-preflight-stop-2967b39` — stop-slot release used to carry nodes up to the fork. Pre-fork transaction protocol; incompatible with the post-fork chain.
+- `4.0.0-preflight1-b649c79` — original preflight build. Listed for reference only.
 
 ### Docker Images
 
 Docker images are available for both `amd64` and `arm64` architectures, on the `bookworm` and `noble` base distributions:
 
-- **Mina Daemon:** `gcr.io/o1labs-192920/mina-daemon:4.0.0-preflight-stop-2967b39-bookworm-mesa`
-- **Archive Node:** `gcr.io/o1labs-192920/mina-archive:4.0.0-preflight-stop-2967b39-bookworm-mesa`
-- **Rosetta:** `gcr.io/o1labs-192920/mina-rosetta:4.0.0-preflight-stop-2967b39-bookworm-mesa`
+- **Mina Daemon:** `gcr.io/o1labs-192920/mina-daemon:4.0.0-preflight-3f038cb-bookworm-mesa`
+- **Archive Node:** `gcr.io/o1labs-192920/mina-archive:4.0.0-preflight-3f038cb-bookworm-mesa`
+- **Rosetta:** `gcr.io/o1labs-192920/mina-rosetta:4.0.0-preflight-3f038cb-bookworm-mesa`
 
-For `noble`, swap `bookworm` for `noble` in the tag (e.g. `mina-daemon:4.0.0-preflight-stop-2967b39-noble-mesa`).
+For `noble`, swap `bookworm` for `noble` in the tag (e.g. `mina-daemon:4.0.0-preflight-3f038cb-noble-mesa`).
 
 ### Debian Packages
 
@@ -5616,7 +5633,7 @@ Debian packages are available from the unstable repository:
 **Channel:** `preflight`
 **Codenames:** `bookworm`, `noble`
 
-Available packages (each at version `4.0.0-preflight-stop-2967b39`):
+Available packages (each at version `4.0.0-preflight-3f038cb`):
 
 - `mina-mesa`
 - `mina-archive-mesa`
@@ -5644,7 +5661,7 @@ To start a Mina daemon node using Docker:
 docker run --name mina-mesa-preflight -d \
   -p 8302:8302 \
   --restart=always \
-  gcr.io/o1labs-192920/mina-daemon:4.0.0-preflight-stop-2967b39-bookworm-mesa \
+  gcr.io/o1labs-192920/mina-daemon:4.0.0-preflight-3f038cb-bookworm-mesa \
   daemon \
   --peer-list-url https://storage.googleapis.com/o1labs-gitops-infrastructure/mina-mesa-network/mina-mesa-network-seeds.txt
 ```
@@ -5656,7 +5673,7 @@ docker run --name mina-mesa-preflight -d \
   -p 8302:8302 \
   --restart=always \
   -v $(pwd)/.mina-config:/root/.mina-config \
-  gcr.io/o1labs-192920/mina-daemon:4.0.0-preflight-stop-2967b39-bookworm-mesa \
+  gcr.io/o1labs-192920/mina-daemon:4.0.0-preflight-3f038cb-bookworm-mesa \
   daemon \
   --peer-list-url https://storage.googleapis.com/o1labs-gitops-infrastructure/mina-mesa-network/mina-mesa-network-seeds.txt \
   --libp2p-keypair /root/.mina-config/keys/libp2p-key
@@ -5680,7 +5697,7 @@ echo "deb https://unstable.apt.packages.minaprotocol.com $(lsb_release -cs) pref
 
 # Step 4: Update and install
 sudo apt-get update
-sudo apt-get install -y mina-mesa=4.0.0-preflight-stop-2967b39
+sudo apt-get install -y mina-mesa=4.0.0-preflight-3f038cb
 ```
 
 Then start the daemon:
@@ -5724,7 +5741,7 @@ echo "deb https://unstable.apt.packages.minaprotocol.com $(lsb_release -cs) pref
 
 # Step 4: Install mina-archive-mesa
 sudo apt-get update
-sudo apt-get install -y mina-archive-mesa=4.0.0-preflight-stop-2967b39
+sudo apt-get install -y mina-archive-mesa=4.0.0-preflight-3f038cb
 
 # Step 5: Create PostgreSQL database
 sudo -u postgres createdb archive
@@ -5745,7 +5762,7 @@ mina-archive run \
 docker run --name mina-archive-mesa -d \
   -p 3086:3086 \
   --restart=always \
-  gcr.io/o1labs-192920/mina-archive:4.0.0-preflight-stop-2967b39-bookworm-mesa \
+  gcr.io/o1labs-192920/mina-archive:4.0.0-preflight-3f038cb-bookworm-mesa \
   mina-archive run \
   --postgres-uri postgresql://archive_user:your-secure-password@postgres-host:5432/archive \
   --server-port 3086
@@ -5781,7 +5798,7 @@ echo "deb https://unstable.apt.packages.minaprotocol.com $(lsb_release -cs) pref
 
 # Step 4: Install mina-rosetta-mesa
 sudo apt-get update
-sudo apt-get install -y mina-rosetta-mesa=4.0.0-preflight-stop-2967b39
+sudo apt-get install -y mina-rosetta-mesa=4.0.0-preflight-3f038cb
 
 # Step 5: Start Rosetta
 # Rosetta connects to both the mina daemon and archive node
@@ -5797,7 +5814,7 @@ mina-rosetta \
 docker run --name mina-rosetta-mesa -d \
   -p 3087:3087 \
   --restart=always \
-  gcr.io/o1labs-192920/mina-rosetta:4.0.0-preflight-stop-2967b39-bookworm-mesa \
+  gcr.io/o1labs-192920/mina-rosetta:4.0.0-preflight-3f038cb-bookworm-mesa \
   --port 3087 \
   --archive-uri http://archive-host:3086/graphql \
   --graphql-uri http://mina-daemon-host:3085/graphql


### PR DESCRIPTION
## Summary

- The Mesa preflight network hard-forked at **2026-04-27 14:00 UTC**. The post-fork chain runs **`4.0.0-preflight-3f038cb`**, which raises the **transaction protocol version to 5.0.0** — a breaking wire-format change that retires every pre-fork build.
- Rewrites the warning banners on `network-upgrades/index.mdx`, `mesa/preflight-network.mdx`, and `mesa/archive-upgrade.mdx` to describe the hard fork as completed (rather than upcoming) and to call out the protocol version bump.
- Promotes `4.0.0-preflight-3f038cb` to the current preflight build across every Docker tag, Debian package pin, and inline command. Demotes `4.0.0-preflight-stop-2967b39` (stop-slot) and `4.0.0-preflight1-b649c79` (original) to a historical-only list with an explicit incompatibility note.
- Regenerates `static/llms-full.txt` to keep the `check-llms-txt` CI check green.

This PR simulates a real hard-fork rollout for the preflight network so the docs reflect the post-fork operator path end-to-end.

## Test plan

- [ ] CI: `validate-docker-images` passes (the new `4.0.0-preflight-3f038cb` tags must be reachable on the registry, otherwise the validator will need an angle-bracket placeholder pass).
- [ ] CI: `check-llms-txt` passes against the regenerated `static/llms-full.txt`.
- [ ] CI: Vercel preview builds and renders the three updated pages without MDX errors.
- [ ] Manual: open the Vercel preview and confirm the post-fork banner renders on `/network-upgrades`, `/network-upgrades/mesa/preflight-network`, and `/network-upgrades/mesa/archive-upgrade`, and that the build matrix on the preflight page reads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)