### PR TITLE
Use :::tip for Mesa post-fork banner and trim title

### DIFF
--- a/docs/network-upgrades/index.mdx
+++ b/docs/network-upgrades/index.mdx
@@ -14,9 +14,9 @@ keywords:
 
 Mina protocol evolves through network upgrades (hard forks) that introduce new features and improvements. Each upgrade requires node operators to update their software to remain compatible with the network.
 
-:::warning Mesa preflight hard fork completed — 2026-04-27 13:00 UTC
+:::tip Mesa preflight hard fork completed
 
-The Mesa preflight network has hard-forked. The post-fork chain is now running the Mesa release **`4.0.0-preflight-3f038cb`**, which raises the **transaction protocol version to 5.0.0**.
+The Mesa preflight network hard-forked at **2026-04-27 13:00 UTC**. The post-fork chain is now running the Mesa release **`4.0.0-preflight-3f038cb`**, which raises the **transaction protocol version to 5.0.0**.
 
 Operators must run **`4.0.0-preflight-3f038cb`** to remain on the preflight network. Earlier builds — including the stop-slot release `4.0.0-preflight-stop-2967b39` — are no longer compatible with the post-fork chain.
 

--- a/docs/network-upgrades/mesa/archive-upgrade.mdx
+++ b/docs/network-upgrades/mesa/archive-upgrade.mdx
@@ -15,7 +15,7 @@ keywords:
 
 This guide describes the general procedure for upgrading a Mina archive database from Berkeley to Mesa. The same steps apply to every Mesa deployment (preflight, devnet, mainnet) — only the archive package version differs.
 
-:::warning Hard fork completed — 2026-04-27 13:00 UTC
+:::tip Mesa preflight hard fork completed
 
 The Mesa preflight network hard-forked at **2026-04-27 13:00 UTC**. The post-fork chain runs **`4.0.0-preflight-3f038cb`**, which raises the **transaction protocol version to 5.0.0**. Pre-fork builds — including the stop-slot release `4.0.0-preflight-stop-2967b39` — are no longer compatible.
 

--- a/docs/network-upgrades/mesa/preflight-network.mdx
+++ b/docs/network-upgrades/mesa/preflight-network.mdx
@@ -15,7 +15,7 @@ keywords:
 
 The Mesa preflight network is a testing environment for validating the Mesa upgrade before deployment to devnet and mainnet. This network allows node operators and developers to test their infrastructure and applications with the new Mesa release.
 
-:::warning Hard fork completed — 2026-04-27 13:00 UTC
+:::tip Mesa preflight hard fork completed
 
 The Mesa preflight network hard-forked at **2026-04-27 13:00 UTC**. The post-fork chain is now running the Mesa release **`4.0.0-preflight-3f038cb`**, which bumps the **transaction protocol version to 5.0.0**.
 

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -5397,9 +5397,9 @@ url: /network-upgrades
 
 Mina protocol evolves through network upgrades (hard forks) that introduce new features and improvements. Each upgrade requires node operators to update their software to remain compatible with the network.
 
-:::warning Mesa preflight hard fork completed — 2026-04-27 13:00 UTC
+:::tip Mesa preflight hard fork completed
 
-The Mesa preflight network has hard-forked. The post-fork chain is now running the Mesa release **`4.0.0-preflight-3f038cb`**, which raises the **transaction protocol version to 5.0.0**.
+The Mesa preflight network hard-forked at **2026-04-27 13:00 UTC**. The post-fork chain is now running the Mesa release **`4.0.0-preflight-3f038cb`**, which raises the **transaction protocol version to 5.0.0**.
 
 Operators must run **`4.0.0-preflight-3f038cb`** to remain on the preflight network. Earlier builds — including the stop-slot release `4.0.0-preflight-stop-2967b39` — are no longer compatible with the post-fork chain.
 
@@ -5422,7 +5422,7 @@ url: /network-upgrades/mesa/archive-upgrade
 
 This guide describes the general procedure for upgrading a Mina archive database from Berkeley to Mesa. The same steps apply to every Mesa deployment (preflight, devnet, mainnet) — only the archive package version differs.
 
-:::warning Hard fork completed — 2026-04-27 13:00 UTC
+:::tip Mesa preflight hard fork completed
 
 The Mesa preflight network hard-forked at **2026-04-27 13:00 UTC**. The post-fork chain runs **`4.0.0-preflight-3f038cb`**, which raises the **transaction protocol version to 5.0.0**. Pre-fork builds — including the stop-slot release `4.0.0-preflight-stop-2967b39` — are no longer compatible.
 
@@ -5592,7 +5592,7 @@ url: /network-upgrades/mesa/preflight-network
 
 The Mesa preflight network is a testing environment for validating the Mesa upgrade before deployment to devnet and mainnet. This network allows node operators and developers to test their infrastructure and applications with the new Mesa release.
 
-:::warning Hard fork completed — 2026-04-27 13:00 UTC
+:::tip Mesa preflight hard fork completed
 
 The Mesa preflight network hard-forked at **2026-04-27 13:00 UTC**. The post-fork chain is now running the Mesa release **`4.0.0-preflight-3f038cb`**, which bumps the **transaction protocol version to 5.0.0**.
 


### PR DESCRIPTION
## Summary

Follow-up to #1193. The post-hard-fork banner used `:::warning` with a long inline title (`Mesa preflight hard fork completed — 2026-04-27 13:00 UTC`), which both rendered awkwardly and signalled "something is wrong" when in fact the fork landed successfully.

- Switched the admonition type from `:::warning` to `:::tip` on the post-fork banner so it reads as positive news.
- Dropped the date from the admonition title (it remained verbose with the em-dash + UTC). The date stays in the body's first sentence, so no information is lost.
- Applied consistently across the three places #1193 added the banner: `docs/network-upgrades/index.mdx`, `docs/network-upgrades/mesa/preflight-network.mdx`, and `docs/network-upgrades/mesa/archive-upgrade.mdx`.
- Regenerated `static/llms-full.txt` to match.

## Test plan

- [ ] Render the docs and confirm the banner shows in the green `:::tip` style on `/network-upgrades`, `/network-upgrades/mesa/preflight-network`, and `/network-upgrades/mesa/archive-upgrade`.
- [ ] Confirm the title is "Mesa preflight hard fork completed" (no trailing date) and the body still calls out the **2026-04-27 13:00 UTC** time and the `4.0.0-preflight-3f038cb` version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)